### PR TITLE
Fix read-after-write race in the web cache

### DIFF
--- a/apps/deployex_web/lib/deployex_web/cache/table.ex
+++ b/apps/deployex_web/lib/deployex_web/cache/table.ex
@@ -22,9 +22,9 @@ defmodule DeployexWeb.Cache do
   end
 
   @impl true
-  def handle_cast({:update_data, key, data}, state) do
+  def handle_call({:update_data, key, data}, _from, state) do
     :ets.insert(@table_name, {key, data})
-    {:noreply, state}
+    {:reply, :ok, state}
   end
 
   ### ==========================================================================
@@ -40,7 +40,9 @@ defmodule DeployexWeb.Cache do
     end
   end
 
+  # NOTE: The write is a synchronous call so that a subsequent get/1 is
+  #       guaranteed to observe it, get/1 reads the ETS table directly.
   def set(key, data) do
-    GenServer.cast(__MODULE__, {:update_data, key, data})
+    GenServer.call(__MODULE__, {:update_data, key, data})
   end
 end


### PR DESCRIPTION
DeployexWeb.Cache.set/2 was an asynchronous GenServer.cast while get/1 reads the ETS table directly, so a get right after a set could observe the previous value. This surfaced as a flaky UiSettingsTest failure where the setup wrote the cache and the test read a stale entry.

The write is now a synchronous GenServer.call, guaranteeing that any subsequent read observes it.

Risk assessment:
- Impact: UI settings writes (nav menu toggle) become synchronous. The caller now waits for the cache GenServer, which only does an ETS insert, so the latency is negligible.
- Blast radius: DeployexWeb.Cache only; the single caller today is Cache.UiSettings.
- Regression risk: very low. A call can time out if the cache server is overloaded, but it handles rare, tiny writes.
- Rollback: revert this commit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>