### PR TITLE
chore(ci): parametrize release workflows with an OTP matrix

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -8,17 +8,19 @@ on:
 env:
   MIX_ENV: prod
   SHELL: /usr/bin/bash
-  UBUNTU_2404_OTP_27_NAME: deployex-ubuntu-24.04-otp-27.tar.gz
-  UBUNTU_2404_OTP_28_NAME: deployex-ubuntu-24.04-otp-28.tar.gz
 
 jobs:
-  buildUbuntu2404Otp27:
+  build:
     if: github.event.base_ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: [27, 28]
+    env:
+      ARTIFACT_NAME: deployex-ubuntu-24.04-otp-${{ matrix.otp }}.tar.gz
     steps:
       - uses: actions/checkout@v7
 
@@ -26,7 +28,7 @@ jobs:
         run: sudo apt-get install libcap-dev -y
 
       - name: Copy .tool-versions
-        run: cp devops/releases/otp-27/.tool-versions .
+        run: cp devops/releases/otp-${{ matrix.otp }}/.tool-versions .
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
@@ -44,92 +46,43 @@ jobs:
         run: mix release
 
       - name: Rename Artifact
-        run: mv _build/prod/*.tar.gz ${{ env.UBUNTU_2404_OTP_27_NAME }}
+        run: mv _build/prod/*.tar.gz ${{ env.ARTIFACT_NAME }}
 
       - name: Calculate checksum
-        id: checksum
-        run: |
-          SHA=$(sha256sum ${{ env.UBUNTU_2404_OTP_27_NAME }} | awk '{print $1}')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
+        run: sha256sum ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.UBUNTU_2404_OTP_27_NAME }}
-          path: ${{ env.UBUNTU_2404_OTP_27_NAME }}
-
-  buildUbuntu2404Otp28:
-    if: github.event.base_ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install libcap-dev [recommended by erlexec]
-        run: sudo apt-get install libcap-dev -y
-
-      - name: Copy .tool-versions
-        run: cp devops/releases/otp-28/.tool-versions .
-
-      - name: Setup BEAM
-        uses: erlef/setup-beam@v1
-        with:
-          version-file: .tool-versions
-          version-type: strict
-
-      - name: Install Elixir dependencies
-        run: mix do deps.get + compile --warnings-as-errors
-
-      - name: Assets Deploy
-        run: mix assets.deploy
-
-      - name: Compile and Generate a Release
-        run: mix release
-
-      - name: Rename Artifact
-        run: mv _build/prod/*.tar.gz ${{ env.UBUNTU_2404_OTP_28_NAME }}
-
-      - name: Calculate checksum
-        id: checksum
-        run: |
-          SHA=$(sha256sum ${{ env.UBUNTU_2404_OTP_28_NAME }} | awk '{print $1}')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.UBUNTU_2404_OTP_28_NAME }}
-          path: ${{ env.UBUNTU_2404_OTP_28_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            ${{ env.ARTIFACT_NAME }}
+            ${{ env.ARTIFACT_NAME }}.sha256
 
   copyInstaller:
     if: github.event.base_ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
 
-      - name: Calculate checksum
-        id: checksum
+      - name: Prepare installer and checksum
         run: |
-          SHA=$(sha256sum devops/installer/deployex.sh | awk '{print $1}')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          cp devops/installer/deployex.sh .
+          sha256sum deployex.sh > deployex.sh.sha256
 
       - uses: actions/upload-artifact@v4
         with:
           name: deployex.sh
-          path: devops/installer/deployex.sh
+          path: |
+            deployex.sh
+            deployex.sh.sha256
 
   copyChangelog:
     if: github.event.base_ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
 
@@ -141,42 +94,21 @@ jobs:
   createRelease:
     if: github.event.base_ref == 'refs/heads/main'
     name: Publish artifacts to the release
-    needs:
-      [buildUbuntu2404Otp27, buildUbuntu2404Otp28, copyInstaller, copyChangelog]
+    needs: [build, copyInstaller, copyChangelog]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
-      - name: Download ${{ env.UBUNTU_2404_OTP_27_NAME }} artefact
+      - name: Download all artefacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.UBUNTU_2404_OTP_27_NAME }}
-
-      - name: Download ${{ env.UBUNTU_2404_OTP_28_NAME }} artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.UBUNTU_2404_OTP_28_NAME }}
-
-      - name: Download installer artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: deployex.sh
-
-      - name: Download chnagelog artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: CHANGELOG.md
+          merge-multiple: true
 
       - name: Create checksums file
-        run: |
-          cat << EOF > checksum.txt
-          ${{ needs.buildUbuntu2404Otp27.outputs.sha }}  ${{ env.UBUNTU_2404_OTP_27_NAME }}
-          ${{ needs.buildUbuntu2404Otp28.outputs.sha }}  ${{ env.UBUNTU_2404_OTP_28_NAME }}
-          ${{ needs.copyInstaller.outputs.sha }}  deployex.sh
-          EOF
+        run: cat *.sha256 > checksum.txt
 
       - name: Release the files
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "${{ env.UBUNTU_2404_OTP_27_NAME }}, ${{ env.UBUNTU_2404_OTP_28_NAME }}, deployex.sh, checksum.txt"
+          artifacts: "deployex-ubuntu-24.04-otp-*.tar.gz, deployex.sh, checksum.txt"
           bodyFile: "CHANGELOG.md"

--- a/.github/workflows/testing-release.yaml
+++ b/.github/workflows/testing-release.yaml
@@ -8,17 +8,19 @@ on:
 env:
   MIX_ENV: prod
   SHELL: /usr/bin/bash
-  UBUNTU_2404_OTP_27_NAME: deployex-ubuntu-24.04-otp-27.tar.gz
-  UBUNTU_2404_OTP_28_NAME: deployex-ubuntu-24.04-otp-28.tar.gz
 
 jobs:
-  buildUbuntu2404Otp27:
+  build:
     if: github.event.base_ref != 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: [27, 28]
+    env:
+      ARTIFACT_NAME: deployex-ubuntu-24.04-otp-${{ matrix.otp }}.tar.gz
     steps:
       - uses: actions/checkout@v7
 
@@ -26,7 +28,7 @@ jobs:
         run: sudo apt-get install libcap-dev -y
 
       - name: Copy .tool-versions
-        run: cp devops/releases/otp-27/.tool-versions .
+        run: cp devops/releases/otp-${{ matrix.otp }}/.tool-versions .
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
@@ -44,166 +46,60 @@ jobs:
         run: mix release
 
       - name: Rename Artifact
-        run: mv _build/prod/*.tar.gz ${{ env.UBUNTU_2404_OTP_27_NAME }}
+        run: mv _build/prod/*.tar.gz ${{ env.ARTIFACT_NAME }}
+
+      - name: Calculate checksum
+        run: sha256sum ${{ env.ARTIFACT_NAME }} > ${{ env.ARTIFACT_NAME }}.sha256
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.UBUNTU_2404_OTP_27_NAME }}
-          path: ${{ env.UBUNTU_2404_OTP_27_NAME }}
-
-      - name: Calculate checksum
-        id: checksum
-        run: |
-          SHA=$(sha256sum ${{ env.UBUNTU_2404_OTP_27_NAME }} | awk '{print $1}')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-
-  buildUbuntu2404Otp28:
-    if: github.event.base_ref != 'refs/heads/main'
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install libcap-dev [recommended by erlexec]
-        run: sudo apt-get install libcap-dev -y
-
-      - name: Copy .tool-versions
-        run: cp devops/releases/otp-28/.tool-versions .
-
-      - name: Setup BEAM
-        uses: erlef/setup-beam@v1
-        with:
-          version-file: .tool-versions
-          version-type: strict
-
-      - name: Install Elixir dependencies
-        run: mix do deps.get + compile --warnings-as-errors
-
-      - name: Assets Deploy
-        run: mix assets.deploy
-
-      - name: Compile and Generate a Release
-        run: mix release
-
-      - name: Rename Artifact
-        run: mv _build/prod/*.tar.gz ${{ env.UBUNTU_2404_OTP_28_NAME }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.UBUNTU_2404_OTP_28_NAME }}
-          path: ${{ env.UBUNTU_2404_OTP_28_NAME }}
-
-      - name: Calculate checksum
-        id: checksum
-        run: |
-          SHA=$(sha256sum ${{ env.UBUNTU_2404_OTP_28_NAME }} | awk '{print $1}')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            ${{ env.ARTIFACT_NAME }}
+            ${{ env.ARTIFACT_NAME }}.sha256
 
   copyInstaller:
     if: github.event.base_ref != 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    outputs:
-      sha: ${{ steps.checksum.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Prepare installer and checksum
+        run: |
+          cp devops/installer/deployex.sh .
+          sha256sum deployex.sh > deployex.sh.sha256
 
       - uses: actions/upload-artifact@v4
         with:
           name: deployex.sh
-          path: devops/installer/deployex.sh
-
-      - name: Calculate checksum
-        id: checksum
-        run: |
-          SHA=$(sha256sum devops/installer/deployex.sh | awk '{print $1}')
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-
-  checksum:
-    if: github.event.base_ref != 'refs/heads/main'
-    name: Calculate and save checksum file
-    needs: [buildUbuntu2404Otp27, buildUbuntu2404Otp28, copyInstaller]
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Create checksums file
-        run: |
-          cat << EOF > checksum.txt
-          ${{ needs.buildUbuntu2404Otp27.outputs.sha }}  ${{ env.UBUNTU_2404_OTP_27_NAME }}
-          ${{ needs.buildUbuntu2404Otp28.outputs.sha }}  ${{ env.UBUNTU_2404_OTP_28_NAME }}
-          ${{ needs.copyInstaller.outputs.sha }}  deployex.sh
-          EOF
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: checksum.txt
-          path: checksum.txt
+          path: |
+            deployex.sh
+            deployex.sh.sha256
 
   upload_aws:
     if: github.event.base_ref != 'refs/heads/main'
     name: Upload files to AWS environment
-    needs: checksum
+    needs: [build, copyInstaller]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
-      - name: Download ${{ env.UBUNTU_2404_OTP_27_NAME }} artefact
+      - name: Download all artefacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.UBUNTU_2404_OTP_27_NAME }}
+          merge-multiple: true
 
-      - name: Upload ${{ env.UBUNTU_2404_OTP_27_NAME }} artefact
-        uses: prewk/s3-cp-action@v2
-        with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: "sa-east-1"
-          source: ${{ env.UBUNTU_2404_OTP_27_NAME }}
-          dest: "s3://${{ secrets.CLOUD_TEST_STORAGE}}"
+      - name: Create checksums file
+        run: cat *.sha256 > checksum.txt
 
-      - name: Download ${{ env.UBUNTU_2404_OTP_28_NAME }} artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ env.UBUNTU_2404_OTP_28_NAME }}
-
-      - name: Upload ${{ env.UBUNTU_2404_OTP_28_NAME }} artefact
-        uses: prewk/s3-cp-action@v2
-        with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: "sa-east-1"
-          source: ${{ env.UBUNTU_2404_OTP_28_NAME }}
-          dest: "s3://${{ secrets.CLOUD_TEST_STORAGE}}"
-
-      - name: Download installer artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: deployex.sh
-
-      - name: Upload installer artefact
-        uses: prewk/s3-cp-action@v2
-        with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: "sa-east-1"
-          source: deployex.sh
-          dest: "s3://${{ secrets.CLOUD_TEST_STORAGE}}"
-
-      - name: Download checksum artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: checksum.txt
-
-      - name: Upload checksum artefact
-        uses: prewk/s3-cp-action@v2
-        with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: "sa-east-1"
-          source: checksum.txt
-          dest: "s3://${{ secrets.CLOUD_TEST_STORAGE}}"
+      - name: Upload artefacts to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: sa-east-1
+        run: |
+          for file in deployex-ubuntu-24.04-otp-*.tar.gz deployex.sh checksum.txt; do
+            aws s3 cp "$file" "s3://${{ secrets.CLOUD_TEST_STORAGE }}"
+          done


### PR DESCRIPTION
## What changed and why

The `releases.yaml` and `testing-release.yaml` workflows duplicated the whole build job per OTP version (`buildUbuntu2404Otp27` / `buildUbuntu2404Otp28`), so every toolchain change had to be applied to four places. Both now use a single `build` job with:

```yaml
strategy:
  fail-fast: false
  matrix:
    otp: [27, 28]
```

All OTP-specific values derive from `matrix.otp` (`devops/releases/otp-${{ matrix.otp }}/.tool-versions`, artifact name). Supporting OTP 29 later is a one-line change per workflow.

Design notes:
- Matrix legs cannot expose per-leg job `outputs` (they overwrite each other), so checksums now travel as `<artifact>.sha256` files uploaded alongside each tarball; the aggregate `checksum.txt` is built with `cat *.sha256`. Content is the same as before (line order may differ).
- `testing-release`: the standalone `checksum` job is merged into `upload_aws`, and the per-file `prewk/s3-cp-action` steps became a single `aws s3 cp` loop - the same command that action runs internally, using the preinstalled AWS CLI (one less third-party action).
- `fail-fast: false` keeps the matrix legs independent, matching the old separate-jobs behavior.
- `checksum.txt` is no longer stored as a workflow artifact in testing-release (it is still uploaded to S3 as before).

## Risk assessment

- **Impact:** identical release artifacts, names and checksum content; OTP additions become a one-line matrix change.
- **Blast radius:** `releases.yaml` and `testing-release.yaml` only; PR CI and hot upgrade workflows untouched.
- **Regression risk:** medium - these workflows trigger only on tag pushes, so PR CI cannot exercise them. YAML syntax validated locally. Recommend pushing a non-main test tag (e.g. an `-rc` tag from a branch) to run `testing-release` end to end before the next real release.
- **Rollback:** revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)