### PR TITLE
docs(changelog): add 0.9.5 entries for #245 and #246

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
  * [`PULL-237`](https://github.com/thiagoesteves/deployex/pull/237) Add CloudWatch log group retention policy (terraform)
  * [`PULL-238`](https://github.com/thiagoesteves/deployex/pull/238) Updated observer web and packages
  * [`PULL-243`](https://github.com/thiagoesteves/deployex/pull/243) Adding agents.md file for tracking
+ * [`PULL-245`](https://github.com/thiagoesteves/deployex/pull/245) Update actions/checkout from v5 to v7 in all workflows
+ * [`PULL-246`](https://github.com/thiagoesteves/deployex/pull/246) Parametrize release workflows with an OTP matrix
 
 ## 0.9.4 🚀 (2026-06-22)
 


### PR DESCRIPTION
## What changed and why

Adds the missing `0.9.5` Enhancements entries for the two CI PRs merged today, following the changelog maintenance rules in `AGENTS.md`:

- #245 Update actions/checkout from v5 to v7 in all workflows
- #246 Parametrize release workflows with an OTP matrix

## Risk assessment

- **Impact:** documentation only.
- **Blast radius:** `CHANGELOG.md`.
- **Regression risk:** none.
- **Rollback:** revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)