### PR TITLE
fix(deployer): keep runtime configuration during hot upgrades with anonymous functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG (0.9.X)
 
+## 0.9.9 ()
+
+### Backwards incompatible changes from 0.9.8
+ * None
+
+### Bug fixes
+ * [`PULL-258`](https://github.com/thiagoesteves/deployex/pull/258) Keep runtime configuration during hot upgrades with anonymous functions
+
+### Enhancements
+ * None
+
 ## 0.9.8 🚀 (2026-08-06)
 
 ### Backwards incompatible changes from 0.9.7

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -548,21 +548,11 @@ defmodule Deployer.HotUpgrade.Application do
     original_sys_config_file = "#{rel_vsn_dir}/original.sys.config"
     # Read the build time config from build.config
     {:ok, [sys_config]} = :file.consult(sys_config_path)
-    # In this step, it will run the runtime.exs and Config Providers for the current version
-    sys_config =
-      sys_config
-      |> Keyword.get(:elixir)
-      |> Keyword.get(:config_provider_init)
-      |> Map.get(:providers)
-      |> Enum.reduce(sys_config, fn {mod, arg}, cfg ->
-        Rpc.call(node, mod, :load, [cfg, arg], @rpc_timeout)
-      end)
 
-    {serializable_config, runtime_config} = split_runtime_only_config(sys_config)
-
-    log_deferred_config(runtime_config, to_version)
-
-    with :ok <- File.rename(sys_config_path, original_sys_config_file),
+    with {:ok, resolved_config} <- run_config_providers(node, sys_config),
+         {serializable_config, runtime_config} = split_runtime_only_config(resolved_config),
+         :ok <- log_deferred_config(runtime_config, to_version),
+         :ok <- File.rename(sys_config_path, original_sys_config_file),
          :ok <-
            File.write(
              sys_config_path,
@@ -700,6 +690,34 @@ defmodule Deployer.HotUpgrade.Application do
       status: :error,
       message: message
     })
+  end
+
+  # Run runtime.exs and the Config Providers for the version being installed. They execute over
+  # RPC inside the still running old version, so a provider that assumes a cold system fails
+  # here. Mirror Config.Provider.run_providers/2 and require a list back, otherwise the failure
+  # reason would be carried forward as if it were the configuration.
+  @spec run_config_providers(node(), keyword()) :: {:ok, keyword()} | {:error, any()}
+  defp run_config_providers(node, sys_config) do
+    sys_config
+    |> Keyword.get(:elixir)
+    |> Keyword.get(:config_provider_init)
+    |> Map.get(:providers)
+    |> Enum.reduce_while({:ok, sys_config}, fn {mod, arg}, {:ok, config} ->
+      case Rpc.call(node, mod, :load, [config, arg], @rpc_timeout) do
+        new_config when is_list(new_config) ->
+          {:cont, {:ok, new_config}}
+
+        reason ->
+          Logger.error("""
+          Config provider #{inspect(mod)} did not return a configuration on node #{node}, got: \
+          #{inspect(reason)}. Providers run inside the already running old version, so they must \
+          tolerate a started system: one that starts a process the application already owns fails \
+          here with {:already_started, pid} even though it works on a cold boot.\
+          """)
+
+          {:halt, {:error, {:config_provider_failed, mod, reason}}}
+      end
+    end)
   end
 
   # Split the resolved config into the part sys.config can carry and the part that has to be

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -19,6 +19,7 @@ defmodule Deployer.HotUpgrade.Application do
        c. Check Install release using release_handler:check_install_release
          i. Request via RPC to run  ConfigProvider and Runtime and populate sys.config (Only ELixir)
        d. Install the release using release_handler:install_release
+         i. Apply the config entries sys.config cannot carry (Only Elixir)
        e. Make the release permanent using release_handler:make_permanent
          i. Return original empty sys.config (Only ELixir)
 
@@ -34,6 +35,26 @@ defmodule Deployer.HotUpgrade.Application do
      provider. It's important to note that these actions occur within the current version,
      meaning the system is not immediately prepared to execute hot upgrades when configuration
      changes occur.
