### PR TITLE
feat(deployer): apply deferred runtime config from inside install_release via a relup hook

### DIFF
--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -50,11 +50,17 @@ defmodule Deployer.HotUpgrade.Application do
      raises `undef` when called - a worse failure than losing the configuration.
 
      Those entries are therefore kept out of the generated file, per `{app, key}` pair, and
-     applied over RPC with `:application.set_env/2` right after the release is installed. That
-     is the same primitive `Config.Provider` uses on a cold start through
-     `Application.put_all_env/2`, which has no serialization step and carries these values
-     without trouble. The generated file is then consulted back as a second guard, so anything
-     the split does not catch fails the upgrade instead of silently wiping the configuration.
+     applied with `:application.set_env/2`. That is the same primitive `Config.Provider` uses on
+     a cold start through `Application.put_all_env/2`, which has no serialization step and
+     carries these values without trouble. The generated file is then consulted back as a second
+     guard, so anything the split does not catch fails the upgrade instead of silently wiping
+     the configuration.
+
+     They are applied twice, which is harmless and deliberate. A hook spliced into the relup
+     (see `install_runtime_config_hook/2`) applies them from inside `install_release/2`, before
+     any `suspend` or `code_change` observes them as missing, and `restore_runtime_config/2`
+     applies them again once the release is installed so the upgrade does not depend on the
+     hook being in place.
 
   References:
 
@@ -77,6 +83,7 @@ defmodule Deployer.HotUpgrade.Application do
   @check_timeout 300_000
   @behaviour Deployer.HotUpgrade.Adapter
   @events_topic "deployex::hotupgrade::events"
+  @runtime_config_key {:deployex, :runtime_config}
 
   alias Deployer.HotUpgrade.Check
   alias Deployer.HotUpgrade.Execute
@@ -181,6 +188,7 @@ defmodule Deployer.HotUpgrade.Application do
          :ok <- check_install_release(data),
          :ok <- notify_progress(data.sname, "Updating sys.config file"),
          {:ok, runtime_config} <- update_sys_config_from_installed_version(data),
+         :ok <- install_runtime_config_hook(data, runtime_config),
          :ok <- notify_progress(data.sname, "Installing release"),
          :ok <- install_release(data),
          :ok <- notify_progress(data.sname, "Applying the runtime configuration"),
