### PR TITLE
Make the engine worker resilient to restarts while monitors are running

### DIFF
--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -284,7 +284,9 @@ defmodule Deployer.Engine.Worker do
 
     state =
       if sname == current_deployment.sname do
-        Process.cancel_timer(current_deployment.timer_ref)
+        # NOTE: The rollback timer may not be armed, e.g. when the monitor
+        #       reports running right after an engine worker restart
+        if current_deployment.timer_ref, do: Process.cancel_timer(current_deployment.timer_ref)
 
         Foundation.Notifications.notify("deployment_complete", %{
           node: node(),
@@ -426,18 +428,31 @@ defmodule Deployer.Engine.Worker do
     current_version = Status.current_version(sname)
 
     if sname != nil and current_version != nil do
-      {:ok, _} =
-        Monitor.start_service(%Monitor.Service{
-          name: name,
-          sname: sname,
-          language: language,
-          ports: ports,
-          env: env
-        })
+      start_monitor_service!(%Monitor.Service{
+        name: name,
+        sname: sname,
+        language: language,
+        ports: ports,
+        env: env
+      })
 
       set_timeout_to_rollback(state, sname, ports)
     else
       state
+    end
+  end
+
+  # NOTE: The monitor may already be running when the engine worker is
+  #       restarted by its supervisor, since monitors live in a separate
+  #       supervision tree.
+  defp start_monitor_service!(%Monitor.Service{} = service) do
+    case Monitor.start_service(service) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        Logger.warning("Monitor for sname: #{service.sname} is already running")
+        :ok
     end
   end
 
@@ -576,14 +591,13 @@ defmodule Deployer.Engine.Worker do
 
       Status.set_current_version_map(new_sname, release, deployment: :full_deployment)
 
-      {:ok, _} =
-        Monitor.start_service(%Monitor.Service{
-          name: name,
-          sname: new_sname,
-          language: language,
-          ports: available_ports,
-          env: env
-        })
+      start_monitor_service!(%Monitor.Service{
+        name: name,
+        sname: new_sname,
+        language: language,
+        ports: available_ports,
+        env: env
+      })
     end)
 
     state

--- a/apps/deployer/lib/deployer/monitor.ex
+++ b/apps/deployer/lib/deployer/monitor.ex
@@ -47,7 +47,7 @@ defmodule Deployer.Monitor do
   """
   @impl true
   @spec start_service(service :: Monitor.Service.t()) ::
-          {:ok, pid} | {:error, pid(), :already_started}
+          {:ok, pid()} | {:error, {:already_started, pid()} | any()}
   def start_service(%Monitor.Service{} = service) do
     default().start_service(service)
   end

--- a/apps/deployer/lib/deployer/monitor/adapter.ex
+++ b/apps/deployer/lib/deployer/monitor/adapter.ex
@@ -7,7 +7,8 @@ defmodule Deployer.Monitor.Adapter do
 
   @type bin_path :: :new | :current
 
-  @callback start_service(Monitor.Service.t()) :: {:ok, pid} | {:error, pid(), :already_started}
+  @callback start_service(Monitor.Service.t()) ::
+              {:ok, pid()} | {:error, {:already_started, pid()} | any()}
   @callback stop_service(String.t() | nil, String.t() | nil) :: :ok
   @callback restart(String.t()) :: :ok | {:error, :application_is_not_running}
   @callback state(String.t()) :: Monitor.t()

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -137,6 +137,100 @@ defmodule Deployer.EngineTest do
     end
   end
 
+  describe "Engine worker restart resilience" do
+    @tag :capture_log
+    test "Initialization tolerates an already running monitor service" do
+      # Monitors live in a separate supervision tree, so when the engine
+      # worker is restarted by its supervisor the monitor for the installed
+      # application may still be running
+      name = "myelixir"
+      language = "elixir"
+
+      ref = make_ref()
+      pid = self()
+      sname = Catalog.create_sname("myelixir")
+      FixtureFiles.create_bin_files(sname)
+      version = "1.2.3"
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [sname] end)
+      |> stub(:current_version, fn _sname -> version end)
+      |> expect(:history_version_list, fn _name, _options ->
+        [%Catalog.Version{version: version}]
+      end)
+
+      Deployer.MonitorMock
+      |> expect(:start_service, 1, fn %{sname: ^sname} ->
+        send(pid, {:handle_ref_event, ref})
+        {:error, {:already_started, self()}}
+      end)
+
+      Deployer.ReleaseMock
+      |> stub(:download_version_map, fn _app_name ->
+        %{version: version, hash: "local", pre_commands: []}
+      end)
+
+      with_mock System, [:passthrough],
+        cmd: fn "tar", ["-x", "-f", _source_path, "-C", _dest_path] -> {"", 0} end do
+        assert {:ok, worker_pid} =
+                 Engine.Worker.start_link(%Engine.Worker{
+                   deploy_rollback_timeout_ms: 1_000,
+                   deploy_schedule_interval_ms: 100,
+                   name: name,
+                   language: language
+                 })
+
+        assert_receive {:handle_ref_event, ^ref}, 1_000
+
+        # Let the engine run a few schedule cycles after initialization
+        :timer.sleep(300)
+
+        assert Process.alive?(worker_pid)
+
+        state = :sys.get_state(String.to_atom(name))
+        assert %Deployer.Engine.Deployment{sname: ^sname, state: :active} = state.deployments[1]
+      end
+    end
+
+    @tag :capture_log
+    test "Application running notification before the rollback timer is armed" do
+      # A monitor that survived an engine worker restart can report the
+      # application running before the engine arms any rollback timer
+      name = "myelixir"
+      language = "elixir"
+
+      sname = Catalog.create_sname("myelixir")
+      FixtureFiles.create_bin_files(sname)
+      version = "1.2.3"
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [sname] end)
+      |> stub(:current_version, fn _sname -> version end)
+      |> expect(:history_version_list, fn _name, _options ->
+        [%Catalog.Version{version: version}]
+      end)
+
+      with_mock System, [:passthrough],
+        cmd: fn "tar", ["-x", "-f", _source_path, "-C", _dest_path] -> {"", 0} end do
+        assert {:ok, worker_pid} =
+                 Engine.Worker.start_link(%Engine.Worker{
+                   deploy_rollback_timeout_ms: 60_000,
+                   deploy_schedule_interval_ms: 60_000,
+                   name: name,
+                   language: language
+                 })
+
+        # No schedule cycle has run yet, so no rollback timer is armed
+        Engine.notify_application_running(sname)
+
+        state = :sys.get_state(String.to_atom(name))
+
+        assert Process.alive?(worker_pid)
+        assert state.current == 1
+      end
+    end
+  end
+
   describe "Checking deployment" do
     @tag :capture_log
     test "Check for new version - full deployment - no pre-commands" do


### PR DESCRIPTION
Monitors live in a separate supervision tree, so when the engine worker is restarted by its supervisor, the monitors of installed applications keep running. Two paths crashed in that scenario:

- initialize_version and full_deployment matched Monitor.start_service against {:ok, _}, so {:error, {:already_started, pid}} raised a MatchError and crash-looped the engine worker, potentially exceeding the supervisor restart intensity.
- The {:application_running, sname} handler called Process.cancel_timer with a nil timer_ref when the monitor reported the application running before the restarted engine armed a rollback timer, raising an ArgumentError.

Monitor.start_service now tolerates {:error, {:already_started, pid}} and the rollback timer is only canceled when armed. The start_service specs were also corrected: they declared {:error, pid(), :already_started} while the implementation returns DynamicSupervisor.start_child shapes, which is what hid this bug from Dialyzer.

Risk assessment:
- Impact: an engine worker restart no longer escalates into a crash loop when the monitored applications are still running; deployments resume from the recovered state.
- Blast radius: Deployer.Engine.Worker (initialize_version, full_deployment and the application_running handler) plus the Monitor.start_service typespec. The happy paths return the same values as before.
- Regression risk: low. Treating already_started as success is correct here because the monitor process is registered per sname and an existing one is already supervising the same service. Other error tuples from start_service still crash loudly, unchanged.
- Rollback: revert this commit.


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>