### PR TITLE
Fix engine state corruption on rollback timeout during initial boot

### DIFF
--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -166,8 +166,11 @@ defmodule Deployer.Engine.Worker do
           |> Status.current_version_map()
           |> Status.add_ghosted_version()
 
-        # Return deployment to the current one
-        deployments = Map.put(deployments, state.current, deployment_to_terminate)
+        # Return deployment to the current one. When the rollback timer was
+        # armed by the initial boot there is no previous deployment to return
+        # to, so reset the instance to an empty deployment
+        deployments =
+          Map.put(deployments, state.current, deployment_to_terminate || %Engine.Deployment{})
 
         %{
           state

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -948,6 +948,67 @@ defmodule Deployer.EngineTest do
     end
 
     @tag :capture_log
+    test "Rollback after timeout on initial boot keeps the engine alive" do
+      # When the engine initializes with an installed application, the rollback
+      # timer is armed without a previous deployment to terminate. If the
+      # application never reports running, the rollback must reset the instance
+      # to an empty deployment instead of corrupting the state.
+      name = "myelixir"
+      language = "elixir"
+
+      ref = make_ref()
+      pid = self()
+      sname = Catalog.create_sname("myelixir")
+      FixtureFiles.create_bin_files(sname)
+      version_to_ghost = "1.2.3"
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [sname] end)
+      |> stub(:current_version, fn _sname -> version_to_ghost end)
+      |> expect(:history_version_list, fn _name, _options ->
+        [%Catalog.Version{version: version_to_ghost}]
+      end)
+      |> expect(:current_version_map, 1, fn _sname ->
+        %{version: version_to_ghost, hash: "local", pre_commands: []}
+      end)
+      |> expect(:add_ghosted_version, 1, fn version_map -> {:ok, [version_map]} end)
+
+      Deployer.MonitorMock
+      |> expect(:start_service, 1, fn %{sname: ^sname} -> {:ok, self()} end)
+      |> expect(:stop_service, fn _name, ^sname ->
+        send(pid, {:handle_ref_event, ref})
+        :ok
+      end)
+
+      Deployer.ReleaseMock
+      |> stub(:download_version_map, fn _app_name ->
+        %{version: version_to_ghost, hash: "local", pre_commands: []}
+      end)
+
+      with_mock System, [:passthrough],
+        cmd: fn "tar", ["-x", "-f", _source_path, "-C", _dest_path] -> {"", 0} end do
+        assert {:ok, worker_pid} =
+                 Engine.Worker.start_link(%Engine.Worker{
+                   deploy_rollback_timeout_ms: 100,
+                   deploy_schedule_interval_ms: 100,
+                   name: name,
+                   language: language
+                 })
+
+        assert_receive {:handle_ref_event, ^ref}, 1_000
+
+        # Let the engine run a few schedule cycles after the rollback
+        :timer.sleep(300)
+
+        assert Process.alive?(worker_pid)
+
+        state = :sys.get_state(String.to_atom(name))
+        assert %Deployer.Engine.Deployment{sname: nil} = state.deployments[1]
+        assert Enum.any?(state.ghosted_version_list, &(&1.version == version_to_ghost))
+      end
+    end
+
+    @tag :capture_log
     test "Invalid rollback message" do
       name = "myelixir"
       language = "elixir"


### PR DESCRIPTION
When the engine worker initializes with an already installed application, initialize_version arms the rollback timer without setting deployment_to_terminate (that field is only set by full deployments). If the application failed to report running within the rollback timeout, the timeout handler restored the current instance with nil, and the next schedule tick crashed the engine worker when accessing the deployment state, leading to a supervisor restart loop.

The rollback now falls back to an empty deployment when there is no previous deployment to return to, keeping the engine alive after ghosting the version.

Risk assessment:
- Impact: the engine worker survives a rollback of the very first deployment after a DeployEx restart. The version is still ghosted and the node is still stopped, as before.
- Blast radius: the :timeout_rollback handler in Deployer.Engine.Worker. Rollbacks of regular full deployments keep the exact same behavior since deployment_to_terminate is always set on that path.
- Regression risk: low. The new fallback only triggers where the code previously crashed.
- Rollback: revert this commit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>