### PR TITLE
chore: prepare release 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG (0.9.X)
 
-## 0.9.7 🚀 (2026-07-14)
+## 0.9.7 🚀 (2026-07-21)
 
 ### Backwards incompatible changes from 0.9.6
  * None - version `0.9.7` supports hot upgrade from `0.9.6`
@@ -9,7 +9,7 @@
  * None
 
 ### Enhancements
- * [`PULL-250`](https://github.com/thiagoesteves/deployex/pull/250) FUpdating ObserverWeb and adding new disclosure component
+ * [`PULL-250`](https://github.com/thiagoesteves/deployex/pull/250) Updating ObserverWeb and adding new disclosure component
 
 ## 0.9.6 🚀 (2026-07-14)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| [**0.9.7**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.7) | **27.3.4.14**                                              | **28.5.0.3**                                               |
 | [**0.9.6**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.6) | **27.3.4.14**                                              | **28.5.0.3**                                               |
 | [**0.9.5**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.5) | **27.3.4.14**                                              | **28.5.0.3**                                               |
 | [**0.9.4**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.4) | **27.3.4.13**                                              | **28.5.0.2**                                               |

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.6"
+version: "0.9.7"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.6"
+version: "0.9.7"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.6"                                         # DeployEx version
+version: "0.9.7"                                         # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 


### PR DESCRIPTION
## Summary
- Add the 0.9.7 row to the README OTP compatibility table
- Bump `devops/installer/deployex-{aws,gcp}.yaml` and `guides/docs/yaml/README.md` to version 0.9.7
- Set the CHANGELOG 0.9.7 release date to today and fix a typo in the PR-250 entry
- Regenerate `apps/deployex_web/priv/static/docs/docs.tar.gz` via `mix docs`

`mix/shared.exs` was already at `0.9.7` (no `-rc` suffix), so no change needed there.

Follows the "Release Preparation" checklist in `AGENTS.md`. After merge, pushing the `0.9.7` tag from main triggers `.github/workflows/releases.yaml`.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix docs` regenerated cleanly
- [ ] CI green on this PR

## Risk assessment
- **Impact:** documentation and installer config only, no runtime behavior changes.
- **Blast radius:** README.md, CHANGELOG.md, devops/installer/*.yaml, guides/docs/yaml/README.md, docs.tar.gz. No app code touched.
- **Regression risk:** none - docs/config-only diff.
- **Rollback:** plain commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)