+
+     sys.config can only hold terms that `:file.consult/1` can read back. A value with no
+     textual term syntax - an anonymous function (for example
+     `customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]`
+     in an Ecto Repo), a pid, a port or a reference - is printed as `#Fun<...>` and makes the
+     whole file unparseable. OTP does not report that: `release_handler:change_appl_data/3`
+     falls back to an empty config and `change_application_data/2` then resets every
+     application to its compile time environment, so the upgrade reports success while the
+     runtime configuration is gone.
+
+     Note that `fun M:F/A` does parse, but only names exported functions. A closure such as the
+     one above is a compiler generated local lambda, so writing it that way yields a fun that
+     raises `undef` when called - a worse failure than losing the configuration.
+
+     Those entries are therefore kept out of the generated file, per `{app, key}` pair, and
+     applied over RPC with `:application.set_env/2` right after the release is installed. That
+     is the same primitive `Config.Provider` uses on a cold start through
+     `Application.put_all_env/2`, which has no serialization step and carries these values
+     without trouble. The generated file is then consulted back as a second guard, so anything
+     the split does not catch fails the upgrade instead of silently wiping the configuration.
 
   References:
 
@@ -61,6 +82,12 @@ defmodule Deployer.HotUpgrade.Application do
   alias Deployer.HotUpgrade.Execute
   alias Deployer.HotUpgrade.Jellyfish
   alias Foundation.Rpc
+
+  @typedoc """
+  Application environment entries that sys.config cannot carry, applied over RPC once the
+  release is installed. Same shape as sys.config itself: `[{app, [{key, value}]}]`.
+  """
+  @type runtime_config :: [{app :: atom(), env :: keyword()}]
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -153,9 +180,11 @@ defmodule Deployer.HotUpgrade.Application do
          :ok <- notify_progress(data.sname, "Checking release can be installed"),
          :ok <- check_install_release(data),
          :ok <- notify_progress(data.sname, "Updating sys.config file"),
-         :ok <- update_sys_config_from_installed_version(data),
+         {:ok, runtime_config} <- update_sys_config_from_installed_version(data),
          :ok <- notify_progress(data.sname, "Installing release"),
          :ok <- install_release(data),
+         :ok <- notify_progress(data.sname, "Applying the runtime configuration"),
+         :ok <- restore_runtime_config(data, runtime_config),
          :ok <- notify_progress(data.sname, "Returning original sys.config file"),
          :ok <- return_original_sys_config(data),
          :ok <- notify_make_permanent(data.make_permanent_async, data.sname, data.to_version),
@@ -169,6 +198,10 @@ defmodule Deployer.HotUpgrade.Application do
       :ok
     else
       error ->
+        # A failure between the sys.config rewrite and install_release leaves the generated
+        # file behind, and the next attempt reads it with :file.consult/1
+        _ = return_original_sys_config(data)
+
         notify_error(data.sname, error)
         error
     end
@@ -502,7 +535,8 @@ defmodule Deployer.HotUpgrade.Application do
     releases |> Enum.map(fn {_name, version, _modules, status} -> {status, version} end)
   end
 
-  @spec update_sys_config_from_installed_version(Execute.t()) :: :ok | {:error, any()}
+  @spec update_sys_config_from_installed_version(Execute.t()) ::
+          {:ok, runtime_config()} | {:error, any()}
   def update_sys_config_from_installed_version(%Execute{
         node: node,
         language: "elixir",
@@ -524,21 +558,68 @@ defmodule Deployer.HotUpgrade.Application do
         Rpc.call(node, mod, :load, [cfg, arg], @rpc_timeout)
       end)
 
+    {serializable_config, runtime_config} = split_runtime_only_config(sys_config)
+
+    log_deferred_config(runtime_config, to_version)
+
     with :ok <- File.rename(sys_config_path, original_sys_config_file),
          :ok <-
-           File.write(sys_config_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [sys_config])) do
-      :ok
+           File.write(
+             sys_config_path,
+             :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [serializable_config])
+           ),
+         :ok <- validate_sys_config(sys_config_path) do
+      {:ok, runtime_config}
     else
       {:error, reason} ->
         Logger.error(
           "Error while updating sys.config to: #{to_version}, reason: #{inspect(reason)}"
         )
 
+        # Leave the release directory exactly as it was found. A generated sys.config left
+        # behind is read by the next attempt with :file.consult/1, which would fail to match
+        _ = File.rename(original_sys_config_file, sys_config_path)
+
         {:error, reason}
     end
   end
 
