### PR TITLE
Add OTP/Elixir/Phoenix version info to monitored app status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG (0.9.X)
 
+## 0.9.3 🚀 (2026-06-17)
+
+### Backwards incompatible changes from 0.9.2
+ * None
+
+### Bug fixes
+ * None
+
+### Enhancements
+ * [`PULL-228`](https://github.com/thiagoesteves/deployex/pull/228) Add OTP/Elixir/Phoenix version info to monitored app status
+
+
 ## 0.9.2 🚀 (2026-06-15)
 
 ### Backwards incompatible changes from 0.9.1

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| [**0.9.3**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.3) | **27.3.4.13**                                              | **28.5.0.2**                                               |
 | [**0.9.2**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.2) | **27.3.4.13**                                              | **28.5.0.2**                                               |
 | [**0.9.1**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.1) | **27.3.4.9**                                               | **28.4.1**                                                 |
 | [**0.9.0**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.0) | **27.3.4.9**                                               | **28.4.1**                                                 |

--- a/apps/deployer/lib/deployer/status.ex
+++ b/apps/deployer/lib/deployer/status.ex
@@ -32,7 +32,10 @@ defmodule Deployer.Status do
           # Monitoring capabilities
           monitoring: [],
           # Certificates capabilities
-          certificates: []
+          certificates: [],
+          otp_version: String.t() | nil,
+          elixir_version: String.t() | nil,
+          phoenix_version: String.t() | nil
         }
 
   defstruct name: nil,
@@ -55,7 +58,10 @@ defmodule Deployer.Status do
             config: nil,
             children: [],
             monitoring: [],
-            certificates: []
+            certificates: [],
+            otp_version: nil,
+            elixir_version: nil,
+            phoenix_version: nil
 
   @behaviour Deployer.Status.Adapter
 

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -14,6 +14,7 @@ defmodule Deployer.Status.Application do
   alias Foundation.Catalog
   alias Foundation.Certificates.PublicKey
   alias Foundation.Common
+  alias Foundation.Rpc
 
   @update_apps_interval :timer.seconds(1)
   @apps_data_updated_topic "deployex::monitoring_app_updated"
@@ -244,6 +245,20 @@ defmodule Deployer.Status.Application do
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+  defmacrop cache_in_process(key, do: block) do
+    quote do
+      case Process.get(unquote(key), "not-available-yet") do
+        "not-available-yet" ->
+          value = unquote(block)
+          Process.put(unquote(key), value)
+          value
+
+        value ->
+          value
+      end
+    end
+  end
+
   defp do_set_mode(name, :automatic = mode, _version) do
     config = Catalog.config(name)
     Catalog.config_update(name, %{config | mode: mode})
@@ -275,6 +290,8 @@ defmodule Deployer.Status.Application do
         certificate -> [certificate]
       end
 
+    node = Node.self()
+
     %Status{
       name: name,
       sname: name,
@@ -296,7 +313,10 @@ defmodule Deployer.Status.Application do
       uptime: uptime,
       latest_release: deployex_latest_release,
       monitoring: Application.get_env(:foundation, :monitoring),
-      certificates: certificates
+      certificates: certificates,
+      otp_version: node_otp_version(node),
+      elixir_version: node_elixir_version(node),
+      phoenix_version: node_phoenix_version(node)
     }
   end
 
@@ -337,22 +357,42 @@ defmodule Deployer.Status.Application do
       force_restart_count: force_restart_count,
       uptime: Common.uptime_to_string(start_time),
       language: language,
-      monitoring: monitoring
+      monitoring: monitoring,
+      otp_version: node_otp_version(node),
+      elixir_version: node_elixir_version(node),
+      phoenix_version: node_phoenix_version(node)
     }
   end
 
-  # Caches the mTLS certificate in the process dictionary on first access,
-  # since the certificate doesn't change during the application's lifetime.
-  # Returns the %Foundation.Certificate{} struct or nil if mTLS is not supported.
   defp mtls_certificate do
-    case Process.get(:mtls_certificate, :unchecked) do
-      :unchecked ->
-        cert = Common.mtls_certificate()
-        Process.put(:mtls_certificate, cert)
-        cert
+    cache_in_process(:mtls_certificate) do
+      Common.mtls_certificate()
+    end
+  end
 
