### PR TITLE
terraform: add CloudWatch log group retention policy

### DIFF
--- a/guides/docs/aws-elixir/terraform/modules/standard-account/metrics.tf
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/metrics.tf
@@ -3,7 +3,8 @@
 #
 
 resource "aws_cloudwatch_log_group" "ec2_instance_logs" {
-  name = "myappname-${var.account_name}-ec2-instance-logs"
+  name              = "myappname-${var.account_name}-ec2-instance-logs"
+  retention_in_days = var.log_retention_in_days
 }
 
 resource "aws_iam_policy" "ec2_cloudwatch_policy" {

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/variables.tf
@@ -38,3 +38,9 @@ variable "ec2_instance_type" {
   type        = string
   nullable    = false
 }
+
+variable "log_retention_in_days" {
+  description = "Number of days CloudWatch log groups are retained before deletion"
+  type        = number
+  default     = 30
+}

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/metrics.tf
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/metrics.tf
@@ -3,7 +3,8 @@
 #
 
 resource "aws_cloudwatch_log_group" "ec2_instance_logs" {
-  name = "myappname-${var.account_name}-ec2-instance-logs"
+  name              = "myappname-${var.account_name}-ec2-instance-logs"
+  retention_in_days = var.log_retention_in_days
 }
 
 resource "aws_iam_policy" "ec2_cloudwatch_policy" {

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/variables.tf
@@ -38,3 +38,9 @@ variable "ec2_instance_type" {
   type        = string
   nullable    = false
 }
+
+variable "log_retention_in_days" {
+  description = "Number of days CloudWatch log groups are retained before deletion"
+  type        = number
+  default     = 30
+}

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/metrics.tf
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/metrics.tf
@@ -3,7 +3,8 @@
 #
 
 resource "aws_cloudwatch_log_group" "ec2_instance_logs" {
-  name = "myappname-${var.account_name}-ec2-instance-logs"
+  name              = "myappname-${var.account_name}-ec2-instance-logs"
+  retention_in_days = var.log_retention_in_days
 }
 
 resource "aws_iam_policy" "ec2_cloudwatch_policy" {

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/variables.tf
@@ -38,3 +38,9 @@ variable "ec2_instance_type" {
   type        = string
   nullable    = false
 }
+
+variable "log_retention_in_days" {
+  description = "Number of days CloudWatch log groups are retained before deletion"
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
Add `retention_in_days` to `aws_cloudwatch_log_group` in the `standard-account` module for aws-elixir, aws-erlang and aws-gleam. Without this, AWS retains logs indefinitely by default, leading to unbounded storage costs.  

A new optional variable `log_retention_in_days` (default: 30 days) is introduced in each module's `variables.tf`. No existing callers need to be updated. The default of 30 days matches the value already used in the aws-elixir-db-certificate module, the only module that had retention configured prior to this change.  

Relates to the CloudWatch Logs Without Retention finding flagged in #236.