@@ -577,6 +585,53 @@ defmodule Deployer.HotUpgrade.Application do
   def update_sys_config_from_installed_version(_data), do: {:ok, []}
 
   @doc """
+  Splice a hook into the generated relup that applies the deferred configuration from inside
+  `release_handler:install_release/2`.
+
+  `change_appl_data/3` rebuilds the application environment from sys.config and only then does
+  `eval_script/5` run the relup instructions, so an instruction placed at the head of the script
+  executes after the new configuration is in place but before any `suspend`, `code_change` or
+  `resume`. That closes the window where a process restarted by the upgrade would observe the
+  deferred keys as missing.
+
+  The configuration itself cannot travel in the relup, which `release_handler` also reads with
+  `:file.consult/1`. It is stashed in `:persistent_term` over RPC instead, which survives
+  `change_appl_data/3` because it is not application environment, and the relup only carries
+  abstract forms, which are plain terms:
+
+      {apply, {erl_eval, exprs, [Forms, []]}}
+
+  evaluating `application:set_env(persistent_term:get(Key), [{persistent, true}])`. Nothing is
+  compiled and no module is injected into the target, so this is independent of the OTP version
+  the managed application was built with.
+
+  This is an optimisation. When it fails the upgrade carries on and
+  `restore_runtime_config/2` still applies the configuration once the release is installed.
+  """
+  @spec install_runtime_config_hook(Execute.t(), runtime_config()) :: :ok
+  def install_runtime_config_hook(_data, []), do: :ok
+
+  def install_runtime_config_hook(
+        %Execute{node: node, current_path: current_path, to_version: to_version},
+        runtime_config
+      ) do
+    relup_path = "#{current_path}/releases/#{to_version}/relup"
+
+    with :ok <- stash_runtime_config(node, runtime_config),
+         :ok <- splice_runtime_config_hook(relup_path) do
+      Logger.info("Runtime config hook added to the relup at: #{relup_path}")
+    else
+      {:error, reason} ->
+        Logger.warning(
+          "Could not add the runtime config hook, reason: #{inspect(reason)}. The configuration " <>
+            "is applied after the release is installed instead."
+        )
+    end
+
+    :ok
+  end
+
+  @doc """
   Apply the configuration entries that sys.config cannot carry.
 
   `release_handler:install_release/2` rebuilds the environment of every application from
@@ -602,6 +657,11 @@ defmodule Deployer.HotUpgrade.Application do
          ) do
       :ok ->
         Logger.info("Applied runtime config for apps: #{inspect(Keyword.keys(runtime_config))}")
+
+        # Setting the same values twice is harmless, the relup hook may already have applied
+        # them, but the stash must not outlive the upgrade
+        _ = Rpc.call(node, :persistent_term, :erase, [@runtime_config_key], @rpc_timeout)
+
         :ok
 
       reason ->
@@ -690,6 +750,61 @@ defmodule Deployer.HotUpgrade.Application do
       status: :error,
       message: message
     })
+  end
+
+  @spec stash_runtime_config(node(), runtime_config()) :: :ok | {:error, any()}
+  defp stash_runtime_config(node, runtime_config) do
+    case Rpc.call(
+           node,
+           :persistent_term,
+           :put,
+           [@runtime_config_key, runtime_config],
+           @rpc_timeout
+         ) do
+      :ok -> :ok
+      reason -> {:error, {:stash_failed, reason}}
+    end
+  end
+
+  @spec splice_runtime_config_hook(binary()) :: :ok | {:error, any()}
+  defp splice_runtime_config_hook(relup_path) do
+    instruction = {:apply, {:erl_eval, :exprs, [runtime_config_hook_forms(), []]}}
+
+    case :file.consult(relup_path) do
+      {:ok, [{to_vsn, up, down}]} ->
+        patched = {to_vsn, Enum.map(up, &prepend_instruction(&1, instruction)), down}
+        File.write(relup_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [patched]))
+
+      reason ->
+        {:error, {:unreadable_relup, reason}}
+    end
+  end
+
+  # An emulator upgrade restarts the VM and the configuration is resolved again on boot, so
+  # there is nothing to reapply and the script must keep restart_new_emulator at its head
+  defp prepend_instruction({from_vsn, descr, [:restart_new_emulator | _] = script}, _instruction),
+    do: {from_vsn, descr, script}
+
+  defp prepend_instruction({from_vsn, descr, script}, instruction),
+    do: {from_vsn, descr, [instruction | script]}
+
+  # Abstract forms for:
+  #   application:set_env(persistent_term:get(Key), [{persistent, true}])
+  # Forms are plain terms, so unlike the configuration they survive the relup file, and
+  # erl_eval is in stdlib so nothing has to be compiled or loaded into the target node.
+  @spec runtime_config_hook_forms() :: [tuple()]
+  defp runtime_config_hook_forms do
+    l = 0
+    {app, key} = @runtime_config_key
+
+    [
+      {:call, l, {:remote, l, {:atom, l, :application}, {:atom, l, :set_env}},
+       [
+         {:call, l, {:remote, l, {:atom, l, :persistent_term}, {:atom, l, :get}},
+          [{:tuple, l, [{:atom, l, app}, {:atom, l, key}]}]},
+         {:cons, l, {:tuple, l, [{:atom, l, :persistent}, {:atom, l, true}]}, {nil, l}}
+       ]}
+    ]
   end
 
   # Run runtime.exs and the Config Providers for the version being installed. They execute over

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1097,6 +1097,133 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     refute File.exists?("#{current_releases_version_path}/original.sys.config")
   end
 
+  test "install_runtime_config_hook/2 makes no rpc call when there is nothing to apply", %{
+    node: node
+  } do
+    Foundation.RpcMock
+    |> stub(:call, fn _node, _module, _function, _args, _timeout ->
+      flunk("no rpc call expected")
+    end)
+
+    assert :ok = UpgradeApp.install_runtime_config_hook(%Execute{node: node}, [])
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 stashes the config and heads the relup script", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+
+    original_script = [
+      {:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}},
+      {:suspend, [:test_app_sm]},
+      {:code_change, :up, [{:test_app_sm, []}]},
+      {:resume, [:test_app_sm]}
+    ]
+
+    relup = {~c"0.2.0", [{~c"0.1.0", ~c"", original_script}], []}
+    File.write!(relup_path, :io_lib.format(~c"~tp.~n", [relup]))
+
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+    runtime_config = [testapp: [{Testapp.Repo, [ssl_opts: [match_fun: match_fun]]}]]
+    test_pid = self()
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, args, @expected_timeout ->
+      send(test_pid, {:stashed, args})
+      :ok
+    end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{
+                 node: node,
+                 current_path: current_path,
+                 to_version: to_version
+               },
+               runtime_config
+             )
+
+    # The configuration itself cannot travel in the relup, it goes over RPC
+    assert_receive {:stashed, [{:deployex, :runtime_config}, ^runtime_config]}
+
+    # release_handler reads the relup with :file.consult/1 too, so the patched file must parse
+    assert {:ok, [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}]} = :file.consult(relup_path)
+
+    # Heading the script puts it after change_appl_data/3 and before suspend/code_change
+    assert [{:apply, {:erl_eval, :exprs, [forms, []]}} | ^original_script] = script
+
+    # The forms must evaluate to the set_env call, with no module loaded into the target
+    :persistent_term.put({:deployex, :runtime_config}, runtime_config)
+    on_exit(fn -> :persistent_term.erase({:deployex, :runtime_config}) end)
+
+    assert {:value, :ok, _bindings} = :erl_eval.exprs(forms, [])
+    assert Application.get_env(:testapp, Testapp.Repo)[:ssl_opts][:match_fun] == match_fun
+    on_exit(fn -> Application.delete_env(:testapp, Testapp.Repo) end)
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 leaves an emulator restart script untouched", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+
+    script = [:restart_new_emulator, {:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}}]
+
+    File.write!(
+      relup_path,
+      :io_lib.format(~c"~tp.~n", [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}])
+    )
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{
+                 node: node,
+                 current_path: current_path,
+                 to_version: to_version
+               },
+               testapp: [{Testapp.Repo, []}]
+             )
+
+    # The VM restarts and Config.Provider resolves the configuration again on boot
+    assert {:ok, [{_to, [{_from, _descr, ^script}], _}]} = :file.consult(relup_path)
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 does not fail the upgrade when the relup is missing", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    assert capture_log(fn ->
+             assert :ok =
+                      UpgradeApp.install_runtime_config_hook(
+                        %Execute{
+                          node: node,
+                          current_path: current_path,
+                          to_version: to_version
+                        },
+                        testapp: [{Testapp.Repo, []}]
+                      )
+           end) =~ "Could not add the runtime config hook"
+  end
+
   test "restore_runtime_config/2 makes no rpc call when there is nothing to apply", %{node: node} do
     Foundation.RpcMock
     |> stub(:call, fn _node, _module, _function, _args, _timeout ->
@@ -1119,9 +1246,14 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     ]
 
     Foundation.RpcMock
-    |> stub(:call, fn ^node, :application, :set_env, args, @expected_timeout ->
-      send(test_pid, {:set_env, args})
-      :ok
+    |> stub(:call, fn
+      ^node, :application, :set_env, args, @expected_timeout ->
+        send(test_pid, {:set_env, args})
+        :ok
+
+      ^node, :persistent_term, :erase, args, @expected_timeout ->
+        send(test_pid, {:erase, args})
+        true
     end)
 
     assert :ok = UpgradeApp.restore_runtime_config(%Execute{node: node}, runtime_config)
@@ -1129,6 +1261,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     # Same primitive and shape Config.Provider uses at boot via Application.put_all_env/2
     assert_receive {:set_env, [^runtime_config, [persistent: true]]}
     refute_receive {:set_env, _args}
+
+    # The relup hook stash must not outlive the upgrade
+    assert_receive {:erase, [{:deployex, :runtime_config}]}
   end
 
   @tag :capture_log


### PR DESCRIPTION
> Stacked on #258. Base is `thiagoesteves/fix-hot-upgrade-config-loss`, so the diff shows only the hook. GitHub retargets this to `main` once #258 merges.

## Why

#258 applies the entries sys.config cannot carry after `install_release/2` returns. That leaves a window:

```
install_release/2
  change_appl_data/3   <- env rebuilt from the generated sys.config, deferred keys absent
  eval_script/5        <- suspend / code_change / resume run HERE, still absent
returns
  set_env              <- #258 applies them here
```

A process restarted by the upgrade observes an incomplete configuration.

## How

`release_handler` applies sys.config **before** evaluating the relup, and `{apply, {M,F,A}}` is a real relup instruction:

```erlang
%% release_handler.erl:1735
Apps = change_appl_data(RelDir, Release, Masters),
...
case eval_script(Script, Apps, LibDirs, NewLibs, Opts) of

%% release_handler_1.erl:463
eval({apply, {M, F, A}}, EvalState) -> apply(M, F, A), EvalState;
```

So an instruction at the **head** of the script runs after the new config is in place and before anything is suspended.

The configuration itself cannot travel in the relup, which `release_handler` also reads with `:file.consult/1` (`release_handler.erl:2215`) - the same limitation that caused the original bug. So it is stashed in `:persistent_term` over RPC, which survives `change_appl_data/3` because it is not application environment, and the relup carries only abstract forms, which are plain terms:

```erlang
{apply,{erl_eval,exprs,
    [[{call,0,{remote,0,{atom,0,application},{atom,0,set_env}},
        [{call,0,{remote,0,{atom,0,persistent_term},{atom,0,get}},
             [{tuple,0,[{atom,0,deployex},{atom,0,runtime_config}]}]},
         {cons,0,{tuple,0,[{atom,0,persistent},{atom,0,true}]},{nil,0}}]}],
     []]}}
```

evaluating `application:set_env(persistent_term:get(Key), [{persistent, true}])`.

## Why not a compiled helper module

The obvious approach is `:code.load_binary/3` with a small helper module. It does not survive version skew. An OTP 28 compiled beam loaded into older VMs:

```
VM: OTP 28 -> load_binary {module,dx_hook} OK
VM: OTP 27 -> load_binary {error,badfile} FAILED   beam_load.c: corrupt atom table
VM: OTP 26 -> load_binary {error,badfile} FAILED   beam_load.c: corrupt atom table
```

It fails even one major back, and DeployEx manages applications built on their own OTP version. `erl_eval` and `persistent_term` are in stdlib and kernel, so the forms route is version neutral and needs nothing loaded into the target.

## Emulator upgrades

Scripts starting with `restart_new_emulator` are left untouched: that atom must stay at the head, and the VM restart resolves the configuration again on boot anyway.

## Risk assessment

**Impact:** the deferred configuration is in place before any `code_change` or supervisor restart during the upgrade. No visible change for applications with nothing deferred, where the hook is skipped entirely.

**Blast radius:** `apps/deployer/lib/deployer/hot_upgrade/application.ex` only, one new step between `update_sys_config_from_installed_version/1` and `install_release/1`. The relup generated by `systools:make_relup/4` is rewritten in place, after `check_install_release/1` has already validated it. Erlang releases defer nothing and skip the step. Nothing else in the umbrella is touched, and the deployment engine is unchanged.

**Regression risk:** low. The hook is an optimisation, not a guarantee. Every failure path logs a warning and returns `:ok`, and `restore_runtime_config/2` still applies the same values after `install_release/2`, so a failed splice degrades to exactly #258's behaviour. Applying the values twice is idempotent.

**Rollback:** plain commit revert.

## Testing

Unit tested: the stash goes over RPC and never into the relup, the patched relup still parses with `:file.consult/1`, the instruction heads the script ahead of the original instructions, the forms actually evaluate and land the value (including a real closure) in the application environment, `restart_new_emulator` scripts are untouched, a missing relup logs and does not fail the upgrade, and the stash is erased afterwards.

Not covered locally: a real `install_release/2` executing the spliced instruction on a live node. That needs a staging upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
