### PR TITLE
Prepare release 0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,31 @@
 # CHANGELOG (0.9.X)
 
-## 0.9.8 ()
+## 0.9.8 🚀 (2026-08-06)
 
 ### Backwards incompatible changes from 0.9.7
- * None
+
+#### Installer Actions
+ 1. It's not mandatory, but it's recommended to update `deployex.sh` so new installations pick up the hardened systemd service and the needrestart exclusion.
+ ```bash
+ rm deployex.sh
+ wget https://github.com/thiagoesteves/deployex/releases/download/0.9.8/deployex.sh
+ chmod a+x deployex.sh
+ ./deployex.sh --update
+ ```
+ 2. `--update` does not rewrite `/etc/systemd/system/deployex.service`, so an existing installation keeps its current unit and none of the service changes from [`PULL-254`](https://github.com/thiagoesteves/deployex/pull/254) take effect. Running `--install` recreates the unit, but it also removes `/var/lib/deployex` and the monitored application logs first. To keep the installation intact, apply the new `KillMode`, `TimeoutStopSec` and `OOMPolicy` settings to the existing unit by hand and reload systemd.
+ ```bash
+ systemctl daemon-reload
+ systemctl restart deployex
+ ```
 
 ### Bug fixes
- * None
+ * [`PULL-254`](https://github.com/thiagoesteves/deployex/pull/254) Stop left-over processes in the control group and unattended needrestart restarts
+ * [`PULL-256`](https://github.com/thiagoesteves/deployex/pull/256) Write the needrestart exclusion even when needrestart is absent
 
 ### Enhancements
- * None
+ * [`PULL-252`](https://github.com/thiagoesteves/deployex/pull/252) Update OTP to 27.3.4.15 and 28.5.0.4
+ * [`PULL-253`](https://github.com/thiagoesteves/deployex/pull/253) Update library dependencies
+ * [`PULL-255`](https://github.com/thiagoesteves/deployex/pull/255) Add copy button next to the application version
 
 ## 0.9.7 🚀 (2026-07-21)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
-| :soon: [**0.9.8**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.8) | **27.3.4.15**                                              | **28.5.0.4**                                               |
+| [**0.9.8**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.8) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.7**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.7) | **27.3.4.14**                                              | **28.5.0.3**                                               |
 | [**0.9.6**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.6) | **27.3.4.14**                                              | **28.5.0.3**                                               |
 | [**0.9.5**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.5) | **27.3.4.14**                                              | **28.5.0.3**                                               |

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.7"
+version: "0.9.8"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.7"
+version: "0.9.8"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.7"                                         # DeployEx version
+version: "0.9.8"                                         # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 


### PR DESCRIPTION
Release preparation for `0.9.8`, following the steps in [AGENTS.md](https://github.com/thiagoesteves/deployex/blob/main/AGENTS.md#release-preparation).

## Steps applied

| # | Step | Status |
| --- | --- | --- |
| 1 | `mix/shared.exs` final version, no `-rcN` suffix | Already `"0.9.8"`, set in #252 |
| 2 | `README.md` remove `:soon:`, OTP columns match `devops/releases/otp-*/.tool-versions` | Done, `27.3.4.15` and `28.5.0.4` verified against both files |
| 3 | `deployex-aws.yaml` and `deployex-gcp.yaml` `version:` | `0.9.7` -> `0.9.8` |
| 4 | `guides/docs/yaml/README.md` `version:` | `0.9.7` -> `0.9.8` |
| 5 | `CHANGELOG.md` release date on the heading | `## 0.9.8 🚀 (2026-08-06)` |
| 6 | `mix docs` to regenerate `docs.tar.gz` | Regenerated |

## Changelog contents

The five PRs merged since `0.9.7` had no changelog entries recorded when they were merged, so they are added here.

**Bug fixes**
- #254 Stop left-over processes in the control group and unattended needrestart restarts
- #256 Write the needrestart exclusion even when needrestart is absent

**Enhancements**
- #252 Update OTP to 27.3.4.15 and 28.5.0.4
- #253 Update library dependencies
- #255 Add copy button next to the application version

Two judgement calls worth reviewing:

**Entry wording.** The rule says to use the PR title verbatim, but #254, #255 and #256 carry `fix(...)`/`feat(...)` prefixes that no existing entry in the file has. The prefixes are stripped so the entries read consistently with the rest of the changelog.

**An Installer Actions section.** `0.9.5` also bumped OTP and still recorded `None`, so the OTP change alone is not treated as breaking and no hot upgrade caveat is claimed. The section is there for a different reason: `update_deployex` never writes `${DEPLOYEX_SYSTEMD_PATH}`, so `--update` leaves the existing unit in place and none of the service changes from #254 reach an existing installation. `--install` does recreate the unit, but `remove_deployex` first runs `rm -rf` on `/var/lib/deployex` and the monitored application log directory, so it cannot be recommended unqualified. The note follows the `0.9.2` precedent and points at a manual edit as the non-destructive path.

## Risk assessment

**Low.** Documentation, changelog and installer example configuration only.

- No application code, dependency or build configuration changes, so runtime behaviour is unchanged.
- `docs.tar.gz` is a regenerated build artifact. The 1.9KB size change is consistent with previous release commits.
- The diff touches the same six files as the `0.9.7` preparation commit (b690a7b), which is a useful shape check.
- The release itself is not triggered by this merge. Pushing the `0.9.8` tag from `main` afterwards is what runs `.github/workflows/releases.yaml`.

## Checklist

- [x] All six AGENTS.md release preparation steps applied or verified as already done
- [x] OTP versions in the README table checked against `devops/releases/otp-27/.tool-versions` and `otp-28/.tool-versions`
- [x] `mix docs` run successfully, `docs.tar.gz` updated
- [x] Changelog entries cover every PR merged since `0.9.7`
- [ ] Changelog wording reviewed by the maintainer
- [ ] `0.9.8` tag pushed from `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
