### PR TITLE
Update actions/checkout from v5 to v7 in all workflows

### DIFF
--- a/.github/workflows/hot_upgrade.yaml
+++ b/.github/workflows/hot_upgrade.yaml
@@ -30,7 +30,7 @@ jobs:
   generate_release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install libcap-dev [recommended by erlexec]
         run: sudo apt-get install libcap-dev -y
@@ -65,7 +65,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install libcap-dev [recommended by erlexec]
         run: sudo apt-get install libcap-dev -y
@@ -110,7 +110,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Calculate checksum
         id: checksum
@@ -131,7 +131,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/testing-release.yaml
+++ b/.github/workflows/testing-release.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install libcap-dev [recommended by erlexec]
         run: sudo apt-get install libcap-dev -y
@@ -65,7 +65,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install libcap-dev [recommended by erlexec]
         run: sudo apt-get install libcap-dev -y
@@ -110,7 +110,7 @@ jobs:
     outputs:
       sha: ${{ steps.checksum.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Bump the checkout action across pr-ci, releases, testing-release and hot_upgrade workflows (11 call sites). No workflow here is affected by the v6/v7 breaking changes: v6 moved persisted credentials to RUNNER_TEMP (only impacts Docker container actions using git credentials, none used here) and v7 blocks fork PR checkout for pull_request_target/workflow_run triggers (these workflows use pull_request and tag push only).

Risk assessment:
- Impact: CI-only dependency bump, no application code changes.
- Blast radius: the four GitHub Actions workflows.
- Regression risk: low. GitHub-hosted ubuntu-24.04 runners satisfy the v6+ minimum runner version, and no workflow persists git credentials or uses the affected triggers. The PR CI run on this branch exercises the new version directly.
- Rollback: revert this commit.