### PR TITLE
fix(installer): write the needrestart exclusion even when needrestart is absent

### DIFF
--- a/devops/installer/deployex.sh
+++ b/devops/installer/deployex.sh
@@ -200,10 +200,14 @@ DEPLOYEX_SYSTEMD_FILE="
     #       unattended-upgrades restart the whole platform, taking down every other
     #       application with it. Opting out keeps the timing of that restart with the
     #       operator, who is responsible for restarting deployex after library upgrades.
-    if [ -d "$(dirname ${DEPLOYEX_NEEDRESTART_PATH})" ]; then
-        echo "# Excluding deployex from needrestart      #"
-        printf "%s\n" '$nrconf{override_rc}{qr(^deployex\.service$)} = 0;' > ${DEPLOYEX_NEEDRESTART_PATH}
-    fi
+    #
+    #       The drop-in is written whether or not needrestart is currently installed,
+    #       since it is frequently pulled in later as a dependency. needrestart globs
+    #       conf.d/*.conf when it runs, so an exclusion waiting there is honoured from
+    #       the first upgrade onwards.
+    echo "# Excluding deployex from needrestart      #"
+    mkdir -p "$(dirname ${DEPLOYEX_NEEDRESTART_PATH})"
+    printf "%s\n" '$nrconf{override_rc}{qr(^deployex\.service$)} = 0;' > ${DEPLOYEX_NEEDRESTART_PATH}
 
     echo "#    Deployex installed with success       #"
 }


### PR DESCRIPTION
Follow-up to #254.

## Problem

The needrestart exclusion added in #254 is written only when `/etc/needrestart/conf.d` already exists:

```bash
if [ -d "$(dirname ${DEPLOYEX_NEEDRESTART_PATH})" ]; then
    printf "%s\n" '$nrconf{override_rc}{qr(^deployex\.service$)} = 0;' > ${DEPLOYEX_NEEDRESTART_PATH}
fi
```

needrestart ships by default on Ubuntu Server 22.04 and later, so the guard passes on the hosts where #254 was diagnosed. A minimal Debian install usually does not have it, and there the drop-in was silently skipped.

That is the wrong failure mode for this particular fix. needrestart is frequently pulled in later as a dependency, and when it arrives the exclusion is not there, so the host is back to unattended-upgrades restarting the whole platform during the daily apt window. The protection goes missing precisely on the hosts that were never protected in the first place, with no signal that anything was skipped.

## Change

Create the directory and write the drop-in unconditionally. needrestart globs `conf.d/*.conf` at run time, so a file waiting there is honoured from the first upgrade onwards, whenever the package shows up.

```bash
mkdir -p "$(dirname ${DEPLOYEX_NEEDRESTART_PATH})"
printf "%s\n" '$nrconf{override_rc}{qr(^deployex\.service$)} = 0;' > ${DEPLOYEX_NEEDRESTART_PATH}
```

`remove_deployex` already deletes the file, so the uninstall path is unchanged.

## Risk assessment

**Low.** One directory and one file, both within the paths the installer already owns.

- On a host without needrestart this leaves an unowned `/etc/needrestart/conf.d`. dpkg tolerates unowned directories, and a later `apt install needrestart` adopts it rather than conflicting.
- Behaviour is unchanged on hosts where needrestart is already installed, which covers every Ubuntu deployment.
- No change to the systemd unit or to any other install step.

## Notes for Debian users

The restart mechanism itself is identical on Debian: needrestart is a Debian-native package, with the same `DPkg::Post-Invoke` hook, the same `conf.d` drop-in directory, the same `override_rc` semantics, and the same non-interactive auto-restart. `apt-daily-upgrade.timer` ships with `apt` on both distributions with the same schedule. So both the original problem and this fix transfer unchanged.

Separately, and out of scope here: releases are built only as `deployex-ubuntu-24.04-otp-*.tar.gz`, so there is no Debian artifact. Running the Ubuntu 24.04 build (glibc 2.39) on Debian 12 bookworm (glibc 2.36) is expected to fail on symbol versions. Debian 13 trixie is glibc 2.41 and should be compatible. Supporting bookworm would need either its own entry in the release matrix or a build on an older base.

## Checklist

- [x] Installer script passes `bash -n`
- [x] Uninstall path already removes the file this creates
- [x] Behaviour unchanged on hosts where needrestart is present
- [ ] Verified end to end with a full `--install` on a clean Debian host

🤖 Generated with [Claude Code](https://claude.com/claude-code)