-      cert ->
-        cert
+  defp node_otp_version(node) do
+    cache_in_process({node, :otp}) do
+      rpc_string(node, :erlang, :system_info, [:otp_release])
+    end
+  end
+
+  defp node_elixir_version(node) do
+    cache_in_process({node, :elixir}) do
+      rpc_string(node, Application, :spec, [:elixir, :vsn])
+    end
+  end
+
+  defp node_phoenix_version(node) do
+    cache_in_process({node, :phoenix}) do
+      rpc_string(node, Application, :spec, [:phoenix, :vsn])
+    end
+  end
+
+  def rpc_string(node, module, functions, args) do
+    case Rpc.call(node, module, functions, args, 1000) do
+      {:badrpc, {:EXIT, {:undef, _}}} -> nil
+      {:badrpc, _} -> "not-available-yet"
+      version -> "#{version}"
     end
   end
 end

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -245,20 +245,6 @@ defmodule Deployer.Status.Application do
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
-  defmacrop cache_in_process(key, do: block) do
-    quote do
-      case Process.get(unquote(key), "not-available-yet") do
-        "not-available-yet" ->
-          value = unquote(block)
-          Process.put(unquote(key), value)
-          value
-
-        value ->
-          value
-      end
-    end
-  end
-
   defp do_set_mode(name, :automatic = mode, _version) do
     config = Catalog.config(name)
     Catalog.config_update(name, %{config | mode: mode})
@@ -365,8 +351,33 @@ defmodule Deployer.Status.Application do
   end
 
   defp mtls_certificate do
-    cache_in_process(:mtls_certificate) do
-      Common.mtls_certificate()
+    case Process.get(:mtls_certificate, :not_fetched) do
+      :not_fetched ->
+        value = Common.mtls_certificate()
+        Process.put(:mtls_certificate, value)
+        value
+
+      value ->
+        value
+    end
+  end
+
+  defmacrop cache_in_process(key, do: block) do
+    quote do
+      case Process.get(unquote(key), :not_available_yet) do
+        :not_available_yet ->
+          case unquote(block) do
+            {:ok, value} ->
+              Process.put(unquote(key), value)
+              value
+
+            _ ->
+              nil
+          end
+
+        value ->
+          value
+      end
     end
   end
 
@@ -388,11 +399,11 @@ defmodule Deployer.Status.Application do
     end
   end
 
-  def rpc_string(node, module, functions, args) do
+  defp rpc_string(node, module, functions, args) do
     case Rpc.call(node, module, functions, args, 1000) do
-      {:badrpc, {:EXIT, {:undef, _}}} -> nil
-      {:badrpc, _} -> "not-available-yet"
-      version -> "#{version}"
+      {:badrpc, {:EXIT, {:undef, _}}} -> {:ok, nil}
+      {:badrpc, _} -> {:error, nil}
+      version -> {:ok, "#{version}"}
     end
   end
 end

--- a/apps/deployer/test/status/application_test.exs
+++ b/apps/deployer/test/status/application_test.exs
@@ -161,6 +161,9 @@ defmodule Deployer.Status.ApplicationTest do
     end)
     |> expect(:list, 1, fn -> [sname_1, sname_2, sname_3] end)
 
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+
     # No info, update needed
     assert {:noreply, %{monitoring: monitoring}} =
              StatusApp.handle_info(:update_apps, %{monitoring: []})
@@ -212,6 +215,9 @@ defmodule Deployer.Status.ApplicationTest do
 
     Deployer.HotUpgradeMock
     |> stub(:connect, fn _node -> {:error, :not_connecting} end)
+
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
 
     # No info, update needed
     assert {:noreply, %{monitoring: monitoring}} =
@@ -268,6 +274,9 @@ defmodule Deployer.Status.ApplicationTest do
     Deployer.HotUpgradeMock
     |> stub(:connect, fn _node -> {:ok, :connected} end)
 
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+
     # No info, update needed
     assert {:noreply, %{monitoring: monitoring}} =
              StatusApp.handle_info(:update_apps, %{monitoring: []})
@@ -323,6 +332,9 @@ defmodule Deployer.Status.ApplicationTest do
 
     Deployer.HotUpgradeMock
     |> stub(:connect, fn _node -> {:ok, :connected} end)
+
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
 
     ghosted_version = "1.1.1"
     version_map = StatusApp.current_version_map(sname_1)
@@ -402,6 +414,9 @@ defmodule Deployer.Status.ApplicationTest do
     end)
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
 
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 
     {:ok, _map} = StatusApp.set_mode(module_name, name_1, :manual, "1.0.2")
@@ -452,6 +467,9 @@ defmodule Deployer.Status.ApplicationTest do
       }
     end)
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
+
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
 
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 
@@ -504,6 +522,9 @@ defmodule Deployer.Status.ApplicationTest do
     end)
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
 
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 
     {:ok, _map} = StatusApp.set_mode(module_name, name_1, :manual, "invalid")
@@ -546,6 +567,9 @@ defmodule Deployer.Status.ApplicationTest do
       }
     end)
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
+
+    Foundation.RpcMock
+    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
 
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 

