### PR TITLE
Add on-the-fly notification config and change events to strings

### DIFF
--- a/apps/deployer/lib/deployer/application.ex
+++ b/apps/deployer/lib/deployer/application.ex
@@ -53,7 +53,7 @@ defmodule Deployer.Application do
     defp notify_startup do
       version = Application.spec(:deployer, :vsn) |> to_string()
 
-      Foundation.Notifications.notify(:deployment_started, %{
+      Foundation.Notifications.notify("deployment_started", %{
         node: node(),
         sname: "deployex",
         version: version
@@ -61,7 +61,7 @@ defmodule Deployer.Application do
     end
 
     defp notify_shutdown do
-      Foundation.Notifications.notify(:deployment_complete, %{
+      Foundation.Notifications.notify("deployment_complete", %{
         node: node(),
         sname: "deployex",
         status: :ok,

--- a/apps/deployer/lib/deployer/deployex.ex
+++ b/apps/deployer/lib/deployer/deployex.ex
@@ -19,7 +19,7 @@ defmodule Deployer.Deployex do
   def force_terminate(sleep_time) do
     Logger.warning("Deployex was requested to terminate, see you soon!!!")
 
-    Foundation.Notifications.notify(:deployment_shutdown, %{node: node(), sname: "deployex"})
+    Foundation.Notifications.notify("deployment_shutdown", %{node: node(), sname: "deployex"})
 
     :timer.sleep(sleep_time)
 

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -286,7 +286,7 @@ defmodule Deployer.Engine.Worker do
       if sname == current_deployment.sname do
         Process.cancel_timer(current_deployment.timer_ref)
 
-        Foundation.Notifications.notify(:deployment_complete, %{
+        Foundation.Notifications.notify("deployment_complete", %{
           node: node(),
           sname: sname,
           status: :ok,
@@ -404,7 +404,7 @@ defmodule Deployer.Engine.Worker do
     new_deployments =
       Enum.reduce(deployments, %{}, fn {instance, %Engine.Deployment{sname: sname}}, acc ->
         Logger.info(" # Terminating node: #{sname}")
-        Foundation.Notifications.notify(:deployment_shutdown, %{node: node(), sname: sname})
+        Foundation.Notifications.notify("deployment_shutdown", %{node: node(), sname: sname})
         Monitor.stop_service(state.name, sname)
         Catalog.cleanup(sname)
 

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -595,7 +595,7 @@ defmodule Deployer.HotUpgrade.Application do
       {:hot_upgrade_complete, Node.self(), sname, :ok, "Hot upgrade applied successfully!"}
     )
 
-    Foundation.Notifications.notify(:deployment_complete, %{
+    Foundation.Notifications.notify("deployment_complete", %{
       node: node(),
       sname: sname,
       status: :ok,
@@ -613,7 +613,7 @@ defmodule Deployer.HotUpgrade.Application do
       {:hot_upgrade_complete, Node.self(), sname, :error, message}
     )
 
-    Foundation.Notifications.notify(:deployment_complete, %{
+    Foundation.Notifications.notify("deployment_complete", %{
       node: node(),
       sname: sname,
       status: :error,

--- a/apps/deployer/lib/deployer/monitor/application.ex
+++ b/apps/deployer/lib/deployer/monitor/application.ex
@@ -93,7 +93,10 @@ defmodule Deployer.Monitor.Application do
   def handle_call(:restart, _from, state) do
     Logger.warning("Restart requested for sname: #{state.sname}")
 
-    Foundation.Notifications.notify(:deployment_shutdown, %{node: node(), sname: "#{state.sname}"})
+    Foundation.Notifications.notify("deployment_shutdown", %{
+      node: node(),
+      sname: "#{state.sname}"
+    })
 
     # Stop current application
     Commander.stop(state.current_pid)
@@ -159,7 +162,7 @@ defmodule Deployer.Monitor.Application do
     # Update the number of crash restarts
     crash_restart_count = state.crash_restart_count + 1
 
-    Foundation.Notifications.notify(:crash_restart, %{
+    Foundation.Notifications.notify("crash_restart", %{
       node: Node.self(),
       sname: state.sname,
       name: state.name,
@@ -253,7 +256,7 @@ defmodule Deployer.Monitor.Application do
     version = version_map.version
 
     notify_new_deploy = fn ->
-      Foundation.Notifications.notify(:deployment_started, %{
+      Foundation.Notifications.notify("deployment_started", %{
         node: Node.self(),
         sname: sname,
         version: version

--- a/apps/deployex_web/lib/deployex_web/application.ex
+++ b/apps/deployex_web/lib/deployex_web/application.ex
@@ -42,7 +42,7 @@ defmodule DeployexWeb.Application do
   ### Private Functions
   ### ==========================================================================
   defp notify_finish_deployment do
-    Foundation.Notifications.notify(:deployment_complete, %{
+    Foundation.Notifications.notify("deployment_complete", %{
       node: node(),
       sname: "deployex",
       status: :ok,

--- a/apps/deployex_web/lib/deployex_web/live/components/config_changes_modal.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/config_changes_modal.ex
@@ -299,6 +299,46 @@ defmodule DeployexWeb.Components.ConfigChangesModal do
     """
   end
 
+  defp render_change_section(%{field: :notifications} = assigns) do
+    ~H"""
+    <div class="bg-base-200 rounded-lg p-4 border border-base-300">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2">
+          <svg class="w-5 h-5 text-info" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+            >
+            </path>
+          </svg>
+          <h3 class="text-lg font-bold text-base-content">Notifications</h3>
+        </div>
+        <.strategy_badge strategy={@change_data.apply_strategy} />
+      </div>
+      <div class="grid grid-cols-2 gap-4">
+        <div class="bg-error/10 border border-error/20 rounded-lg p-3">
+          <div class="text-xs font-semibold text-error mb-2">
+            Current ({length(@change_data.old)} entries)
+          </div>
+          <%= for notif <- @change_data.old do %>
+            <.render_notification_entry notification={notif} />
+          <% end %>
+        </div>
+        <div class="bg-success/10 border border-success/20 rounded-lg p-3">
+          <div class="text-xs font-semibold text-success mb-2">
+            New ({length(@change_data.new)} entries)
+          </div>
+          <%= for notif <- @change_data.new do %>
+            <.render_notification_entry notification={notif} />
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   defp render_change_section(%{field: field} = assigns) do
     field_name = format_field_name(field)
 
@@ -336,6 +376,21 @@ defmodule DeployexWeb.Components.ConfigChangesModal do
             {format_value(@field, @change_data.new)}
           </div>
         </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_notification_entry(assigns) do
+    adapter_name = assigns.notification.adapter |> Module.split() |> List.last()
+    assigns = assign(assigns, :adapter_name, adapter_name)
+
+    ~H"""
+    <div class="mb-2 last:mb-0 font-mono text-sm">
+      <span class="font-semibold">{@adapter_name}</span>
+      <span :if={not @notification.enabled} class="text-xs text-warning ml-1">(disabled)</span>
+      <div class="text-xs text-base-content/60 mt-0.5">
+        {Enum.join(@notification.events, ", ")}
       </div>
     </div>
     """

--- a/apps/deployex_web/test/deployex_web/live/applications/watcher_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/applications/watcher_test.exs
@@ -137,8 +137,7 @@ defmodule DeployexWeb.Applications.WatcherTest do
 
     send(
       liveview.pid,
-      {:watcher_config_new, Node.self(),
-       FixtureWatcher.build_pending_changes_with_certificates()}
+      {:watcher_config_new, Node.self(), FixtureWatcher.build_pending_changes_with_certificates()}
     )
 
     assert liveview |> element("#deployex-config-changes") |> render_click()

--- a/apps/deployex_web/test/deployex_web/live/applications/watcher_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/applications/watcher_test.exs
@@ -102,6 +102,55 @@ defmodule DeployexWeb.Applications.WatcherTest do
   end
 
   @tag :capture_log
+  test "GET /applications Review pending notification changes renders adapter names and events",
+       %{conn: conn} do
+    Deployer.StatusMock
+    |> expect(:monitoring, fn -> {:ok, FixtureStatus.list()} end)
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:history_version_list, fn _name, _options -> FixtureStatus.versions() end)
+
+    {:ok, liveview, _html} = live(conn, ~p"/applications")
+
+    send(
+      liveview.pid,
+      {:watcher_config_new, Node.self(),
+       FixtureWatcher.build_pending_changes_with_notifications()}
+    )
+
+    assert liveview |> element("#deployex-config-changes") |> render_click()
+
+    html = render(liveview)
+    assert html =~ "Notifications"
+    assert html =~ "Slack"
+    assert html =~ "Webhook"
+    assert html =~ "crash_restart"
+  end
+
+  @tag :capture_log
+  test "GET /applications Review pending certificate changes renders domain info", %{conn: conn} do
+    Deployer.StatusMock
+    |> expect(:monitoring, fn -> {:ok, FixtureStatus.list()} end)
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:history_version_list, fn _name, _options -> FixtureStatus.versions() end)
+
+    {:ok, liveview, _html} = live(conn, ~p"/applications")
+
+    send(
+      liveview.pid,
+      {:watcher_config_new, Node.self(),
+       FixtureWatcher.build_pending_changes_with_certificates()}
+    )
+
+    assert liveview |> element("#deployex-config-changes") |> render_click()
+
+    html = render(liveview)
+    assert html =~ "myphoenixapp"
+    assert html =~ "Certificates"
+    assert html =~ "DOMAINS"
+    assert html =~ "*.example.com"
+  end
+
+  @tag :capture_log
   test "GET /applications ignore changes from other nodes", %{conn: conn} do
     Deployer.StatusMock
     |> expect(:monitoring, fn -> {:ok, FixtureStatus.list()} end)

--- a/apps/foundation/lib/foundation/certificates/manager/manager.ex
+++ b/apps/foundation/lib/foundation/certificates/manager/manager.ex
@@ -80,7 +80,7 @@ defmodule Foundation.Certificates.Manager do
           "Certificate check completed successfully for app: #{state.app_name}, domains: #{inspect(certificate.domains)}"
         )
 
-        Foundation.Notifications.notify(:certificate_renewed, %{
+        Foundation.Notifications.notify("certificate_renewed", %{
           app_name: state.app_name,
           domains: state.domains
         })
@@ -91,7 +91,7 @@ defmodule Foundation.Certificates.Manager do
       {:error, reason} ->
         Logger.error("Certificate renewal check failed: #{inspect(reason)}")
 
-        Foundation.Notifications.notify(:certificate_failed, %{
+        Foundation.Notifications.notify("certificate_failed", %{
           app_name: state.app_name,
           domains: state.domains,
           reason: inspect(reason)

--- a/apps/foundation/lib/foundation/notifications.ex
+++ b/apps/foundation/lib/foundation/notifications.ex
@@ -17,14 +17,14 @@ defmodule Foundation.Notifications do
 
   | Event atom                       | Trigger                                                    | Payload keys                                                                |
   |----------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------|
-  | `:crash_restart`                 | Monitored app crashed and is being restarted               | `node`, `sname`, `name`, `language`, `crash_restart_count`                 |
-  | `:deployment_started`            | New deployment was initiated for an sname                  | `node`, `sname`, `version`                                                  |
-  | `:deployment_complete`           | Hot-upgrade finished (success or failure)                  | `node`, `sname`, `status` (`:ok`/`:error`), `message`                      |
-  | `:watchdog_threshold_exceeded`   | Watchdog exceeded a resource threshold and restarted an app| `node`, `type`, `current_percentage`, `restart_threshold_percent`          |
-  | `:watchdog_threshold_warning`    | Resource crossed the warning threshold (or returned below) | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
-  | `:certificate_renewed`           | TLS certificate was successfully renewed                   | `app_name`, `domains`                                                       |
-  | `:certificate_failed`            | TLS certificate renewal failed                             | `app_name`, `domains`, `reason`                                             |
-  | `:deployment_shutdown`           | DeployEx was force-terminated (kill -9 path)               | `node`, `sname`                                                             |
+  | `"crash_restart"`                 | Monitored app crashed and is being restarted               | `node`, `sname`, `name`, `language`, `crash_restart_count`                 |
+  | `"deployment_started"`            | New deployment was initiated for an sname                  | `node`, `sname`, `version`                                                  |
+  | `"deployment_complete"`           | Hot-upgrade finished (success or failure)                  | `node`, `sname`, `status` (`:ok`/`:error`), `message`                      |
+  | `"watchdog_threshold_exceeded"`   | Watchdog exceeded a resource threshold and restarted an app| `node`, `type`, `current_percentage`, `restart_threshold_percent`          |
+  | `"watchdog_threshold_warning"`    | Resource crossed the warning threshold (or returned below) | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
+  | `"certificate_renewed"`           | TLS certificate was successfully renewed                   | `app_name`, `domains`                                                       |
+  | `"certificate_failed"`            | TLS certificate renewal failed                             | `app_name`, `domains`, `reason`                                             |
+  | `"deployment_shutdown"`           | DeployEx was force-terminated (kill -9 path)               | `node`, `sname`                                                             |
 
   ## Available adapters
 
@@ -95,6 +95,20 @@ defmodule Foundation.Notifications do
     :ok
   end
 
+  @spec stop_notification_manager() :: :ok
+  def stop_notification_manager do
+    Foundation.Notifications.Supervisor.stop_all_notification_workers()
+  end
+
+  @spec start_notification_manager(notifications :: list()) :: :ok
+  def start_notification_manager(notifications) do
+    notifications
+    |> Enum.map(&to_notification_struct/1)
+    |> Enum.each(&Foundation.Notifications.Supervisor.start_notification_worker/1)
+
+    :ok
+  end
+
   @doc """
   Returns the PubSub topic for a specific event.
 
@@ -104,10 +118,10 @@ defmodule Foundation.Notifications do
 
   ## Example
 
-      iex> Foundation.Notifications.topic(:crash_restart)
+      iex> Foundation.Notifications.topic("crash_restart")
       "deployex::notifications::crash_restart"
   """
-  @spec topic(event :: atom()) :: String.t()
+  @spec topic(event :: String.t()) :: String.t()
   def topic(event), do: "#{@topic_prefix}::#{event}"
 
   @doc """
@@ -116,7 +130,7 @@ defmodule Foundation.Notifications do
   Returns `:ok` immediately; delivery to each adapter happens asynchronously
   inside the respective `Foundation.Notifications.Worker` process.
   """
-  @spec notify(event :: atom(), payload :: map()) :: :ok
+  @spec notify(event :: String.t(), payload :: map()) :: :ok
   def notify(event, payload) do
     Phoenix.PubSub.broadcast(Foundation.PubSub, topic(event), {event, payload})
   end

--- a/apps/foundation/lib/foundation/notifications.ex
+++ b/apps/foundation/lib/foundation/notifications.ex
@@ -25,6 +25,8 @@ defmodule Foundation.Notifications do
   | `"certificate_renewed"`           | TLS certificate was successfully renewed                   | `app_name`, `domains`                                                       |
   | `"certificate_failed"`            | TLS certificate renewal failed                             | `app_name`, `domains`, `reason`                                             |
   | `"deployment_shutdown"`           | DeployEx was force-terminated (kill -9 path)               | `node`, `sname`                                                             |
+  | `"config_changed"`                | Upgradable config change detected in the YAML file         | `node`, `changes_count`, `fields`                                           |
+  | `"config_change_applied"`         | Pending config changes were successfully applied           | `node`, `changes_count`, `fields`                                           |
 
   ## Available adapters
 
@@ -89,8 +91,7 @@ defmodule Foundation.Notifications do
   def initialize_notification_manager do
     :foundation
     |> Application.fetch_env!(:notifications)
-    |> Enum.map(&to_notification_struct/1)
-    |> Enum.each(&Foundation.Notifications.Supervisor.start_notification_worker/1)
+    |> Enum.each(&start_notification_manager/1)
 
     :ok
   end

--- a/apps/foundation/lib/foundation/notifications/adapter.ex
+++ b/apps/foundation/lib/foundation/notifications/adapter.ex
@@ -46,11 +46,11 @@ defmodule Foundation.Notifications.Adapter do
 
   ## Parameters
 
-    - `event`   — one of the atoms defined in `Foundation.Notifications` (e.g. `:crash_restart`)
+    - `event`   — one of the strings defined in `Foundation.Notifications` (e.g. `"crash_restart"`)
     - `payload` — map with event-specific fields; keys are atoms
     - `config`  — the `Foundation.Notifications.Worker` struct for this adapter instance,
                   containing `:url`, `:options`, and so on
   """
-  @callback notify(event :: atom(), payload :: map(), config :: Worker.t()) ::
+  @callback notify(event :: String.t(), payload :: map(), config :: Worker.t()) ::
               :ok | {:error, term()}
 end

--- a/apps/foundation/lib/foundation/notifications/adapter.ex
+++ b/apps/foundation/lib/foundation/notifications/adapter.ex
@@ -6,8 +6,8 @@ defmodule Foundation.Notifications.Adapter do
 
   1. Create a module that `@behaviour Foundation.Notifications.Adapter`.
   2. Implement `notify/3`.  Return `:ok` on success or `{:error, reason}` on
-     failure — `Foundation.Notifications` will log the error automatically.
-  3. Add a new clause to `Foundation.Yaml.Notifications` so the adapter
+     failure — `Foundation.Notifications.Worker` will log the error automatically.
+  3. Add a new clause to `Foundation.Yaml.notification_adapter/1` so the adapter
      can be selected from `deployex.yaml`.
 
   ### Example skeleton
@@ -18,7 +18,7 @@ defmodule Foundation.Notifications.Adapter do
         alias Foundation.Notifications.Worker
 
         @impl true
-        def notify(event, payload, %Notifications.Worker{url: url, options: options}) do
+        def notify(event, payload, %Worker{url: url, options: options}) do
           # build and send the notification
           :ok
         end
@@ -34,6 +34,21 @@ defmodule Foundation.Notifications.Adapter do
         channel: "#alerts"
 
   accessed as `Map.get(options, :api_token)` inside `notify/3`.
+
+  ## Supported events and payload fields
+
+  | Event                          | Payload keys                                                                                   |
+  |--------------------------------|-----------------------------------------------------------------------------------------------|
+  | `"crash_restart"`              | `node`, `sname`, `name`, `language`, `crash_restart_count`                                   |
+  | `"deployment_started"`         | `node`, `sname`, `version`                                                                    |
+  | `"deployment_complete"`        | `node`, `sname`, `status` (`:ok`/`:error`), `message`                                        |
+  | `"deployment_shutdown"`        | `node`, `sname`                                                                               |
+  | `"watchdog_threshold_exceeded"`| `node`, `type`, `current_percentage`, `restart_threshold_percent`                             |
+  | `"watchdog_threshold_warning"` | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
+  | `"certificate_renewed"`        | `app_name`, `domains`                                                                         |
+  | `"certificate_failed"`         | `app_name`, `domains`, `reason`                                                               |
+  | `"config_changed"`             | `node`, `changes_count`, `fields`                                                             |
+  | `"config_change_applied"`      | `node`, `changes_count`, `fields`                                                             |
   """
 
   alias Foundation.Notifications.Worker

--- a/apps/foundation/lib/foundation/notifications/pagerduty.ex
+++ b/apps/foundation/lib/foundation/notifications/pagerduty.ex
@@ -45,6 +45,8 @@ defmodule Foundation.Notifications.PagerDuty do
   | `certificate_renewed`         | `info`             |
   | `certificate_failed`          | `error`            |
   | `deployment_shutdown`         | `warning`          |
+  | `config_changed`              | `warning`          |
+  | `config_change_applied`       | `info`             |
 
   ## Payload sent to PagerDuty
 
@@ -150,6 +152,14 @@ defmodule Foundation.Notifications.PagerDuty do
   defp format_summary("deployment_shutdown", payload),
     do: "deployment_shutdown — #{payload.sname} on #{payload.node} (force-terminated)"
 
+  defp format_summary("config_changed", payload),
+    do:
+      "config_changed — #{payload.changes_count} change(s) detected on #{payload.node}: #{Enum.join(payload.fields, ", ")}"
+
+  defp format_summary("config_change_applied", payload),
+    do:
+      "config_change_applied — #{payload.changes_count} change(s) applied on #{payload.node}: #{Enum.join(payload.fields, ", ")}"
+
   defp format_summary(event, payload),
     do: "#{event} — #{inspect(payload)}"
 
@@ -163,6 +173,8 @@ defmodule Foundation.Notifications.PagerDuty do
   defp event_severity("certificate_renewed", _payload), do: "info"
   defp event_severity("certificate_failed", _payload), do: "error"
   defp event_severity("deployment_shutdown", _payload), do: "warning"
+  defp event_severity("config_changed", _payload), do: "warning"
+  defp event_severity("config_change_applied", _payload), do: "info"
   defp event_severity(_event, _payload), do: "info"
 
   defp event_source(%{node: node}), do: to_string(node)

--- a/apps/foundation/lib/foundation/notifications/pagerduty.ex
+++ b/apps/foundation/lib/foundation/notifications/pagerduty.ex
@@ -69,7 +69,7 @@ defmodule Foundation.Notifications.PagerDuty do
   @default_api_url "https://events.pagerduty.com/v2/enqueue"
 
   @impl true
-  @spec notify(event :: atom(), payload :: map(), config :: Worker.t()) ::
+  @spec notify(event :: String.t(), payload :: map(), config :: Worker.t()) ::
           :ok | {:error, term()}
   def notify(event, payload, %Worker{url: url, options: options}) do
     routing_key = options[:routing_key]
@@ -120,49 +120,49 @@ defmodule Foundation.Notifications.PagerDuty do
     {:error, reason}
   end
 
-  defp format_summary(:crash_restart, payload),
+  defp format_summary("crash_restart", payload),
     do: "crash_restart — #{payload.sname} on #{payload.node}"
 
-  defp format_summary(:deployment_started, payload),
+  defp format_summary("deployment_started", payload),
     do: "deployment_started — #{payload.sname} on #{payload.node} (version #{payload.version})"
 
-  defp format_summary(:deployment_complete, payload),
+  defp format_summary("deployment_complete", payload),
     do: "deployment_complete (#{payload.status}) — #{payload.sname} on #{payload.node}"
 
-  defp format_summary(:watchdog_threshold_exceeded, payload),
+  defp format_summary("watchdog_threshold_exceeded", payload),
     do:
       "watchdog_threshold_exceeded — #{payload.type} at #{payload.current_percentage}% on #{payload.node}"
 
-  defp format_summary(:watchdog_threshold_warning, %{action: :warning} = payload),
+  defp format_summary("watchdog_threshold_warning", %{action: :warning} = payload),
     do:
       "watchdog_threshold_warning — #{payload.type} at #{payload.current_percentage}% on #{payload.node} (warning: #{payload.warning_threshold_percent}%)"
 
-  defp format_summary(:watchdog_threshold_warning, %{action: :normalized} = payload),
+  defp format_summary("watchdog_threshold_warning", %{action: :normalized} = payload),
     do:
       "watchdog_threshold_warning — #{payload.type} normalized to #{payload.current_percentage}% on #{payload.node}"
 
-  defp format_summary(:certificate_renewed, payload),
+  defp format_summary("certificate_renewed", payload),
     do: "certificate_renewed — #{payload.app_name} (#{Enum.join(payload.domains, ", ")})"
 
-  defp format_summary(:certificate_failed, payload),
+  defp format_summary("certificate_failed", payload),
     do: "certificate_failed — #{payload.app_name}: #{payload.reason}"
 
-  defp format_summary(:deployment_shutdown, payload),
+  defp format_summary("deployment_shutdown", payload),
     do: "deployment_shutdown — #{payload.sname} on #{payload.node} (force-terminated)"
 
   defp format_summary(event, payload),
     do: "#{event} — #{inspect(payload)}"
 
-  defp event_severity(:crash_restart, _payload), do: "error"
-  defp event_severity(:deployment_started, _payload), do: "info"
-  defp event_severity(:deployment_complete, %{status: :ok}), do: "info"
-  defp event_severity(:deployment_complete, %{status: :error}), do: "error"
-  defp event_severity(:watchdog_threshold_exceeded, _payload), do: "critical"
-  defp event_severity(:watchdog_threshold_warning, %{action: :warning}), do: "warning"
-  defp event_severity(:watchdog_threshold_warning, %{action: :normalized}), do: "info"
-  defp event_severity(:certificate_renewed, _payload), do: "info"
-  defp event_severity(:certificate_failed, _payload), do: "error"
-  defp event_severity(:deployment_shutdown, _payload), do: "warning"
+  defp event_severity("crash_restart", _payload), do: "error"
+  defp event_severity("deployment_started", _payload), do: "info"
+  defp event_severity("deployment_complete", %{status: :ok}), do: "info"
+  defp event_severity("deployment_complete", %{status: :error}), do: "error"
+  defp event_severity("watchdog_threshold_exceeded", _payload), do: "critical"
+  defp event_severity("watchdog_threshold_warning", %{action: :warning}), do: "warning"
+  defp event_severity("watchdog_threshold_warning", %{action: :normalized}), do: "info"
+  defp event_severity("certificate_renewed", _payload), do: "info"
+  defp event_severity("certificate_failed", _payload), do: "error"
+  defp event_severity("deployment_shutdown", _payload), do: "warning"
   defp event_severity(_event, _payload), do: "info"
 
   defp event_source(%{node: node}), do: to_string(node)

--- a/apps/foundation/lib/foundation/notifications/slack.ex
+++ b/apps/foundation/lib/foundation/notifications/slack.ex
@@ -18,9 +18,13 @@ defmodule Foundation.Notifications.Slack do
             - "crash_restart"
             - "deployment_started"
             - "deployment_complete"
+            - "deployment_shutdown"
             - "watchdog_threshold_exceeded"
+            - "watchdog_threshold_warning"
             - "certificate_renewed"
             - "certificate_failed"
+            - "config_changed"
+            - "config_change_applied"
           options:
             username: "DeployEx"        # optional, default: "DeployEx"
             icon_emoji: ":rocket:"      # optional, default: ":robot_face:"
@@ -41,6 +45,22 @@ defmodule Foundation.Notifications.Slack do
 
       ✅ *deployment_complete* — `myapp-1` on `myapp@prod-1`
       Status: *ok* — Hot upgrade applied successfully!
+
+  ## Supported events
+
+  | Event                           | Emoji | Description                                           |
+  |---------------------------------|-------|-------------------------------------------------------|
+  | `crash_restart`                 | 🚨    | App crashed and was restarted                         |
+  | `deployment_started`            | 🚀    | New deployment initiated                              |
+  | `deployment_complete` (ok)      | ✅    | Deployment finished successfully                      |
+  | `deployment_complete` (error)   | ❌    | Deployment finished with error                        |
+  | `deployment_shutdown`           | 🛑    | App force-terminated (will restart shortly)           |
+  | `watchdog_threshold_exceeded`   | ⚠️    | Resource threshold crossed; app restarted             |
+  | `watchdog_threshold_warning`    | 🔶/✅ | Resource crossed warning threshold or normalized      |
+  | `certificate_renewed`           | 🔒    | TLS certificate successfully renewed                  |
+  | `certificate_failed`            | 🔓    | TLS certificate renewal failed                        |
+  | `config_changed`                | ⚙️    | Upgradable config change detected in YAML             |
+  | `config_change_applied`         | ✅    | Pending config changes successfully applied           |
   """
 
   @behaviour Foundation.Notifications.Adapter
@@ -164,6 +184,20 @@ defmodule Foundation.Notifications.Slack do
     """
     🛑 *deployment_shutdown* — `#{payload.sname}` on `#{payload.node}`
     `#{payload.sname}` was force-terminated and will restart shortly.\
+    """
+  end
+
+  defp format_message("config_changed", payload) do
+    """
+    ⚙️ *config_changed* — `#{payload.node}`
+    #{payload.changes_count} change(s) detected: #{Enum.join(payload.fields, ", ")}\
+    """
+  end
+
+  defp format_message("config_change_applied", payload) do
+    """
+    ✅ *config_change_applied* — `#{payload.node}`
+    #{payload.changes_count} change(s) applied: #{Enum.join(payload.fields, ", ")}\
     """
   end
 

--- a/apps/foundation/lib/foundation/notifications/slack.ex
+++ b/apps/foundation/lib/foundation/notifications/slack.ex
@@ -53,7 +53,7 @@ defmodule Foundation.Notifications.Slack do
   @default_icon_emoji ":robot_face:"
 
   @impl true
-  @spec notify(event :: atom(), payload :: map(), config :: Worker.t()) ::
+  @spec notify(event :: String.t(), payload :: map(), config :: Worker.t()) ::
           :ok | {:error, term()}
   def notify(event, payload, %Worker{url: url, options: options}) do
     body =
@@ -96,63 +96,63 @@ defmodule Foundation.Notifications.Slack do
     {:error, reason}
   end
 
-  defp format_message(:crash_restart, payload) do
+  defp format_message("crash_restart", payload) do
     """
     🚨 *crash_restart* — `#{payload.sname}` on `#{payload.node}`
     Crash count: *#{payload.crash_restart_count}*\
     """
   end
 
-  defp format_message(:deployment_started, payload) do
+  defp format_message("deployment_started", payload) do
     """
     🚀 *deployment_started* — `#{payload.sname}` on `#{payload.node}`
     Version: *#{payload.version}*\
     """
   end
 
-  defp format_message(:deployment_complete, %{status: :ok} = payload) do
+  defp format_message("deployment_complete", %{status: :ok} = payload) do
     """
     ✅ *deployment_complete* — `#{payload.sname}` on `#{payload.node}`
     Status: *ok* — #{payload.message}\
     """
   end
 
-  defp format_message(:deployment_complete, %{status: :error} = payload) do
+  defp format_message("deployment_complete", %{status: :error} = payload) do
     """
     ❌ *deployment_complete* — `#{payload.sname}` on `#{payload.node}`
     Status: *error* — #{payload.message}\
     """
   end
 
-  defp format_message(:watchdog_threshold_exceeded, payload) do
+  defp format_message("watchdog_threshold_exceeded", payload) do
     """
     ⚠️ *watchdog_threshold_exceeded* — `#{payload.node}`
     Resource: *#{payload.type}* at *#{payload.current_percentage}%* (threshold: #{payload.restart_threshold_percent}%)\
     """
   end
 
-  defp format_message(:watchdog_threshold_warning, %{action: :warning} = payload) do
+  defp format_message("watchdog_threshold_warning", %{action: :warning} = payload) do
     """
     🔶 *watchdog_threshold_warning* — `#{payload.node}`
     Resource: *#{payload.type}* at *#{payload.current_percentage}%* (warning: #{payload.warning_threshold_percent}%)\
     """
   end
 
-  defp format_message(:watchdog_threshold_warning, %{action: :normalized} = payload) do
+  defp format_message("watchdog_threshold_warning", %{action: :normalized} = payload) do
     """
     ✅ *watchdog_threshold_warning* — `#{payload.node}` normalized
     Resource: *#{payload.type}* back to *#{payload.current_percentage}%* (below #{payload.warning_threshold_percent}%)\
     """
   end
 
-  defp format_message(:certificate_renewed, payload) do
+  defp format_message("certificate_renewed", payload) do
     """
     🔒 *certificate_renewed* — `#{payload.app_name}`
     Domains: #{Enum.join(payload.domains, ", ")}\
     """
   end
 
-  defp format_message(:certificate_failed, payload) do
+  defp format_message("certificate_failed", payload) do
     """
     🔓 *certificate_failed* — `#{payload.app_name}`
     Domains: #{Enum.join(payload.domains, ", ")}
@@ -160,7 +160,7 @@ defmodule Foundation.Notifications.Slack do
     """
   end
 
-  defp format_message(:deployment_shutdown, payload) do
+  defp format_message("deployment_shutdown", payload) do
     """
     🛑 *deployment_shutdown* — `#{payload.sname}` on `#{payload.node}`
     `#{payload.sname}` was force-terminated and will restart shortly.\

--- a/apps/foundation/lib/foundation/notifications/supervisor.ex
+++ b/apps/foundation/lib/foundation/notifications/supervisor.ex
@@ -42,4 +42,13 @@ defmodule Foundation.Notifications.Supervisor do
 
     DynamicSupervisor.start_child(__MODULE__, spec)
   end
+
+  @spec stop_all_notification_workers() :: :ok
+  def stop_all_notification_workers do
+    __MODULE__
+    |> DynamicSupervisor.which_children()
+    |> Enum.each(fn {_, pid, _, _} -> DynamicSupervisor.terminate_child(__MODULE__, pid) end)
+
+    :ok
+  end
 end

--- a/apps/foundation/lib/foundation/notifications/webhook.ex
+++ b/apps/foundation/lib/foundation/notifications/webhook.ex
@@ -61,7 +61,7 @@ defmodule Foundation.Notifications.Webhook do
   alias Foundation.Notifications.Worker
 
   @impl true
-  @spec notify(event :: atom(), payload :: map(), config :: Worker.t()) ::
+  @spec notify(event :: String.t(), payload :: map(), config :: Worker.t()) ::
           :ok | {:error, term()}
   def notify(event, payload, %Worker{url: url}) do
     body =

--- a/apps/foundation/lib/foundation/notifications/webhook.ex
+++ b/apps/foundation/lib/foundation/notifications/webhook.ex
@@ -16,9 +16,13 @@ defmodule Foundation.Notifications.Webhook do
             - "crash_restart"
             - "deployment_started"
             - "deployment_complete"
+            - "deployment_shutdown"
             - "watchdog_threshold_exceeded"
+            - "watchdog_threshold_warning"
             - "certificate_renewed"
             - "certificate_failed"
+            - "config_changed"
+            - "config_change_applied"
 
   The `options:` key is accepted but currently unused; it is reserved for
   future extensions such as custom headers or HMAC signing.
@@ -44,14 +48,18 @@ defmodule Foundation.Notifications.Webhook do
 
   ## Payload fields per event
 
-  | Event                          | Fields in `payload`                                                    |
-  |--------------------------------|------------------------------------------------------------------------|
-  | `crash_restart`                | `node`, `sname`, `name`, `language`, `crash_restart_count`            |
-  | `deployment_started`           | `node`, `sname`, `version`                                             |
-  | `deployment_complete`          | `node`, `sname`, `status` (`:ok`/`:error`), `message`                 |
-  | `watchdog_threshold_exceeded`  | `node`, `sname`, `type`, `current_percentage`, `restart_threshold_percent` |
-  | `certificate_renewed`          | `app_name`, `domains`                                                  |
-  | `certificate_failed`           | `app_name`, `domains`, `reason`                                        |
+  | Event                           | Fields in `payload`                                                                                    |
+  |---------------------------------|--------------------------------------------------------------------------------------------------------|
+  | `crash_restart`                 | `node`, `sname`, `name`, `language`, `crash_restart_count`                                            |
+  | `deployment_started`            | `node`, `sname`, `version`                                                                             |
+  | `deployment_complete`           | `node`, `sname`, `status` (`:ok`/`:error`), `message`                                                 |
+  | `deployment_shutdown`           | `node`, `sname`                                                                                        |
+  | `watchdog_threshold_exceeded`   | `node`, `type`, `current_percentage`, `restart_threshold_percent`                                      |
+  | `watchdog_threshold_warning`    | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
+  | `certificate_renewed`           | `app_name`, `domains`                                                                                  |
+  | `certificate_failed`            | `app_name`, `domains`, `reason`                                                                        |
+  | `config_changed`                | `node`, `changes_count`, `fields`                                                                      |
+  | `config_change_applied`         | `node`, `changes_count`, `fields`                                                                      |
   """
 
   @behaviour Foundation.Notifications.Adapter

--- a/apps/foundation/lib/foundation/notifications/worker.ex
+++ b/apps/foundation/lib/foundation/notifications/worker.ex
@@ -26,7 +26,7 @@ defmodule Foundation.Notifications.Worker do
           adapter: module(),
           url: String.t() | nil,
           enabled: boolean(),
-          events: [atom()],
+          events: [String.t()],
           options: map()
         }
 

--- a/apps/foundation/lib/foundation/yaml.ex
+++ b/apps/foundation/lib/foundation/yaml.ex
@@ -546,6 +546,8 @@ defmodule Foundation.Yaml do
     certificate_renewed
     certificate_failed
     deployment_shutdown
+    config_changed
+    config_change_applied
   )
 
   defp parse_notification_events(events) do

--- a/apps/foundation/lib/foundation/yaml.ex
+++ b/apps/foundation/lib/foundation/yaml.ex
@@ -537,18 +537,22 @@ defmodule Foundation.Yaml do
   defp notification_adapter("pagerduty"), do: Foundation.Notifications.PagerDuty
   defp notification_adapter(adapter), do: raise("Notification adapter #{adapter} not supported")
 
+  @valid_notification_events ~w(
+    crash_restart
+    deployment_started
+    deployment_complete
+    watchdog_threshold_exceeded
+    watchdog_threshold_warning
+    certificate_renewed
+    certificate_failed
+    deployment_shutdown
+  )
+
   defp parse_notification_events(events) do
     Enum.map(events, &parse_notification_event/1)
   end
 
-  defp parse_notification_event("crash_restart"), do: :crash_restart
-  defp parse_notification_event("deployment_started"), do: :deployment_started
-  defp parse_notification_event("deployment_complete"), do: :deployment_complete
-  defp parse_notification_event("watchdog_threshold_exceeded"), do: :watchdog_threshold_exceeded
-  defp parse_notification_event("watchdog_threshold_warning"), do: :watchdog_threshold_warning
-  defp parse_notification_event("certificate_renewed"), do: :certificate_renewed
-  defp parse_notification_event("certificate_failed"), do: :certificate_failed
-  defp parse_notification_event("deployment_shutdown"), do: :deployment_shutdown
+  defp parse_notification_event(event) when event in @valid_notification_events, do: event
   defp parse_notification_event(event), do: raise("Unknown notification event: #{event}")
 
   defp atomize_keys(nil), do: %{}

--- a/apps/foundation/test/config_provider/env/config_test.exs
+++ b/apps/foundation/test/config_provider/env/config_test.exs
@@ -721,13 +721,13 @@ defmodule Foundation.ConfigProvider.Env.ConfigTest do
                        url: "https://hooks.example.com/deployex",
                        enabled: true,
                        events: [
-                         :crash_restart,
-                         :deployment_started,
-                         :deployment_complete,
-                         :watchdog_threshold_exceeded,
-                         :watchdog_threshold_warning,
-                         :certificate_renewed,
-                         :certificate_failed
+                         "crash_restart",
+                         "deployment_started",
+                         "deployment_complete",
+                         "watchdog_threshold_exceeded",
+                         "watchdog_threshold_warning",
+                         "certificate_renewed",
+                         "certificate_failed"
                        ],
                        options: %{}
                      },
@@ -735,21 +735,21 @@ defmodule Foundation.ConfigProvider.Env.ConfigTest do
                        adapter: Foundation.Notifications.Slack,
                        url: "https://hooks.slack.com/services/T000/B000/XXX",
                        enabled: true,
-                       events: [:crash_restart, :deployment_complete],
+                       events: ["crash_restart", "deployment_complete"],
                        options: %{username: "DeployEx-Bot", icon_emoji: ":rocket:"}
                      },
                      %Foundation.Yaml.Notification{
                        adapter: Foundation.Notifications.PagerDuty,
                        url: nil,
                        enabled: true,
-                       events: [:crash_restart, :watchdog_threshold_exceeded],
+                       events: ["crash_restart", "watchdog_threshold_exceeded"],
                        options: %{routing_key: "abc123def456"}
                      },
                      %Foundation.Yaml.Notification{
                        adapter: Foundation.Notifications.Webhook,
                        url: "https://hooks2.example.com/deployex",
                        enabled: false,
-                       events: [:crash_restart],
+                       events: ["crash_restart"],
                        options: %{}
                      }
                    ]},

--- a/apps/foundation/test/notifications/notifications_test.exs
+++ b/apps/foundation/test/notifications/notifications_test.exs
@@ -4,10 +4,77 @@ defmodule Foundation.NotificationsTest do
   import Mock
 
   alias Foundation.Notifications
+  alias Foundation.Notifications.Supervisor, as: NotifSupervisor
   alias Foundation.Notifications.Webhook
   alias Foundation.Notifications.Worker
 
   @payload %{node: :deployex@host, sname: "myapp-1", crash_restart_count: 1}
+
+  describe "start_notification_manager/1" do
+    @tag :capture_log
+    test "starts one worker per Foundation.Yaml.Notification entry" do
+      configs = [
+        %Foundation.Yaml.Notification{
+          adapter: Webhook,
+          url: "https://a.example.com",
+          enabled: true,
+          events: ["crash_restart"],
+          options: %{}
+        },
+        %Foundation.Yaml.Notification{
+          adapter: Webhook,
+          url: "https://b.example.com",
+          enabled: true,
+          events: ["deployment_complete"],
+          options: %{}
+        }
+      ]
+
+      before = DynamicSupervisor.count_children(NotifSupervisor).workers
+      assert :ok = Notifications.start_notification_manager(configs)
+      assert DynamicSupervisor.count_children(NotifSupervisor).workers == before + 2
+
+      Notifications.stop_notification_manager()
+    end
+
+    @tag :capture_log
+    test "accepts plain map configs (non-struct)" do
+      configs = [
+        %{
+          adapter: Webhook,
+          url: "https://map.example.com",
+          enabled: true,
+          events: ["crash_restart"],
+          options: %{}
+        }
+      ]
+
+      before = DynamicSupervisor.count_children(NotifSupervisor).workers
+      assert :ok = Notifications.start_notification_manager(configs)
+      assert DynamicSupervisor.count_children(NotifSupervisor).workers == before + 1
+
+      Notifications.stop_notification_manager()
+    end
+  end
+
+  describe "stop_notification_manager/0" do
+    @tag :capture_log
+    test "terminates all running notification workers" do
+      config = %Foundation.Yaml.Notification{
+        adapter: Webhook,
+        url: "https://stop-test.example.com",
+        enabled: true,
+        events: ["crash_restart"],
+        options: %{}
+      }
+
+      Notifications.start_notification_manager([config, config])
+      assert DynamicSupervisor.count_children(NotifSupervisor).workers >= 2
+
+      assert :ok = Notifications.stop_notification_manager()
+      assert DynamicSupervisor.count_children(NotifSupervisor).workers == 0
+    end
+  end
 
   describe "topic/1" do
     test "returns a binary topic string for an event" do
@@ -118,6 +185,32 @@ defmodule Foundation.NotificationsTest do
         Process.sleep(50)
 
         refute called(Webhook.notify(:_, :_, :_))
+      end
+
+      GenServer.stop(worker)
+    end
+
+    @tag :capture_log
+    test "adapter error is logged but worker stays alive" do
+      config = %Worker{
+        adapter: Webhook,
+        url: "https://hooks.example.com/deployex",
+        enabled: true,
+        events: ["crash_restart"],
+        options: %{}
+      }
+
+      {:ok, worker} = Worker.start_link(config)
+
+      with_mocks([
+        {Webhook, [], [notify: fn _event, _payload, _config -> {:error, :econnrefused} end]}
+      ]) do
+        Notifications.notify("crash_restart", @payload)
+
+        Process.sleep(50)
+
+        assert called(Webhook.notify("crash_restart", @payload, config))
+        assert Process.alive?(worker)
       end
 
       GenServer.stop(worker)

--- a/apps/foundation/test/notifications/notifications_test.exs
+++ b/apps/foundation/test/notifications/notifications_test.exs
@@ -11,38 +11,38 @@ defmodule Foundation.NotificationsTest do
 
   describe "topic/1" do
     test "returns a binary topic string for an event" do
-      assert is_binary(Notifications.topic(:crash_restart))
+      assert is_binary(Notifications.topic("crash_restart"))
     end
 
     test "different events produce different topics" do
-      assert Notifications.topic(:crash_restart) != Notifications.topic(:deployment_complete)
+      assert Notifications.topic("crash_restart") != Notifications.topic("deployment_complete")
     end
 
     test "topic contains the event name" do
-      assert Notifications.topic(:crash_restart) =~ "crash_restart"
+      assert Notifications.topic("crash_restart") =~ "crash_restart"
     end
   end
 
   describe "notify/2" do
     test "broadcasts to the per-event topic on Foundation.PubSub" do
-      Phoenix.PubSub.subscribe(Foundation.PubSub, Notifications.topic(:crash_restart))
+      Phoenix.PubSub.subscribe(Foundation.PubSub, Notifications.topic("crash_restart"))
 
-      Notifications.notify(:crash_restart, @payload)
+      Notifications.notify("crash_restart", @payload)
 
-      assert_receive {:crash_restart, received_payload}
+      assert_receive {"crash_restart", received_payload}
       assert received_payload == @payload
     end
 
     test "does not deliver to a subscriber on a different event topic" do
-      Phoenix.PubSub.subscribe(Foundation.PubSub, Notifications.topic(:deployment_complete))
+      Phoenix.PubSub.subscribe(Foundation.PubSub, Notifications.topic("deployment_complete"))
 
-      Notifications.notify(:crash_restart, @payload)
+      Notifications.notify("crash_restart", @payload)
 
-      refute_receive {:crash_restart, _}, 50
+      refute_receive {"crash_restart", _}, 50
     end
 
     test "returns :ok" do
-      assert :ok = Notifications.notify(:crash_restart, @payload)
+      assert :ok = Notifications.notify("crash_restart", @payload)
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Foundation.NotificationsTest do
         adapter: Webhook,
         url: "https://hooks.example.com/deployex",
         enabled: true,
-        events: [:crash_restart],
+        events: ["crash_restart"],
         options: %{}
       }
 
@@ -62,12 +62,12 @@ defmodule Foundation.NotificationsTest do
       with_mocks([
         {Webhook, [], [notify: fn _event, _payload, _config -> :ok end]}
       ]) do
-        Notifications.notify(:crash_restart, @payload)
+        Notifications.notify("crash_restart", @payload)
 
         # allow the worker's handle_info to run
         Process.sleep(50)
 
-        assert called(Webhook.notify(:crash_restart, @payload, config))
+        assert called(Webhook.notify("crash_restart", @payload, config))
       end
 
       GenServer.stop(worker)
@@ -79,7 +79,7 @@ defmodule Foundation.NotificationsTest do
         adapter: Webhook,
         url: "https://hooks.example.com/deployex",
         enabled: true,
-        events: [:watchdog_threshold_exceeded],
+        events: ["watchdog_threshold_exceeded"],
         options: %{}
       }
 
@@ -88,7 +88,7 @@ defmodule Foundation.NotificationsTest do
       with_mocks([
         {Webhook, [], [notify: fn _event, _payload, _config -> :ok end]}
       ]) do
-        Notifications.notify(:crash_restart, @payload)
+        Notifications.notify("crash_restart", @payload)
 
         Process.sleep(50)
 
@@ -104,7 +104,7 @@ defmodule Foundation.NotificationsTest do
         adapter: Webhook,
         url: "https://hooks.example.com/deployex",
         enabled: false,
-        events: [:crash_restart],
+        events: ["crash_restart"],
         options: %{}
       }
 
@@ -113,7 +113,7 @@ defmodule Foundation.NotificationsTest do
       with_mocks([
         {Webhook, [], [notify: fn _event, _payload, _config -> :ok end]}
       ]) do
-        Notifications.notify(:crash_restart, @payload)
+        Notifications.notify("crash_restart", @payload)
 
         Process.sleep(50)
 
@@ -129,7 +129,7 @@ defmodule Foundation.NotificationsTest do
         adapter: Webhook,
         url: "https://a.example.com",
         enabled: true,
-        events: [:crash_restart],
+        events: ["crash_restart"],
         options: %{}
       }
 
@@ -137,7 +137,7 @@ defmodule Foundation.NotificationsTest do
         adapter: Webhook,
         url: "https://b.example.com",
         enabled: true,
-        events: [:crash_restart],
+        events: ["crash_restart"],
         options: %{}
       }
 
@@ -147,12 +147,12 @@ defmodule Foundation.NotificationsTest do
       with_mocks([
         {Webhook, [], [notify: fn _event, _payload, _config -> :ok end]}
       ]) do
-        Notifications.notify(:crash_restart, @payload)
+        Notifications.notify("crash_restart", @payload)
 
         Process.sleep(50)
 
-        assert called(Webhook.notify(:crash_restart, @payload, config_a))
-        assert called(Webhook.notify(:crash_restart, @payload, config_b))
+        assert called(Webhook.notify("crash_restart", @payload, config_a))
+        assert called(Webhook.notify("crash_restart", @payload, config_b))
       end
 
       GenServer.stop(worker_a)

--- a/apps/foundation/test/notifications/pagerduty_test.exs
+++ b/apps/foundation/test/notifications/pagerduty_test.exs
@@ -10,7 +10,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
     adapter: PagerDuty,
     url: nil,
     enabled: true,
-    events: [:crash_restart],
+    events: ["crash_restart"],
     options: %{routing_key: "abc123def456"}
   }
 
@@ -27,7 +27,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        assert :ok = PagerDuty.notify(:crash_restart, payload, @config)
+        assert :ok = PagerDuty.notify("crash_restart", payload, @config)
       end
     end
 
@@ -43,7 +43,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        assert {:error, {:http_error, 400}} = PagerDuty.notify(:crash_restart, payload, @config)
+        assert {:error, {:http_error, 400}} = PagerDuty.notify("crash_restart", payload, @config)
       end
     end
 
@@ -57,7 +57,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        assert {:error, :timeout} = PagerDuty.notify(:crash_restart, payload, @config)
+        assert {:error, :timeout} = PagerDuty.notify("crash_restart", payload, @config)
       end
     end
 
@@ -77,7 +77,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        PagerDuty.notify(:crash_restart, payload, @config)
+        PagerDuty.notify("crash_restart", payload, @config)
 
         assert_receive {:url, url}
         assert url == "https://events.pagerduty.com/v2/enqueue"
@@ -101,7 +101,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        PagerDuty.notify(:crash_restart, payload, custom_config)
+        PagerDuty.notify("crash_restart", payload, custom_config)
 
         assert_receive {:url, url}
         assert url == "https://acme.pagerduty.com/v2/enqueue"
@@ -124,7 +124,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        PagerDuty.notify(:crash_restart, payload, @config)
+        PagerDuty.notify("crash_restart", payload, @config)
 
         assert_receive {:request, headers, body}
 
@@ -143,16 +143,16 @@ defmodule Foundation.Notifications.PagerDutyTest do
 
     test "assigns correct severity for each event" do
       severities = [
-        {:crash_restart, %{node: :n@h, sname: "s", crash_restart_count: 1}, "error"},
-        {:deployment_started, %{node: :n@h, sname: "s", version: "1.0"}, "info"},
-        {:deployment_complete, %{node: :n@h, sname: "s", status: :ok, message: "ok"}, "info"},
-        {:deployment_complete, %{node: :n@h, sname: "s", status: :error, message: "fail"},
+        {"crash_restart", %{node: :n@h, sname: "s", crash_restart_count: 1}, "error"},
+        {"deployment_started", %{node: :n@h, sname: "s", version: "1.0"}, "info"},
+        {"deployment_complete", %{node: :n@h, sname: "s", status: :ok, message: "ok"}, "info"},
+        {"deployment_complete", %{node: :n@h, sname: "s", status: :error, message: "fail"},
          "error"},
-        {:deployment_shutdown, %{node: :n@h, sname: "s"}, "warning"},
-        {:watchdog_threshold_exceeded,
+        {"deployment_shutdown", %{node: :n@h, sname: "s"}, "warning"},
+        {"watchdog_threshold_exceeded",
          %{node: :n@h, type: :memory, current_percentage: 96, restart_threshold_percent: 95},
          "critical"},
-        {:watchdog_threshold_warning,
+        {"watchdog_threshold_warning",
          %{
            node: :n@h,
            type: :atom,
@@ -160,7 +160,7 @@ defmodule Foundation.Notifications.PagerDutyTest do
            warning_threshold_percent: 75,
            action: :warning
          }, "warning"},
-        {:watchdog_threshold_warning,
+        {"watchdog_threshold_warning",
          %{
            node: :n@h,
            type: :atom,
@@ -168,8 +168,9 @@ defmodule Foundation.Notifications.PagerDutyTest do
            warning_threshold_percent: 75,
            action: :normalized
          }, "info"},
-        {:certificate_renewed, %{app_name: "app", domains: ["ex.com"]}, "info"},
-        {:certificate_failed, %{app_name: "app", domains: ["ex.com"], reason: "timeout"}, "error"}
+        {"certificate_renewed", %{app_name: "app", domains: ["ex.com"]}, "info"},
+        {"certificate_failed", %{app_name: "app", domains: ["ex.com"], reason: "timeout"},
+         "error"}
       ]
 
       test_pid = self()

--- a/apps/foundation/test/notifications/pagerduty_test.exs
+++ b/apps/foundation/test/notifications/pagerduty_test.exs
@@ -170,7 +170,11 @@ defmodule Foundation.Notifications.PagerDutyTest do
          }, "info"},
         {"certificate_renewed", %{app_name: "app", domains: ["ex.com"]}, "info"},
         {"certificate_failed", %{app_name: "app", domains: ["ex.com"], reason: "timeout"},
-         "error"}
+         "error"},
+        {"config_changed",
+         %{node: :n@h, changes_count: 2, fields: ["notifications", "monitoring"]}, "warning"},
+        {"config_change_applied",
+         %{node: :n@h, changes_count: 2, fields: ["notifications", "monitoring"]}, "info"}
       ]
 
       test_pid = self()

--- a/apps/foundation/test/notifications/pagerduty_test.exs
+++ b/apps/foundation/test/notifications/pagerduty_test.exs
@@ -141,6 +141,21 @@ defmodule Foundation.Notifications.PagerDutyTest do
       end
     end
 
+    test "falls back gracefully for unknown events" do
+      with_mocks([
+        {Finch, [],
+         [
+           build: fn :post, _url, _headers, _body -> %{} end,
+           request: fn _req, Foundation.Finch ->
+             {:ok, %Finch.Response{status: 202, headers: [], body: ""}}
+           end
+         ]}
+      ]) do
+        payload = %{custom_key: "custom_value"}
+        assert :ok = PagerDuty.notify("unknown_event", payload, @config)
+      end
+    end
+
     test "assigns correct severity for each event" do
       severities = [
         {"crash_restart", %{node: :n@h, sname: "s", crash_restart_count: 1}, "error"},

--- a/apps/foundation/test/notifications/slack_test.exs
+++ b/apps/foundation/test/notifications/slack_test.exs
@@ -143,7 +143,9 @@ defmodule Foundation.Notifications.SlackTest do
            action: :normalized
          }},
         {"certificate_renewed", %{app_name: "myapp", domains: ["example.com"]}},
-        {"certificate_failed", %{app_name: "myapp", domains: ["example.com"], reason: "timeout"}}
+        {"certificate_failed", %{app_name: "myapp", domains: ["example.com"], reason: "timeout"}},
+        {"config_changed", %{node: :n@h, changes_count: 1, fields: ["notifications"]}},
+        {"config_change_applied", %{node: :n@h, changes_count: 1, fields: ["notifications"]}}
       ]
 
       with_mocks([

--- a/apps/foundation/test/notifications/slack_test.exs
+++ b/apps/foundation/test/notifications/slack_test.exs
@@ -117,6 +117,21 @@ defmodule Foundation.Notifications.SlackTest do
       end
     end
 
+    test "falls back gracefully for unknown events" do
+      with_mocks([
+        {Finch, [],
+         [
+           build: fn :post, _url, _headers, _body -> %{} end,
+           request: fn _req, Foundation.Finch ->
+             {:ok, %Finch.Response{status: 200, headers: [], body: "ok"}}
+           end
+         ]}
+      ]) do
+        payload = %{custom_key: "custom_value"}
+        assert :ok = Slack.notify("unknown_event", payload, @config)
+      end
+    end
+
     test "formats all supported events without raising" do
       events_and_payloads = [
         {"crash_restart", %{node: :n@h, sname: "s-1", crash_restart_count: 1}},

--- a/apps/foundation/test/notifications/slack_test.exs
+++ b/apps/foundation/test/notifications/slack_test.exs
@@ -10,7 +10,7 @@ defmodule Foundation.Notifications.SlackTest do
     adapter: Slack,
     url: "https://hooks.slack.com/services/T000/B000/XXX",
     enabled: true,
-    events: [:crash_restart],
+    events: ["crash_restart"],
     options: %{username: "DeployEx", icon_emoji: ":robot_face:"}
   }
 
@@ -27,7 +27,7 @@ defmodule Foundation.Notifications.SlackTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 2}
-        assert :ok = Slack.notify(:crash_restart, payload, @config)
+        assert :ok = Slack.notify("crash_restart", payload, @config)
       end
     end
 
@@ -43,7 +43,7 @@ defmodule Foundation.Notifications.SlackTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 2}
-        assert {:error, {:http_error, 400}} = Slack.notify(:crash_restart, payload, @config)
+        assert {:error, {:http_error, 400}} = Slack.notify("crash_restart", payload, @config)
       end
     end
 
@@ -57,7 +57,7 @@ defmodule Foundation.Notifications.SlackTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 2}
-        assert {:error, :econnrefused} = Slack.notify(:crash_restart, payload, @config)
+        assert {:error, :econnrefused} = Slack.notify("crash_restart", payload, @config)
       end
     end
 
@@ -77,7 +77,7 @@ defmodule Foundation.Notifications.SlackTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 2}
-        Slack.notify(:crash_restart, payload, @config)
+        Slack.notify("crash_restart", payload, @config)
 
         assert_receive {:request, headers, body}
 
@@ -107,7 +107,7 @@ defmodule Foundation.Notifications.SlackTest do
          ]}
       ]) do
         payload = %{node: :app@host, sname: "myapp-1", crash_restart_count: 1}
-        Slack.notify(:crash_restart, payload, config_no_opts)
+        Slack.notify("crash_restart", payload, config_no_opts)
 
         assert_receive {:body, body}
 
@@ -119,14 +119,14 @@ defmodule Foundation.Notifications.SlackTest do
 
     test "formats all supported events without raising" do
       events_and_payloads = [
-        {:crash_restart, %{node: :n@h, sname: "s-1", crash_restart_count: 1}},
-        {:deployment_started, %{node: :n@h, sname: "s-1", version: "1.0.0"}},
-        {:deployment_complete, %{node: :n@h, sname: "s-1", status: :ok, message: "done"}},
-        {:deployment_complete, %{node: :n@h, sname: "s-1", status: :error, message: "fail"}},
-        {:deployment_shutdown, %{node: :n@h, sname: "s-1"}},
-        {:watchdog_threshold_exceeded,
+        {"crash_restart", %{node: :n@h, sname: "s-1", crash_restart_count: 1}},
+        {"deployment_started", %{node: :n@h, sname: "s-1", version: "1.0.0"}},
+        {"deployment_complete", %{node: :n@h, sname: "s-1", status: :ok, message: "done"}},
+        {"deployment_complete", %{node: :n@h, sname: "s-1", status: :error, message: "fail"}},
+        {"deployment_shutdown", %{node: :n@h, sname: "s-1"}},
+        {"watchdog_threshold_exceeded",
          %{node: :n@h, type: :memory, current_percentage: 96, restart_threshold_percent: 95}},
-        {:watchdog_threshold_warning,
+        {"watchdog_threshold_warning",
          %{
            node: :n@h,
            type: :atom,
@@ -134,7 +134,7 @@ defmodule Foundation.Notifications.SlackTest do
            warning_threshold_percent: 75,
            action: :warning
          }},
-        {:watchdog_threshold_warning,
+        {"watchdog_threshold_warning",
          %{
            node: :n@h,
            type: :atom,
@@ -142,8 +142,8 @@ defmodule Foundation.Notifications.SlackTest do
            warning_threshold_percent: 75,
            action: :normalized
          }},
-        {:certificate_renewed, %{app_name: "myapp", domains: ["example.com"]}},
-        {:certificate_failed, %{app_name: "myapp", domains: ["example.com"], reason: "timeout"}}
+        {"certificate_renewed", %{app_name: "myapp", domains: ["example.com"]}},
+        {"certificate_failed", %{app_name: "myapp", domains: ["example.com"], reason: "timeout"}}
       ]
 
       with_mocks([

--- a/apps/foundation/test/notifications/supervisor_test.exs
+++ b/apps/foundation/test/notifications/supervisor_test.exs
@@ -8,7 +8,7 @@ defmodule Foundation.Notifications.SupervisorTest do
     adapter: Foundation.Notifications.Webhook,
     url: "https://hooks.example.com",
     enabled: true,
-    events: [:crash_restart],
+    events: ["crash_restart"],
     options: %{}
   }
 

--- a/apps/foundation/test/notifications/supervisor_test.exs
+++ b/apps/foundation/test/notifications/supervisor_test.exs
@@ -47,4 +47,21 @@ defmodule Foundation.Notifications.SupervisorTest do
       GenServer.stop(pid)
     end
   end
+
+  describe "stop_all_notification_workers/0" do
+    @tag :capture_log
+    test "terminates every worker under the supervisor" do
+      {:ok, pid1} = NotifSupervisor.start_notification_worker(@worker_config)
+      {:ok, pid2} = NotifSupervisor.start_notification_worker(@worker_config)
+
+      assert Process.alive?(pid1)
+      assert Process.alive?(pid2)
+
+      assert :ok = NotifSupervisor.stop_all_notification_workers()
+
+      refute Process.alive?(pid1)
+      refute Process.alive?(pid2)
+      assert DynamicSupervisor.count_children(NotifSupervisor).workers == 0
+    end
+  end
 end

--- a/apps/foundation/test/notifications/webhook_test.exs
+++ b/apps/foundation/test/notifications/webhook_test.exs
@@ -10,7 +10,7 @@ defmodule Foundation.Notifications.WebhookTest do
     adapter: Webhook,
     url: "https://hooks.example.com/deployex",
     enabled: true,
-    events: [:crash_restart],
+    events: ["crash_restart"],
     options: %{}
   }
 
@@ -28,7 +28,7 @@ defmodule Foundation.Notifications.WebhookTest do
            end
          ]}
       ]) do
-        assert :ok = Webhook.notify(:crash_restart, @payload, @config)
+        assert :ok = Webhook.notify("crash_restart", @payload, @config)
       end
     end
 
@@ -43,7 +43,7 @@ defmodule Foundation.Notifications.WebhookTest do
            end
          ]}
       ]) do
-        assert :ok = Webhook.notify(:crash_restart, @payload, @config)
+        assert :ok = Webhook.notify("crash_restart", @payload, @config)
       end
     end
 
@@ -59,7 +59,7 @@ defmodule Foundation.Notifications.WebhookTest do
          ]}
       ]) do
         assert {:error, {:http_error, 500}} =
-                 Webhook.notify(:crash_restart, @payload, @config)
+                 Webhook.notify("crash_restart", @payload, @config)
       end
     end
 
@@ -72,7 +72,7 @@ defmodule Foundation.Notifications.WebhookTest do
            request: fn _req, Foundation.Finch -> {:error, :timeout} end
          ]}
       ]) do
-        assert {:error, :timeout} = Webhook.notify(:crash_restart, @payload, @config)
+        assert {:error, :timeout} = Webhook.notify("crash_restart", @payload, @config)
       end
     end
 
@@ -91,7 +91,7 @@ defmodule Foundation.Notifications.WebhookTest do
            end
          ]}
       ]) do
-        Webhook.notify(:crash_restart, @payload, @config)
+        Webhook.notify("crash_restart", @payload, @config)
 
         assert_receive {:request_body, headers, body}
 

--- a/apps/foundation/test/yaml_test.exs
+++ b/apps/foundation/test/yaml_test.exs
@@ -596,13 +596,13 @@ defmodule Foundation.YamlTest do
         assert webhook.enabled == true
         assert webhook.options == %{}
 
-        assert :crash_restart in webhook.events
-        assert :deployment_started in webhook.events
-        assert :deployment_complete in webhook.events
-        assert :watchdog_threshold_exceeded in webhook.events
-        assert :watchdog_threshold_warning in webhook.events
-        assert :certificate_renewed in webhook.events
-        assert :certificate_failed in webhook.events
+        assert "crash_restart" in webhook.events
+        assert "deployment_started" in webhook.events
+        assert "deployment_complete" in webhook.events
+        assert "watchdog_threshold_exceeded" in webhook.events
+        assert "watchdog_threshold_warning" in webhook.events
+        assert "certificate_renewed" in webhook.events
+        assert "certificate_failed" in webhook.events
       end
     end
 
@@ -620,8 +620,8 @@ defmodule Foundation.YamlTest do
         assert slack.enabled == true
         assert slack.options[:username] == "DeployEx-Bot"
         assert slack.options[:icon_emoji] == ":rocket:"
-        assert :crash_restart in slack.events
-        assert :deployment_complete in slack.events
+        assert "crash_restart" in slack.events
+        assert "deployment_complete" in slack.events
       end
     end
 
@@ -638,8 +638,8 @@ defmodule Foundation.YamlTest do
         assert pagerduty.url == nil
         assert pagerduty.enabled == true
         assert pagerduty.options[:routing_key] == "abc123def456"
-        assert :crash_restart in pagerduty.events
-        assert :watchdog_threshold_exceeded in pagerduty.events
+        assert "crash_restart" in pagerduty.events
+        assert "watchdog_threshold_exceeded" in pagerduty.events
       end
     end
 

--- a/apps/sentinel/lib/sentinel/config/changes.ex
+++ b/apps/sentinel/lib/sentinel/config/changes.ex
@@ -40,6 +40,7 @@ defmodule Sentinel.Config.Changes do
           optional(:logs_retention_time_ms) => numeric_change(),
           optional(:metrics_retention_time_ms) => numeric_change(),
           optional(:monitoring) => list_change(),
+          optional(:notifications) => list_change(),
           optional(:applications) => %{
             old: [Foundation.Yaml.Application.t()],
             new: [Foundation.Yaml.Application.t()],

--- a/apps/sentinel/lib/sentinel/config/upgradable.ex
+++ b/apps/sentinel/lib/sentinel/config/upgradable.ex
@@ -15,6 +15,7 @@ defmodule Sentinel.Config.Upgradable do
             metrics_retention_time_ms: nil,
             monitoring: [],
             applications: [],
+            notifications: [],
             config_checksum: nil
 
   @type t :: %__MODULE__{
@@ -22,6 +23,7 @@ defmodule Sentinel.Config.Upgradable do
           metrics_retention_time_ms: non_neg_integer() | nil,
           monitoring: [{atom(), Yaml.Monitoring.t()}] | [],
           applications: [Yaml.Application.t()] | [],
+          notifications: [Yaml.Notification.t()] | [],
           config_checksum: String.t() | nil
         }
 
@@ -35,6 +37,7 @@ defmodule Sentinel.Config.Upgradable do
       metrics_retention_time_ms: config.metrics_retention_time_ms,
       monitoring: config.monitoring,
       applications: config.applications,
+      notifications: config.notifications,
       config_checksum: config.config_checksum
     }
   end
@@ -49,6 +52,7 @@ defmodule Sentinel.Config.Upgradable do
       metrics_retention_time_ms: Application.get_env(:observer_web, :data_retention_period),
       monitoring: Application.get_env(:foundation, :monitoring, []),
       applications: Application.get_env(:foundation, :applications, []),
+      notifications: Application.get_env(:foundation, :notifications, []),
       config_checksum: Application.get_env(:foundation, :config_checksum)
     }
   end

--- a/apps/sentinel/lib/sentinel/config/watcher.ex
+++ b/apps/sentinel/lib/sentinel/config/watcher.ex
@@ -119,6 +119,12 @@ defmodule Sentinel.Config.Watcher do
 
     Logger.info("ConfigWatcher: Successfully applied configuration updates")
 
+    Notifications.notify("config_change_applied", %{
+      node: Node.self(),
+      changes_count: state.pending_changes.changes_count,
+      fields: state.pending_changes.summary |> Map.keys() |> Enum.map(&to_string/1)
+    })
+
     # Notify subscribers about new changes
     Phoenix.PubSub.broadcast(
       Foundation.PubSub,
@@ -238,6 +244,12 @@ defmodule Sentinel.Config.Watcher do
             @pubsub_topic_new,
             {:watcher_config_new, Node.self(), pending_changes}
           )
+
+          Notifications.notify("config_changed", %{
+            node: Node.self(),
+            changes_count: pending_changes.changes_count,
+            fields: pending_changes.summary |> Map.keys() |> Enum.map(&to_string/1)
+          })
         end
 
         %{state | pending_config: yaml_upgradable, pending_changes: pending_changes}

--- a/apps/sentinel/lib/sentinel/config/watcher.ex
+++ b/apps/sentinel/lib/sentinel/config/watcher.ex
@@ -27,6 +27,7 @@ defmodule Sentinel.Config.Watcher do
   alias Deployer.Monitor.Supervisor, as: MonitorSupervisor
   alias Foundation.Catalog.Local
   alias Foundation.Certificate
+  alias Foundation.Notifications
   alias Foundation.Yaml
   alias Sentinel.Config.Changes
   alias Sentinel.Config.Upgradable
@@ -270,6 +271,7 @@ defmodule Sentinel.Config.Watcher do
     |> add_number_changes(:logs_retention_time_ms, old, new, :immediate)
     |> add_number_changes(:metrics_retention_time_ms, old, new, :immediate)
     |> add_monitoring_changes(old, new, :immediate)
+    |> add_notification_changes(old, new, :immediate)
     |> add_application_changes(old, new)
   end
 
@@ -331,6 +333,18 @@ defmodule Sentinel.Config.Watcher do
           acc
       end
     end)
+  end
+
+  defp add_notification_changes(acc, old, new, strategy) do
+    if normalize(old.notifications) != normalize(new.notifications) do
+      Map.put(acc, :notifications, %{
+        old: old.notifications,
+        new: new.notifications,
+        apply_strategy: strategy
+      })
+    else
+      acc
+    end
   end
 
   defp add_env_changes(acc, old_app, new_app, strategy) do
@@ -451,6 +465,11 @@ defmodule Sentinel.Config.Watcher do
 
           :ok
 
+        :notifications ->
+          Logger.warning("ConfigWatcher: Stopping all notification workers for update")
+          Notifications.stop_notification_manager()
+          :ok
+
         _ ->
           :ok
       end
@@ -508,6 +527,10 @@ defmodule Sentinel.Config.Watcher do
 
         :monitoring ->
           Sentinel.Watchdog.reset_app_statistics("deployex")
+          :ok
+
+        :notifications ->
+          Notifications.start_notification_manager(change.new)
           :ok
 
         :metrics_retention_time_ms ->

--- a/apps/sentinel/lib/sentinel/watchdog/watchdog.ex
+++ b/apps/sentinel/lib/sentinel/watchdog/watchdog.ex
@@ -383,7 +383,7 @@ defmodule Sentinel.Watchdog do
     %{sname: sname} = Catalog.node_info(node)
     Monitor.restart(sname)
 
-    Foundation.Notifications.notify(:watchdog_threshold_exceeded, %{
+    Foundation.Notifications.notify("watchdog_threshold_exceeded", %{
       node: node,
       type: type,
       current_percentage: current_percentage,
@@ -407,7 +407,7 @@ defmodule Sentinel.Watchdog do
       "[#{node}] #{type} threshold exceeded: current #{current_percentage}% > warning #{warning_threshold_percent}%."
     )
 
-    Foundation.Notifications.notify(:watchdog_threshold_warning, %{
+    Foundation.Notifications.notify("watchdog_threshold_warning", %{
       node: node,
       type: type,
       current_percentage: current_percentage,
@@ -435,7 +435,7 @@ defmodule Sentinel.Watchdog do
       "[#{node}] #{type} threshold normalized: current #{current_percentage}% <= warning #{warning_threshold_percent}%."
     )
 
-    Foundation.Notifications.notify(:watchdog_threshold_warning, %{
+    Foundation.Notifications.notify("watchdog_threshold_warning", %{
       node: node,
       type: type,
       current_percentage: current_percentage,
@@ -469,7 +469,7 @@ defmodule Sentinel.Watchdog do
     %{sname: sname} = Catalog.node_info(node)
     Monitor.restart(sname)
 
-    Foundation.Notifications.notify(:watchdog_threshold_exceeded, %{
+    Foundation.Notifications.notify("watchdog_threshold_exceeded", %{
       node: node,
       type: :memory,
       current_percentage: current_percentage,
@@ -492,7 +492,7 @@ defmodule Sentinel.Watchdog do
       "Total Memory threshold exceeded: current #{current_percentage}% > warning #{warning_threshold_percent}%."
     )
 
-    Foundation.Notifications.notify(:watchdog_threshold_warning, %{
+    Foundation.Notifications.notify("watchdog_threshold_warning", %{
       node: node(),
       type: :memory,
       current_percentage: current_percentage,
@@ -522,7 +522,7 @@ defmodule Sentinel.Watchdog do
       "Total Memory threshold normalized: current #{current_percentage}% <= warning #{warning_threshold_percent}%."
     )
 
-    Foundation.Notifications.notify(:watchdog_threshold_warning, %{
+    Foundation.Notifications.notify("watchdog_threshold_warning", %{
       node: node(),
       type: :memory,
       current_percentage: current_percentage,

--- a/apps/sentinel/test/support/watcher.ex
+++ b/apps/sentinel/test/support/watcher.ex
@@ -241,4 +241,78 @@ defmodule Sentinel.Fixture.Watcher do
       changes_count: 4
     }
   end
+
+  def build_pending_changes_with_notifications do
+    %Changes{
+      summary: %{
+        notifications: %{
+          old: [
+            %Foundation.Yaml.Notification{
+              adapter: Foundation.Notifications.Slack,
+              url: "https://hooks.slack.com/test",
+              enabled: true,
+              events: ["crash_restart", "deployment_complete"],
+              options: %{}
+            }
+          ],
+          new: [
+            %Foundation.Yaml.Notification{
+              adapter: Foundation.Notifications.Webhook,
+              url: "https://example.com/hooks/deployex",
+              enabled: true,
+              events: ["crash_restart", "deployment_complete", "config_changed"],
+              options: %{}
+            }
+          ],
+          apply_strategy: :immediate
+        }
+      },
+      timestamp: ~U[2025-11-14 23:41:07.000464Z],
+      changes_count: 1
+    }
+  end
+
+  def build_pending_changes_with_certificates do
+    cert = %Foundation.Yaml.Certificate{
+      type: :domains,
+      domains: ["*.example.com"],
+      certificate_check_interval_ms: 86_400_000,
+      dns_propagation_timeout_ms: 120_000,
+      dns_check_interval_ms: 5000,
+      renew_before_days: 30,
+      dns_provider: :cloudflare,
+      dns_options: nil,
+      acme_provider: :lets_encrypt,
+      acme_options: nil,
+      importer: nil,
+      importer_options: nil
+    }
+
+    %Changes{
+      summary: %{
+        applications: %{
+          old: [],
+          new: [],
+          details: %{
+            "myphoenixapp" => %{
+              status: :modified,
+              changes: %{
+                certificates: %{
+                  old: [],
+                  new: [cert],
+                  details: %{
+                    domains: %{status: :added, config: cert}
+                  },
+                  apply_strategy: :immediate
+                }
+              },
+              apply_strategies: [:immediate]
+            }
+          }
+        }
+      },
+      timestamp: ~U[2025-11-14 23:41:07.000464Z],
+      changes_count: 1
+    }
+  end
 end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -85,26 +85,27 @@ config :foundation,
       restart_threshold_percent: 95
     }
   ],
-  notifications: [],
-  # NOTE: Enable for notifications testing
-  # notifications: [
-  #   %{
-  #     adapter: Foundation.Notifications.Webhook,
-  #     url: "https://example.com/hooks/deployex",
-  #     enabled: true,
-  #     events: [
-  #       :crash_restart,
-  #       :deployment_started,
-  #       :deployment_complete,
-  #       :deployment_shutdown,
-  #       :watchdog_threshold_exceeded,
-  #       :watchdog_threshold_warning,
-  #       :certificate_renewed,
-  #       :certificate_failed
-  #     ],
-  #     options: %{}
-  #   }
-  # ],
+  notifications: [
+    # NOTE: Enable for notifications testing
+    # %{
+    #   adapter: Foundation.Notifications.Webhook,
+    #   url: "https://example.com/hooks/deployex",
+    #   enabled: true,
+    #   events: [
+    #     "crash_restart",
+    #     "deployment_started",
+    #     "deployment_complete",
+    #     "deployment_shutdown",
+    #     "watchdog_threshold_exceeded",
+    #     "watchdog_threshold_warning",
+    #     "certificate_renewed",
+    #     "certificate_failed",
+    #     "config_changed",
+    #     "config_change_applied"
+    #   ],
+    #   options: %{}
+    # }
+  ],
   applications: [
     %{
       name: "myphoenixapp",
@@ -135,36 +136,35 @@ config :foundation,
           restart_threshold_percent: 90
         }
       ],
-      certificates: []
-      # NOTE: Enable for certificate testing
-      # certificates: [
-      #   %{
-      #     type: :domains,
-      #     domains: ["*.calori.com.br"],
-      #     certificate_check_interval_ms: 86_400_000,
-      #     dns_propagation_timeout_ms: 120_000,
-      #     dns_check_interval_ms: 5_000,
-      #     renew_before_days: 30,
-      #     dns_provider: Foundation.Certificates.DNSProvider.Mock,
-      #     dns_options: %{
-      #       ttl: 1,
-      #       zone: "Z6767676776I8",
-      #       api_token: "ABC123GHB" (for cloudflare only)
-      #     },
-      #     acme_provider: Foundation.Certificates.ACMEProvider.LetsEncrypt,
-      #     acme_options: %{
-      #       contact_email: "myapp@mydomain.com",
-      #       url: "https://acme-v02.api.letsencrypt.org/directory",
-      #       key_size: 2048,
-      #       propagation_timeout_ms: 120_000,
-      #       check_interval_ms: 2_000
-      #     },
-      #     importer: Foundation.Certificates.Importer.Mock,
-      #     importer_options: %{
-      #       certificate_arn: "add::certificate::arn"
-      #     }
-      #   }
-      # ]
+      certificates: [
+        # NOTE: Enable for certificate testing
+        #   %{
+        #     type: :domains,
+        #     domains: ["*.calori.com.br"],
+        #     certificate_check_interval_ms: 86_400_000,
+        #     dns_propagation_timeout_ms: 120_000,
+        #     dns_check_interval_ms: 5_000,
+        #     renew_before_days: 30,
+        #     dns_provider: Foundation.Certificates.DNSProvider.Mock,
+        #     dns_options: %{
+        #       ttl: 1,
+        #       zone: "Z6767676776I8",
+        #       api_token: "ABC123GHB" (for cloudflare only)
+        #     },
+        #     acme_provider: Foundation.Certificates.ACMEProvider.LetsEncrypt,
+        #     acme_options: %{
+        #       contact_email: "myapp@mydomain.com",
+        #       url: "https://acme-v02.api.letsencrypt.org/directory",
+        #       key_size: 2048,
+        #       propagation_timeout_ms: 120_000,
+        #       check_interval_ms: 2_000
+        #     },
+        #     importer: Foundation.Certificates.Importer.Mock,
+        #     importer_options: %{
+        #       certificate_arn: "add::certificate::arn"
+        #     }
+        #   }
+      ]
     }
   ]
 

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -85,6 +85,8 @@ notifications:
       - "watchdog_threshold_warning"                     # Resource crossed warning threshold (or normalized)
       - "certificate_renewed"                            # TLS certificate successfully renewed
       - "certificate_failed"                             # TLS certificate renewal failed
+      - "config_changed"                                 # Upgradable config change detected in YAML
+      - "config_change_applied"                          # Pending config changes successfully applied
 
   # Slack Incoming Webhook adapter
   - adapter: "slack"
@@ -236,6 +238,7 @@ These fields can be modified and applied at runtime without restarting DeployEx:
 - `logs_retention_time_ms` - Log data retention period
 - `metrics_retention_time_ms` - Metrics data retention period
 - `monitoring` - Host-level monitoring settings (memory thresholds)
+- `notifications` - External notification channels (workers are stopped and restarted on apply)
 
 #### Application Level (Runtime Upgradable)
 - `monitoring` - Application monitoring settings (atom, process, port thresholds)
@@ -267,7 +270,6 @@ These fields require a **full DeployEx restart**:
 - `secrets_path` - Secrets path
 - `aws_region` - AWS region
 - `google_credentials` - GCP credentials path
-- `notifications` - External notification channels (requires restart to add, remove, or reconfigure)
 
 #### System Requirements
 - `version` - DeployEx version


### PR DESCRIPTION
- Change all notification event identifiers from atoms to strings throughout (yaml parsing, adapters, workers, call sites, and tests)
- Add Foundation.Notifications.stop/start_notification_manager to stop all workers and restart them from a new config list
- Wire :notifications into Sentinel.Config.Watcher so changes detected in the YAML are applied at runtime without a restart
- Add :notifications field to Sentinel.Config.Upgradable and Changes
- Add a dedicated render_change_section for :notifications in the config changes modal to avoid a crash when rendering struct lists