### PR TITLE
[BUG] Set mode page was being triggered when not requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog for version v0.3.0
 
+## 0.3.0-rc20 (2024-10-02)
+
+## Backwards incompatible changes for 0.3.0-rc19
+ * None
+
+### Installer Actions
+ * None
+
+### Bug fixes
+ * [[`PR-64`](https://github.com/thiagoesteves/deployex/pull/64)] Fixed bug that was rendering mode set when not required
+
 ## 0.3.0-rc19 (2024-09-26)
 
 ## Backwards incompatible changes for 0.3.0-rc18

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Deployex.MixProject do
   def project do
     [
       app: :deployex,
-      version: "0.3.0-rc19",
+      version: "0.3.0-rc20",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Adding check if the mode_or_version information has changed when phx-change is triggered. The reason to double check is because disconnections can lead to false-positive changes