-  def update_sys_config_from_installed_version(_data), do: :ok
+  def update_sys_config_from_installed_version(_data), do: {:ok, []}
+
+  @doc """
+  Apply the configuration entries that sys.config cannot carry.
+
+  `release_handler:install_release/2` rebuilds the environment of every application from
+  sys.config, so the entries held back by `update_sys_config_from_installed_version/1` only
+  reach the running system once they are set again over RPC.
+  """
+  @spec restore_runtime_config(Execute.t(), runtime_config()) :: :ok | {:error, any()}
+  def restore_runtime_config(_data, []), do: :ok
+
+  def restore_runtime_config(%Execute{node: node}, runtime_config) do
+    # NOTE: :application.set_env/2 is the primitive Elixir itself uses to apply the resolved
+    #       runtime configuration on a cold start - Config.Provider.boot/1 calls
+    #       Application.put_all_env(config, persistent: true), a straight delegation to it,
+    #       whenever the release does not reboot after config. The whole configuration goes
+    #       in a single call, in sys.config shape, so these entries land exactly as they
+    #       would have on a normal boot.
+    case Rpc.call(
+           node,
+           :application,
+           :set_env,
+           [runtime_config, [persistent: true]],
+           @rpc_timeout
+         ) do
+      :ok ->
+        Logger.info("Applied runtime config for apps: #{inspect(Keyword.keys(runtime_config))}")
+        :ok
+
+      reason ->
+        Logger.error("Error while applying runtime config, reason: #{inspect(reason)}")
+
+        {:error, reason}
+    end
+  end
 
   @spec return_original_sys_config(Execute.t()) :: :ok | {:error, any()}
   def return_original_sys_config(%Execute{
@@ -619,6 +700,68 @@ defmodule Deployer.HotUpgrade.Application do
       status: :error,
       message: message
     })
+  end
+
+  # Split the resolved config into the part sys.config can carry and the part that has to be
+  # applied over RPC. The split is per {app, key} pair, never inside a value: a half written
+  # entry is more dangerous than a missing one, since a Repo that keeps its url but loses its
+  # ssl_opts would connect in plaintext rather than fail.
+  @spec split_runtime_only_config(keyword()) :: {keyword(), runtime_config()}
+  defp split_runtime_only_config(sys_config) do
+    Enum.map_reduce(sys_config, [], fn
+      {app, env}, acc when is_list(env) ->
+        case Enum.split_with(env, fn
+               {_key, value} -> sys_config_term?(value)
+               _entry -> true
+             end) do
+          {keep, []} -> {{app, keep}, acc}
+          {keep, defer} -> {{app, keep}, acc ++ [{app, defer}]}
+        end
+
+      entry, acc ->
+        {entry, acc}
+    end)
+  end
+
+  @spec log_deferred_config(runtime_config(), charlist() | binary()) :: :ok
+  defp log_deferred_config([], _to_version), do: :ok
+
+  defp log_deferred_config(runtime_config, to_version) do
+    keys = for {app, env} <- runtime_config, {key, _value} <- env, do: {app, key}
+
+    Logger.warning("""
+    Hot upgrade to #{to_version}: #{inspect(keys)} hold values with no textual term syntax \
+    (anonymous functions, pids, ports or references), so they cannot be written to sys.config \
+    and are applied over RPC once the release is installed. They are absent from the \
+    application environment while install_release/2 runs.\
+    """)
+  end
+
+  # A term survives the :io_lib.format/2 + :file.consult/1 round trip only if it has no
+  # function, pid, port or reference anywhere in it - those have no textual term syntax.
+  @spec sys_config_term?(any()) :: boolean()
+  defp sys_config_term?(value)
+       when is_function(value) or is_pid(value) or is_port(value) or is_reference(value),
+       do: false
+
+  defp sys_config_term?([head | tail]), do: sys_config_term?(head) and sys_config_term?(tail)
+
+  defp sys_config_term?(value) when is_tuple(value),
+    do: value |> Tuple.to_list() |> sys_config_term?()
+
+  defp sys_config_term?(value) when is_map(value),
+    do: value |> Map.to_list() |> sys_config_term?()
+
+  defp sys_config_term?(_value), do: true
+
+  # Read the file back the same way release_handler does, so a config that OTP would
+  # silently discard fails the upgrade here instead of booting with a wiped environment.
+  @spec validate_sys_config(binary()) :: :ok | {:error, any()}
+  defp validate_sys_config(sys_config_path) do
+    case :file.consult(sys_config_path) do
+      {:ok, [_config]} -> :ok
+      reason -> {:error, {:unparseable_sys_config, reason}}
+    end
   end
 
   defp check_jellyfish_files(files, from_version, to_version) do

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1051,6 +1051,52 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
              })
   end
 
