### PR TITLE
chore(release): prepare 0.9.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,21 @@ Rules:
 
 ---
 
+## Release Preparation
+
+To prepare a release, open a single "prepare release" PR that applies all of the following:
+
+1. `mix/shared.exs`: set the final version, without the `-rcN` suffix (e.g. `"0.9.5-rc1"` -> `"0.9.5"`)
+2. `README.md`: in the version compatibility table, remove the `:soon:` marker from the released version row and make sure the OTP columns match the Erlang versions pinned in `devops/releases/otp-*/.tool-versions`
+3. `devops/installer/deployex-aws.yaml` and `devops/installer/deployex-gcp.yaml`: set `version:` to the released version
+4. `guides/docs/yaml/README.md`: set the `version:` field in the YAML example to the released version
+5. `CHANGELOG.md`: add the release date to the version heading in the format `## X.Y.Z 🚀 (YYYY-MM-DD)`
+6. Run `mix docs` to regenerate the published documentation (commits the updated `apps/deployex_web/priv/static/docs/docs.tar.gz`)
+
+After the PR is merged, pushing the version tag from main triggers `.github/workflows/releases.yaml` to build and publish the release artifacts.
+
+---
+
 ## Guides and Documentation
 
 - `guides/docs/` - deployment guides per cloud/language (AWS-Elixir, GCP-Elixir, Local-Erlang, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG (0.9.X)
 
-## 0.9.5 ()
+## 0.9.5 🚀 (2026-07-08)
 
 ### Backwards incompatible changes from 0.9.4
  * None

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
-| :soon: [**0.9.5**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.5) | **27.3.4.14**                                              | **28.5.0.3**                                               |
+| [**0.9.5**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.5) | **27.3.4.14**                                              | **28.5.0.3**                                               |
 | [**0.9.4**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.4) | **27.3.4.13**                                              | **28.5.0.2**                                               |
 | [**0.9.3**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.3) | **27.3.4.13**                                              | **28.5.0.2**                                               |
 | [**0.9.2**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.2) | **27.3.4.13**                                              | **28.5.0.2**                                               |

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.4"
+version: "0.9.5"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.4"
+version: "0.9.5"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.4"                                         # DeployEx version
+version: "0.9.5"                                         # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.5-rc1"
+  def version, do: "0.9.5"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
## What changed and why

Release preparation for **0.9.5**, following the checklist now documented in `AGENTS.md` ("Release Preparation"):

1. `mix/shared.exs`: `0.9.5-rc1` -> `0.9.5`
2. `README.md`: removed the `:soon:` marker from the 0.9.5 row; verified the OTP columns (27.3.4.14 / 28.5.0.3) match `devops/releases/otp-*/.tool-versions`
3. `devops/installer/deployex-aws.yaml` / `deployex-gcp.yaml`: `version: "0.9.5"`
4. `guides/docs/yaml/README.md`: YAML example bumped to `0.9.5` (step found in the 0.9.4 release commit, now added to the documented checklist)
5. `CHANGELOG.md`: heading set to `## 0.9.5 🚀 (2026-07-08)`
6. `mix docs` run to regenerate `apps/deployex_web/priv/static/docs/docs.tar.gz`

Also adds the "Release Preparation" section to `AGENTS.md` so the full checklist is documented for future releases.

After merge: push the `0.9.5` tag from main to trigger `releases.yaml`. Note this will be the first release using the matrix-based workflows from #246 - consider a quick `-rc` test tag first if you want to exercise them beforehand.

## Risk assessment

- **Impact:** version metadata and docs only, no application code changes.
- **Blast radius:** version pins, README table, installer defaults, changelog heading, generated docs tarball, AGENTS.md.
- **Regression risk:** low for the PR itself; the release build runs on tag push.
- **Rollback:** revert the commit before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)