--- a/apps/deployer/test/status/application_test.exs
+++ b/apps/deployer/test/status/application_test.exs
@@ -162,7 +162,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> expect(:list, 1, fn -> [sname_1, sname_2, sname_3] end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     # No info, update needed
     assert {:noreply, %{monitoring: monitoring}} =
@@ -217,7 +217,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:connect, fn _node -> {:error, :not_connecting} end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     # No info, update needed
     assert {:noreply, %{monitoring: monitoring}} =
@@ -275,7 +275,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:connect, fn _node -> {:ok, :connected} end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     # No info, update needed
     assert {:noreply, %{monitoring: monitoring}} =
@@ -334,7 +334,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:connect, fn _node -> {:ok, :connected} end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     ghosted_version = "1.1.1"
     version_map = StatusApp.current_version_map(sname_1)
@@ -415,7 +415,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 
@@ -469,7 +469,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 
@@ -523,7 +523,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 
@@ -569,7 +569,7 @@ defmodule Deployer.Status.ApplicationTest do
     |> stub(:list, fn -> [sname_1, sname_2, sname_3] end)
 
     Foundation.RpcMock
-    |> expect(:call, fn _node, _module, _functions, _args, _timeout -> "" end)
+    |> stub(:call, fn _node, _module, _functions, _args, _timeout -> nil end)
 
     assert {:ok, _pid} = StatusApp.start_link(update_apps_interval: 50, name: module_name)
 

--- a/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
@@ -42,7 +42,35 @@ defmodule DeployexWeb.Components.ApplicationCard do
               </div>
               <div class="flex-1">
                 <h1 class="text-3xl font-bold text-base-content mb-2">{@application.name}</h1>
-                <div class="badge badge-neutral badge-lg">Application</div>
+                <div class="flex items-center gap-4">
+                  <div class="flex items-center gap-2">
+                    <img src="/images/erlang-otp.png" alt="OTP" class="w-5 h-5" />
+                    <div class="flex flex-col">
+                      <span class="text-xs font-semibold text-base-content">OTP</span>
+                      <span class="text-xs text-base-content/60">
+                        {@application.otp_version || "--"}
+                      </span>
+                    </div>
+                  </div>
+                  <div :if={@application.elixir_version} class="flex items-center gap-2">
+                    <img src="/images/elixir.png" alt="Elixir" class="w-5 h-5" />
+                    <div class="flex flex-col">
+                      <span class="text-xs font-semibold text-base-content">Elixir</span>
+                      <span class="text-xs text-base-content/60">
+                        {@application.elixir_version}
+                      </span>
+                    </div>
+                  </div>
+                  <div :if={@application.phoenix_version} class="flex items-center gap-2">
+                    <img src="/images/phoenix.png" alt="Phoenix" class="w-5 h-5" />
+                    <div class="flex flex-col">
+                      <span class="text-xs font-semibold text-base-content">Phoenix</span>
+                      <span class="text-xs text-base-content/60">
+                        {@application.phoenix_version}
+                      </span>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
             <!-- App Details Grid -->

--- a/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
@@ -48,7 +48,7 @@ defmodule DeployexWeb.Components.ApplicationCard do
                     <div class="flex flex-col">
                       <span class="text-xs font-semibold text-base-content">OTP</span>
                       <span class="text-xs text-base-content/60">
-                        {@application.otp_version || "--"}
+                        {@application.otp_version}
                       </span>
                     </div>
                   </div>

--- a/apps/deployex_web/test/support/status.ex
+++ b/apps/deployex_web/test/support/status.ex
@@ -98,7 +98,10 @@ defmodule DeployexWeb.Fixture.Status do
       crash_restart_count: 0,
       uptime: "long time",
       ports: [%{key: "PORT", base: 5678}],
-      certificates: [default_public_key()]
+      certificates: [default_public_key()],
+      otp_version: "27",
+      elixir_version: "1.20",
+      phoenix_version: "1.3"
     }
 
     %Status{

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.2"
+version: "0.9.3"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -53,7 +53,7 @@ applications:
         dns_propagation_timeout_ms: 120_000
         dns_check_interval_ms: 5000
         renew_before_days: 30
-        dns_provider: "route53"
+        dns_provider: "cloudflare" # or "route53"
         dns_options:
           ttl: 1
           zone: "zone"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.2"
+version: "0.9.3"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.2"                                         # DeployEx version
+version: "0.9.3"                                         # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.2"
+  def version, do: "0.9.3"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
Extend `Deployer.Status` (and its child struct) with `otp_version`, `elixir_version`, and `phoenix_version` fields, populated via RPC calls to each monitored node using a `cache_in_process` macro to avoid repeated round-trips. Phoenix is treated as optional (nil when absent). The `application_card` component now renders these versions below the app name. Tests and fixtures updated accordingly.
<img width="818" height="571" alt="Screenshot 2026-06-17 at 10 59 01" src="https://github.com/user-attachments/assets/b382ec16-e517-41e8-a926-a066fc530e98" />
<img width="813" height="578" alt="Screenshot 2026-06-17 at 10 58 56" src="https://github.com/user-attachments/assets/355d2398-4e24-4971-a99d-ab0bbf11c6a0" />
<img width="791" height="572" alt="Screenshot 2026-06-17 at 10 58 50" src="https://github.com/user-attachments/assets/494b244c-6b6e-444f-b782-ef0af91bd110" />
