### PR TITLE
Fix stderr log streaming from monitored applications

### DIFF
--- a/apps/host/lib/host/terminal/server.ex
+++ b/apps/host/lib/host/terminal/server.ex
@@ -113,8 +113,8 @@ defmodule Host.Terminal.Server do
     {:stop, :normal, state}
   end
 
-  def handle_info({:stdout, os_process, message}, %{process: process} = state)
-      when os_process == process do
+  def handle_info({stream, os_process, message}, %{process: process} = state)
+      when stream in [:stdout, :stderr] and os_process == process do
     state = %{state | msg_sequence: state.msg_sequence + 1, message: message}
 
     notify_target(state)

--- a/apps/host/test/terminal_test.exs
+++ b/apps/host/test/terminal_test.exs
@@ -165,6 +165,56 @@ defmodule Host.TerminalTest do
     end
 
     @tag :capture_log
+    test "Receiving a text from the OS process via stderr" do
+      ref = make_ref()
+      test_pid_process = self()
+      node = Node.self()
+      os_pid = 123_456
+      commands = "command_1"
+      options = [:monitor]
+
+      received_msg1 = "received_stderr_msg1"
+      received_msg2 = "received_stderr_msg2"
+
+      Host.CommanderMock
+      |> expect(:run, fn ^commands, ^options ->
+        {:ok, test_pid_process, os_pid}
+      end)
+      |> expect(:stop, fn ^os_pid ->
+        send(test_pid_process, {:handle_ref_event, ref})
+        :ok
+      end)
+
+      state = %Terminal{
+        node: node,
+        commands: commands,
+        options: [],
+        target: test_pid_process,
+        metadata: "test"
+      }
+
+      assert {:ok, pid} = Terminal.new(state)
+
+      assert_receive {:terminal_update, _state}, 1_000
+
+      send(pid, {:stderr, os_pid, received_msg1})
+
+      assert_receive {:terminal_update, state}, 1_000
+      assert state.message == received_msg1
+      assert state.msg_sequence == 1
+
+      send(pid, {:stderr, os_pid, received_msg2})
+
+      assert_receive {:terminal_update, state}, 1_000
+      assert state.message == received_msg2
+      assert state.msg_sequence == 2
+
+      FixtureTerminal.terminate_all()
+
+      assert_receive {:handle_ref_event, ^ref}, 1_000
+    end
+
+    @tag :capture_log
     test "Receive a DOWN message from the caller" do
       ref = make_ref()
       test_pid_process = self()

--- a/apps/sentinel/lib/sentinel/logs/server.ex
+++ b/apps/sentinel/lib/sentinel/logs/server.ex
@@ -330,7 +330,10 @@ defmodule Sentinel.Logs.Server do
     create_terminal = fn log_type ->
       path = log_path(sname, log_type)
       commands = "tail -F -n 0 #{path}"
-      options = [:"#{log_type}"]
+      # NOTE: tail always writes the file content to its own stdout, regardless
+      #       of which log file is being followed, so the terminal must always
+      #       capture :stdout. The log type is carried by the metadata.
+      options = [:stdout]
 
       Terminal.new(%Terminal{
         # node: node,

--- a/apps/sentinel/test/logs/server_test.exs
+++ b/apps/sentinel/test/logs/server_test.exs
@@ -235,6 +235,25 @@ defmodule Sentinel.Logs.ServerTest do
                    1_000
   end
 
+  test "Log terminals always capture the tail output from stdout", %{pid: pid} do
+    test_pid = self()
+    new_sname = Catalog.create_sname("myelixir")
+    Catalog.setup_new_node(new_sname)
+
+    # NOTE: tail writes the content of the followed file to its own stdout,
+    #       so both the stdout and the stderr log terminals must capture :stdout
+    with_mock Terminal,
+      new: fn %Terminal{options: options, metadata: %{type: type}} ->
+        send(test_pid, {:terminal_created, type, options})
+        :ok
+      end do
+      send(pid, {:new_deploy, Node.self(), new_sname})
+
+      assert_receive {:terminal_created, "stdout", [:stdout]}, 1_000
+      assert_receive {:terminal_created, "stderr", [:stdout]}, 1_000
+    end
+  end
+
   test "Check no Terminal is created if there is no log file", %{
     fake_sname: fake_sname,
     sname: sname,


### PR DESCRIPTION
The Sentinel logs server tails the stdout and stderr log files, but the stderr terminal was created with the erlexec option [:stderr]. Since tail always writes the followed file content to its own stdout, the stderr file content was never captured, so stderr logs were never streamed, stored or displayed. In addition, Host.Terminal.Server only handled {:stdout, ...} messages, silently dropping any {:stderr, ...} data.

Both log terminals now capture :stdout (the log type is carried by the terminal metadata) and the terminal server forwards :stderr messages the same way as :stdout for terminals that do capture that stream.

Risk assessment:
- Impact: stderr logs become visible again in the Logs page and in the retained log storage. No behavior change for stdout streaming.
- Blast radius: Sentinel.Logs.Server terminal creation and Host.Terminal.Server message handling. Web terminals (tty) and the monitor/deploy paths are untouched.
- Regression risk: low. The stderr path was delivering nothing before, so the worst case is additional (correct) log volume in the UI and in the retention tables.
- Rollback: revert this commit, no data or config migration involved.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>