### PR TITLE
feat(web): add copy button next to the application version

### DIFF
--- a/apps/deployex_web/lib/deployex_web/components/core_components.ex
+++ b/apps/deployex_web/lib/deployex_web/components/core_components.ex
@@ -553,11 +553,12 @@ defmodule DeployexWeb.CoreComponents do
 
   attr :id, :string, required: true
   attr :message, :string, required: true
+  attr :class, :any, default: "text-gray-500"
 
   def copy_to_clipboard(assigns) do
     ~H"""
     <button
-      class="text-gray-500"
+      class={@class}
       phx-click={JS.dispatch("phx:copy_to_clipboard", detail: %{text: @message, id: @id})}
     >
       <div class="flex gap-1 items-center object-center">

--- a/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
@@ -432,7 +432,14 @@ defmodule DeployexWeb.Components.ApplicationCard do
             <div class="w-2 h-2 bg-success rounded-full animate-pulse"></div>
             <span class="text-sm font-semibold text-success">Running</span>
           </div>
-          <span class="font-mono text-sm font-medium text-success">{@version}</span>
+          <div class="flex items-center gap-1">
+            <span class="font-mono text-sm font-medium text-success">{@version}</span>
+            <.copy_to_clipboard
+              id={"c2c-version-#{@sname}"}
+              message={@version}
+              class="text-success/70 hover:text-success transition-colors duration-200"
+            />
+          </div>
           <.restart_button sname={@sname} restart_path={@restart_path} />
         </div>
       <% @status == :pre_commands -> %>
@@ -449,7 +456,14 @@ defmodule DeployexWeb.Components.ApplicationCard do
             <div class="w-2 h-2 bg-warning rounded-full animate-pulse"></div>
             <span class="text-sm font-semibold text-warning">Starting</span>
           </div>
-          <span class="font-mono text-sm font-medium text-warning">{@version}</span>
+          <div class="flex items-center gap-1">
+            <span class="font-mono text-sm font-medium text-warning">{@version}</span>
+            <.copy_to_clipboard
+              id={"c2c-version-#{@sname}"}
+              message={@version}
+              class="text-warning/70 hover:text-warning transition-colors duration-200"
+            />
+          </div>
           <.restart_button sname={@sname} restart_path={@restart_path} />
         </div>
       <% true -> %>

--- a/apps/deployex_web/lib/deployex_web/live/components/deployex_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/deployex_card.ex
@@ -433,7 +433,14 @@ defmodule DeployexWeb.Components.DeployexCard do
         <div class="w-2 h-2 bg-success rounded-full animate-pulse"></div>
         <span class="text-sm font-semibold text-success">Running</span>
       </div>
-      <span class="font-mono text-sm font-medium text-success">{@version}</span>
+      <div class="flex items-center gap-1">
+        <span class="font-mono text-sm font-medium text-success">{@version}</span>
+        <.copy_to_clipboard
+          id={"c2c-version-#{@sname}"}
+          message={@version}
+          class="text-success/70 hover:text-success transition-colors duration-200"
+        />
+      </div>
       <div class="flex items-center gap-2">
         <.version_indicator latest_release={@latest_release} version={@version} />
         <.config_changes_button sname={@sname} pending_config_changes={@pending_config_changes} />


### PR DESCRIPTION
## What & why

The running version shown in the application card header could only be copied by selecting the text by hand.
This adds the existing copy-to-clipboard button right next to it, matching how the **Node** field already works.

- `copy_to_clipboard/1` now takes an optional `class` attr (default `text-gray-500`, so existing call sites are unchanged), letting the icon inherit the color of the header it sits in.
- **Application card:** copy button in the `:running` (success) and `:starting` (warning) headers, tinted to match the header and brightening on hover.
- **DeployEx card:** same treatment, so both cards on the page stay visually consistent.

It reuses the already-shipped `phx:copy_to_clipboard` dispatch, so the behaviour is identical to the Node copy button: clipboard write plus the checkmark confirmation that reverts after a moment. No JS changes were needed.

## Risk assessment

- **Impact:** operators can copy a monitored application version with one click instead of selecting the text manually. Purely additive, no existing behaviour changes.
- **Blast radius:** three files in `deployex_web`, all presentation only - `core_components.ex` (new optional attr), `application_card.ex` and `deployex_card.ex` (header markup). No changes to `deployer`, `foundation`, `host` or `sentinel`, and no LiveView state, event handlers or data flow touched.
- **Regression risk:** low. The new attr defaults to the previous hardcoded class, so the four existing `copy_to_clipboard` call sites render identically. No new JS surface.
- **Rollback:** plain commit revert, no data or config steps.

## Checks

- [x] `mix format --check-formatted` (only untracked/gitignored `config/dev.override.exs` is unformatted, pre-existing)
- [x] `mix credo --strict` - no issues
- [x] `mix test apps/deployex_web/test` - 6 doctests, 175 tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean
- [x] Diff small and focused, no debug output left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)
