### PR TITLE
Cleaning up inet_tls.conf file before updating deployex application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 ## 0.9.2 ()
 
 ### Backwards incompatible changes from 0.9.1
- * None
+
+#### Installer Actions
+ 1. It’s not mandatory, but it’s recommended to update `deployex.sh`.
+ ```bash
+ rm deployex.sh
+ wget https://github.com/thiagoesteves/deployex/releases/download/0.9.2/deployex.sh
+ chmod a+x deployex.sh
+ ./deployex.sh --update
+ ```
 
 ### Bug fixes
  * None
@@ -12,6 +20,7 @@
  * [`PULL-220`](https://github.com/thiagoesteves/deployex/pull/220) Changing log level to INFO when running unit tests
  * [`PULL-216`](https://github.com/thiagoesteves/deployex/pull/216) Let's Encrypt Certificate Management for DeployEx
  * [`ISSUE-207`](https://github.com/thiagoesteves/deployex/issues/207) Increase the default timeout for IEX/ERL terminal
+ * [`PULL-225`](https://github.com/thiagoesteves/deployex/pull/225) Cleaning up inet_tls.conf file before updating deployex application
 
 ## 0.9.1 🚀 (2026-05-15)
 
@@ -28,10 +37,10 @@
 
 ### Backwards incompatible changes from 0.8.0
 
-### Hotupgrade
+#### Hotupgrade
  * Hotupgrade from 0.8.0 to 0.9.0 is not viable since the previous version doesn't support it.
 
-### Installer Actions
+#### Installer Actions
  1. It’s not mandatory, but it’s recommended to update `deployex.sh` so it can support custom installation, hotupgrades and changing folder for log directories.
  ```bash
  rm deployex.sh

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -85,7 +85,7 @@ defmodule Deployer.EngineTest do
                  assert {:ok, _pid} =
                           Engine.Worker.start_link(%Engine.Worker{
                             deploy_rollback_timeout_ms: 1_000,
-                            deploy_schedule_interval_ms: 10,
+                            deploy_schedule_interval_ms: 100,
                             name: name,
                             language: language
                           })
@@ -127,7 +127,7 @@ defmodule Deployer.EngineTest do
         assert {:ok, _pid} =
                  Engine.Worker.start_link(%Engine.Worker{
                    deploy_rollback_timeout_ms: 1_000,
-                   deploy_schedule_interval_ms: 10,
+                   deploy_schedule_interval_ms: 100,
                    name: name,
                    language: language
                  })
@@ -210,7 +210,7 @@ defmodule Deployer.EngineTest do
         assert {:ok, _pid} =
                  Engine.Worker.start_link(%Engine.Worker{
                    deploy_rollback_timeout_ms: 1_000,
-                   deploy_schedule_interval_ms: 10,
+                   deploy_schedule_interval_ms: 100,
                    name: name,
                    language: language
                  })
@@ -266,7 +266,7 @@ defmodule Deployer.EngineTest do
         assert {:ok, _pid} =
                  Engine.Worker.start_link(%Engine.Worker{
                    deploy_rollback_timeout_ms: 1_000,
-                   deploy_schedule_interval_ms: 10,
+                   deploy_schedule_interval_ms: 100,
                    name: name,
                    language: language,
                    ghosted_version_list: [%{version: ghosted_version}]
@@ -360,7 +360,7 @@ defmodule Deployer.EngineTest do
         assert {:ok, _pid} =
                  Engine.Worker.start_link(%Engine.Worker{
                    deploy_rollback_timeout_ms: 1_000,
-                   deploy_schedule_interval_ms: 10,
+                   deploy_schedule_interval_ms: 100,
                    name: name,
                    language: language
                  })
@@ -1251,7 +1251,7 @@ defmodule Deployer.EngineTest do
         assert {:ok, _pid} =
                  Engine.Worker.start_link(%Engine.Worker{
                    deploy_rollback_timeout_ms: 1_000,
-                   deploy_schedule_interval_ms: 10,
+                   deploy_schedule_interval_ms: 100,
                    name: name,
                    language: language
                  })

--- a/devops/installer/deployex.sh
+++ b/devops/installer/deployex.sh
@@ -231,6 +231,8 @@ update_deployex() {
     echo "# Checksum verified successfully           #"
     echo "# Stop current service                     #"
     systemctl stop ${DEPLOYEX_SERVICE_NAME}
+    echo "# Clean inet tls info                      #"
+    rm /tmp/inet_tls.conf
     echo "# Clean and create a new directory         #"
     rm -rf ${DEPLOYEX_OPT_DIR}
     mkdir ${DEPLOYEX_OPT_DIR}


### PR DESCRIPTION
There was some reports where this file was misconfigured due to initial deployments without the certificates. The issue is solved deleting this file during update or new installation so it would be recreated again with the correct certificates.