+  @tag :capture_log
+  test "update_sys_config_from_installed_version/1 Elixir fails when a config provider crashes",
+       %{
+         node: node,
+         current_path: current_path,
+         to_version: to_version
+       } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+    original_sys_config = File.read!(sys_config_path)
+
+    # Providers run over RPC inside the still running old version. One that starts a process
+    # the application already owns works on a cold boot and fails here
+    badrpc =
+      {:badrpc,
+       {:EXIT,
+        {{:badmatch, {:error, {:already_started, self()}}},
+         [{Testapp.SecretsProvider, :load, 2, [file: ~c"lib/secrets.ex", line: 54]}]}}}
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      badrpc
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:config_provider_failed, _mod, ^badrpc}} =
+                 UpgradeApp.update_sys_config_from_installed_version(%Execute{
+                   node: node,
+                   language: "elixir",
+                   current_path: current_path,
+                   to_version: to_version
+                 })
+      end)
+
+    assert log =~ "did not return a configuration"
+    assert log =~ "already_started"
+
+    # The failure must not be carried forward as if it were the configuration
+    assert File.read!(sys_config_path) == original_sys_config
+    refute File.exists?("#{current_releases_version_path}/original.sys.config")
+  end
+
   test "restore_runtime_config/2 makes no rpc call when there is nothing to apply", %{node: node} do
     Foundation.RpcMock
     |> stub(:call, fn _node, _module, _function, _args, _timeout ->

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -867,17 +867,145 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
 
     Foundation.RpcMock
-    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-      :ok
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      cfg
     end)
 
-    assert :ok =
+    assert {:ok, []} =
              UpgradeApp.update_sys_config_from_installed_version(%Execute{
                node: node,
                language: "elixir",
                current_path: current_path,
                to_version: to_version
              })
+
+    assert {:ok, [_config]} =
+             :file.consult("#{current_releases_version_path}/sys.config")
+  end
+
+  @tag :capture_log
+  test "update_sys_config_from_installed_version/1 Elixir defers the entries sys.config cannot carry",
+       %{
+         node: node,
+         current_path: current_path,
+         to_version: to_version
+       } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+
+    # The exact value an Ecto Repo gets for a verify_peer TLS connection, and the reason
+    # a hot upgrade used to wipe the whole runtime configuration
+    repo_config = [
+      url: "postgres://user:pass@host:5432/db",
+      ssl_opts: [
+        verify: :verify_peer,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    ]
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      Keyword.update!(cfg, :testapp, fn env ->
+        Keyword.put(env, Testapp.Repo, repo_config)
+      end)
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, [{:testapp, [{Testapp.Repo, ^repo_config}]}]} =
+                 UpgradeApp.update_sys_config_from_installed_version(%Execute{
+                   node: node,
+                   language: "elixir",
+                   current_path: current_path,
+                   to_version: to_version
+                 })
+      end)
+
+    assert log =~ "[testapp: Testapp.Repo]"
+
+    # The file release_handler consults must stay parseable, otherwise OTP falls back to an
+    # empty config and resets EVERY application, not just the one holding the function
+    assert {:ok, [config]} = :file.consult(sys_config_path)
+    refute Keyword.has_key?(config[:testapp], Testapp.Repo)
+    assert config[:testapp][:generators] == [timestamp_type: :utc_datetime]
+    assert config[:logger][:level] == :info
+  end
+
+  @tag :capture_log
+  test "update_sys_config_from_installed_version/1 Elixir defers the whole key, never part of a value",
+       %{
+         node: node,
+         current_path: current_path,
+         to_version: to_version
+       } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      Keyword.update!(cfg, :testapp, fn env ->
+        Keyword.put(env, Testapp.Repo,
+          url: "postgres://host/db",
+          ssl_opts: [verify: fn -> :ok end]
+        )
+      end)
+    end)
+
+    assert {:ok, [{:testapp, [{Testapp.Repo, deferred}]}]} =
+             UpgradeApp.update_sys_config_from_installed_version(%Execute{
+               node: node,
+               language: "elixir",
+               current_path: current_path,
+               to_version: to_version
+             })
+
+    # A Repo that kept its url but lost its ssl_opts would connect in plaintext
+    assert deferred[:url] == "postgres://host/db"
+    assert {:ok, [config]} = :file.consult(sys_config_path)
+    refute Keyword.has_key?(config[:testapp], Testapp.Repo)
+  end
+
+  @tag :capture_log
+  test "update_sys_config_from_installed_version/1 Elixir fails when sys.config cannot be read back",
+       %{
+         node: node,
+         current_path: current_path,
+         to_version: to_version
+       } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+
+    sys_config_path = "#{current_releases_version_path}/sys.config"
+    original_sys_config = File.read!(sys_config_path)
+
+    # A bare function is not an {app, env} pair, so the per-key split cannot see it and
+    # only reading the generated file back catches it
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      cfg ++ [fn -> :boom end]
+    end)
+
+    assert capture_log(fn ->
+             assert {:error, {:unparseable_sys_config, _reason}} =
+                      UpgradeApp.update_sys_config_from_installed_version(%Execute{
+                        node: node,
+                        language: "elixir",
+                        current_path: current_path,
+                        to_version: to_version
+                      })
+           end) =~ "Error while updating sys.config to: #{to_version}"
+
+    assert File.read!(sys_config_path) == original_sys_config
   end
 
   @tag :skip
