### PR TITLE
docs(changelog): add missing 0.9.5 entries and changelog maintenance guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,10 +263,28 @@ Hot upgrade testing has its own workflow: `.github/workflows/hot_upgrade.yaml`.
 
 ---
 
+## Changelog Maintenance
+
+`CHANGELOG.md` is maintained manually.
+After a PR is merged, add an entry for it to the top (unreleased) version section, e.g. `## 0.9.5 ()`.
+
+Rules:
+
+- Place the entry under the matching category: `### Bug fixes`, `### Enhancements`, or `### Backwards incompatible changes`
+- Entry format (one line, PR title as the description):
+  `* [`PULL-NNN`](https://github.com/thiagoesteves/deployex/pull/NNN) <PR title>`
+- For issues, use `ISSUE-NNN` with the `/issues/NNN` URL instead
+- Keep entries sorted by ascending PR number within each category
+- Replace the `* None` placeholder when adding the first entry to a category; keep `* None` in empty categories
+- Backwards incompatible changes also describe the required operator steps (installer commands, hotupgrade caveats), see the `0.9.2` and `0.9.0` sections for examples
+- The release date and rocket emoji are added to the heading only when the version ships: `## 0.9.4 🚀 (2026-06-22)`, unreleased versions keep an empty date: `## 0.9.5 ()`
+
+---
+
 ## Guides and Documentation
 
 - `guides/docs/` - deployment guides per cloud/language (AWS-Elixir, GCP-Elixir, Local-Erlang, etc.)
 - `guides/docs/hot-upgrades/` - hot upgrade documentation
 - `guides/docs/yaml/` - YAML configuration reference
-- `CHANGELOG.md` - version history (do not edit manually)
+- `CHANGELOG.md` - version history, updated manually per merged PR (see "Changelog Maintenance")
 - Docs are generated with `mix docs` and published into `apps/deployex_web/priv/static/docs/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@
  * None
 
 ### Bug fixes
- * None
+ * [`PULL-239`](https://github.com/thiagoesteves/deployex/pull/239) Fix engine state corruption on rollback timeout during initial boot
+ * [`PULL-240`](https://github.com/thiagoesteves/deployex/pull/240) Fix read-after-write race in the web cache
+ * [`PULL-241`](https://github.com/thiagoesteves/deployex/pull/241) Fix stderr log streaming from monitored applications
+ * [`PULL-242`](https://github.com/thiagoesteves/deployex/pull/242) Make the engine worker resilient to restarts while monitors are running
 
 ### Enhancements
  * [`PULL-235`](https://github.com/thiagoesteves/deployex/pull/235) Update library dependencies
+ * [`PULL-237`](https://github.com/thiagoesteves/deployex/pull/237) Add CloudWatch log group retention policy (terraform)
  * [`PULL-238`](https://github.com/thiagoesteves/deployex/pull/238) Updated observer web and packages
  * [`PULL-243`](https://github.com/thiagoesteves/deployex/pull/243) Adding agents.md file for tracking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.5 ()
 
-### Backwards incompatible changes
+### Backwards incompatible changes from 0.9.4
  * None
 
 ### Bug fixes


### PR DESCRIPTION
## What changed and why

- Added the missing `0.9.5` changelog entries for the recently merged PRs:
  - Bug fixes: #239, #240, #241, #242
  - Enhancements: #237 (CloudWatch log group retention policy)
- Documented the changelog maintenance rules in `AGENTS.md` (new "Changelog Maintenance" section: entry format, categories, ordering, placeholder handling, release-date convention) so agents and contributors know how to keep it updated per merged PR.
- Removed the outdated `AGENTS.md` note claiming the changelog must not be edited manually.

## Risk assessment

- **Impact:** documentation only, no runtime behavior changes.
- **Blast radius:** `CHANGELOG.md` and `AGENTS.md`.
- **Regression risk:** none, docs-only diff.
- **Rollback:** revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)