### PR TITLE
Fixes GCP service account credentials config

### DIFF
--- a/apps/deployer/lib/deployer/application.ex
+++ b/apps/deployer/lib/deployer/application.ex
@@ -53,9 +53,12 @@ defmodule Deployer.Application do
         []
 
       file_credentials ->
-        source = {:service_account, Jason.decode!(file_credentials)}
+        decoded_credentials =
+          file_credentials
+          |> File.read!()
+          |> Jason.decode!()
 
-        [{Goth, name: Deployer.Goth, source: source}]
+        [{Goth, name: Deployer.Goth, source: {:service_account, decoded_credentials}}]
     end
   end
 end

--- a/apps/foundation/lib/config_provider/secrets/gcp.ex
+++ b/apps/foundation/lib/config_provider/secrets/gcp.ex
@@ -25,11 +25,14 @@ defmodule Foundation.ConfigProvider.Secrets.Gcp do
 
     file_credentials = Keyword.get(config, :goth) |> Keyword.get(:file_credentials)
 
-    source = {:service_account, Jason.decode!(file_credentials)}
+    decoded_credentials =
+      file_credentials
+      |> File.read!()
+      |> Jason.decode!()
 
     children = [
       {Finch, name: FinchGcpSecretManagerClient},
-      {Goth, name: goth_name, source: source}
+      {Goth, name: goth_name, source: {:service_account, decoded_credentials}}
     ]
 
     {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)

--- a/apps/foundation/test/config_provider/secrets/gcp_test.exs
+++ b/apps/foundation/test/config_provider/secrets/gcp_test.exs
@@ -27,7 +27,7 @@ defmodule Foundation.ConfigProvider.Secrets.GcpTest do
        [start_link: fn _children, _options -> {:ok, pid} end, stop: fn _pid, :normal -> :ok end]}
     ]) do
       assert [
-               {:goth, [file_credentials: "{}"]},
+               {:goth, [file_credentials: "./test/support/files/gcp-config.json"]},
                {:foundation,
                 [
                   {Manager, [adapter: Gcp, path: "any-env-path"]},
@@ -53,7 +53,7 @@ defmodule Foundation.ConfigProvider.Secrets.GcpTest do
                      {Manager, adapter: Gcp, path: "any-env-path"},
                      {:env, "prod"}
                    ],
-                   goth: [{:file_credentials, "{}"}]
+                   goth: [{:file_credentials, "./test/support/files/gcp-config.json"}]
                  ],
                  []
                )
@@ -75,7 +75,7 @@ defmodule Foundation.ConfigProvider.Secrets.GcpTest do
     ]) do
       assert_raise RuntimeError, fn ->
         [
-          {:goth, [file_credentials: "{}"]},
+          {:goth, [file_credentials: "./test/support/files/gcp-config.json"]},
           {:foundation,
            [
              {Manager, [adapter: Gcp, path: "any-env-path"]},
@@ -101,7 +101,7 @@ defmodule Foundation.ConfigProvider.Secrets.GcpTest do
                 {Manager, adapter: Gcp, path: "any-env-path"},
                 {:env, "prod"}
               ],
-              goth: [{:file_credentials, "{}"}]
+              goth: [{:file_credentials, "./test/support/files/gcp-config.json"}]
             ],
             []
           )

--- a/apps/foundation/test/support/files/gcp-config.json
+++ b/apps/foundation/test/support/files/gcp-config.json
@@ -1,0 +1,13 @@
+{
+	"type": "service_account",
+	"project_id": "some-project",
+	"private_key_id": "key-id",
+	"private_key": "-----BEGIN PRIVATE KEY-----s3cr3t-----END PRIVATE KEY-----\n",
+	"client_email": "deployex@some-project.iam.gserviceaccount.com",
+	"client_id": "4420954499999999999",
+	"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+	"token_uri": "https://oauth2.googleapis.com/token",
+	"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+	"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/deployex%40some-project.iam.gserviceaccount.com",
+	"universe_domain": "googleapis.com"
+}


### PR DESCRIPTION
Hey @thiagoesteves ! Finally getting round to trying DeployEx out for a project. Excited to get it working, and I've got some notes and readme updates I'll make in another PR if that's helpful?

While deploying on GCP I'm hitting issues with the config provider.

At some point I think there was a `File.read!` before passing the credentials to `:goth` that got lost, as right now I get the following error on startup:

```
Crash dump is being written to: erl_crash.dump...ERROR! Config provider Foundation.ConfigProvider.Secrets.Manager failed with:
** (Jason.DecodeError) unexpected byte at position 0: 0x2F ("/")
    (jason 1.4.4) lib/jason.ex:92: Jason.decode!/2
    (foundation 0.7.3) lib/config_provider/secrets/gcp.ex:28: Foundation.ConfigProvider.Secrets.Gcp.secrets/3
    (foundation 0.7.3) lib/config_provider/secrets/manager.ex:48: Foundation.ConfigProvider.Secrets.Manager.load/2
    (elixir 1.18.4) lib/config/provider.ex:391: anonymous fn/2 in Config.Provider.run_providers/2
    (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.18.4) lib/config/provider.ex:238: Config.Provider.boot_providers/4
    :init.eval_script/2
    :init.do_boot/3
```

This PR standardizes all the tests to expect a file path in the `:goth` config and adds a fixture in apps/foundation/test/support/files/gcp-config.json.