@@ -892,8 +1020,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
 
     Foundation.RpcMock
-    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-      :ok
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      cfg
     end)
 
     with_mock File, [:passthrough], rename: fn _source, _destination -> {:error, :any} end do
@@ -914,13 +1042,62 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     new_path: new_path,
     to_version: to_version
   } do
-    assert :ok =
+    assert {:ok, []} =
              UpgradeApp.update_sys_config_from_installed_version(%Execute{
                node: node,
                language: "erlang",
                new_path: new_path,
                to_version: to_version
              })
+  end
+
+  test "restore_runtime_config/2 makes no rpc call when there is nothing to apply", %{node: node} do
+    Foundation.RpcMock
+    |> stub(:call, fn _node, _module, _function, _args, _timeout ->
+      flunk("no rpc call expected")
+    end)
+
+    assert :ok = UpgradeApp.restore_runtime_config(%Execute{node: node}, [])
+  end
+
+  @tag :capture_log
+  test "restore_runtime_config/2 applies the whole config in a single call", %{node: node} do
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+    test_pid = self()
+
+    runtime_config = [
+      testapp: [
+        {Testapp.Repo, [ssl_opts: [customize_hostname_check: [match_fun: match_fun]]]},
+        {Testapp.Mailer, [adapter: Swoosh.Adapters.Local]}
+      ]
+    ]
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :application, :set_env, args, @expected_timeout ->
+      send(test_pid, {:set_env, args})
+      :ok
+    end)
+
+    assert :ok = UpgradeApp.restore_runtime_config(%Execute{node: node}, runtime_config)
+
+    # Same primitive and shape Config.Provider uses at boot via Application.put_all_env/2
+    assert_receive {:set_env, [^runtime_config, [persistent: true]]}
+    refute_receive {:set_env, _args}
+  end
+
+  @tag :capture_log
+  test "restore_runtime_config/2 error", %{node: node} do
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :application, :set_env, _args, @expected_timeout ->
+      {:badrpc, :nodedown}
+    end)
+
+    assert capture_log(fn ->
+             assert {:error, {:badrpc, :nodedown}} =
+                      UpgradeApp.restore_runtime_config(%Execute{node: node},
+                        testapp: [{Testapp.Repo, []}]
+                      )
+           end) =~ "Error while applying runtime config, reason: {:badrpc, :nodedown}"
   end
 
   @tag :capture_log
@@ -952,8 +1129,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1021,8 +1198,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1112,8 +1289,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1197,8 +1374,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1282,8 +1459,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1374,8 +1551,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.8"
+  def version, do: "0.9.9-rc1"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
## What changed and why

A hot upgrade could silently wipe the runtime configuration of **every** application in the release.

`sys.config` can only hold terms that `:file.consult/1` can read back. A value with no textual term syntax makes the whole file unparseable. The case that triggered this in practice is an Ecto Repo configured for `verify_peer` TLS in `runtime.exs`:

```elixir
config :myapp, MyApp.Repo,
  ssl_opts: [
    verify: :verify_peer,
    customize_hostname_check: [
      match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
    ]
  ]
```

`pkix_verify_hostname_match_fun/1` **returns a closure**. DeployEx runs the config providers over RPC, then writes the result with `:io_lib.format(~c"~tp", ...)`, which prints the closure as `#Fun<public_key.6.43236260>`:

```
:file.consult -> {:error, {N, :erl_parse, [~c"syntax error before: ", ~c"Fun"]}}
```

OTP does not report this. In `sasl/release_handler.erl`:

```erlang
Config = case consult(filename:join(Dir, "sys.config"), Masters) of
             {ok, [Conf]} -> Conf;
             _ -> []                      %% parse error swallowed
         end,
application_controller:change_application_data(Appls, Config)
```

`sys.config` is a single term, so one bad value anywhere fails the entire file. `Config` becomes `[]`, and `do_change_apps/3` then rebuilds the environment of every loaded application from its `.app` file defaults. `install_release/2` still returns `{:ok, _, _}`. Result: the upgrade reports success, and logger level, endpoint config, storage adapter, mailer and everything else from `runtime.exs` are gone, not only the Repo.

## The fix

Entries whose value holds a function, pid, port or reference are kept out of the generated `sys.config` and applied over RPC with `:application.set_env/2` immediately after `install_release/2`. That is the same primitive `Config.Provider` uses on a cold start via `Application.put_all_env/2`, which has no serialization step, and is why these apps boot correctly but broke on hot upgrade.

The generated file is then consulted back as a second guard, so anything the split cannot structurally see fails the upgrade rather than wiping the configuration.

The split is per `{app, key}` and never inside a value. A Repo that kept its `url` but lost its `ssl_opts` would connect in **plaintext** instead of failing, so the whole key is deferred together.

### Why not represent the function in sys.config

`fun M:F/A` does parse through stock `:file.consult`, and an external fun such as `&:lists.reverse/1` round trips correctly. But this value is a compiler generated local lambda (`type: :local`, `name: :"-pkix_verify_hostname_match_fun/1-fun-0-"`). Writing it that way parses and yields a fun, then raises `UndefinedFunctionError` on first call, because external fun references resolve against the export table. That would turn a loud failure at upgrade time into a TLS handshake crash at the first reconnect.

### Related cleanups

The original `sys.config` is renamed back on any failure inside `update_sys_config_from_installed_version/1`, and `do_execute/1` restores it on any later failure. Previously a failure after the rewrite stranded the generated file on disk, and the next attempt died with a `MatchError` on `{:ok, [sys_config]} = :file.consult/1`.

## Reproduction

`update_sys_config_from_installed_version/1 Elixir defers the entries sys.config cannot carry` feeds the real `:public_key.pkix_verify_hostname_match_fun(:https)` through the config providers and asserts the generated file stays parseable and that unrelated apps keep their config. Without the fix, `:file.consult` fails and every application is reset.

Also covered: whole key deferral rather than partial values, the second guard catching a value the per key split cannot see, sys.config restored on every failure path, and `restore_runtime_config/2` applying everything in a single call.

## Risk assessment

**Impact:** hot upgrades no longer silently reset every application to its `.app` file defaults when a config value holds a function, pid, port or reference. A warning naming the deferred `{app, key}` pairs is logged whenever anything is deferred.

**Blast radius:** `apps/deployer/lib/deployer/hot_upgrade/application.ex` only, in the Elixir path of `update_sys_config_from_installed_version/1` and the `do_execute/1` pipeline. Erlang releases are untouched, they return `{:ok, []}` and skip the new step. No changes to `foundation`, `sentinel`, `host` or `deployex_web`, and none to the deployment engine.

**Regression risk:** low. A configuration that was already serializable produces a byte identical `sys.config`, the split returns nothing to defer, and the RPC step is skipped entirely, so the common path is unchanged. The new behaviour only engages where the upgrade was previously losing configuration. The one genuinely new condition is that deferred entries are absent from the application environment while `install_release/2` runs, so an appup that restarts a supervisor reading one of those keys would fail to start rather than start misconfigured.

**Rollback:** plain commit revert. No data or configuration migration.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and the `deployer` suite (172 tests, 1 pre-existing skip) all pass locally. `mix dialyzer` was not run locally because the PLT is stale and needs a full rebuild; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
