### PR TITLE
fix(deployer): apply the runtime configuration over RPC instead of rewriting sys.config

### DIFF
--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -17,23 +17,40 @@ defmodule Deployer.HotUpgrade.Application do
        a. Unpack a release using release_handler:unpack_release
        b. Create a relup file using systools:make_relup
        c. Check Install release using release_handler:check_install_release
-         i. Request via RPC to run  ConfigProvider and Runtime and populate sys.config (Only ELixir)
+         i. Request via RPC to run ConfigProvider and Runtime and resolve the config (Only Elixir)
+         ii. Add a hook to the relup that applies that config during the install (Only Elixir)
        d. Install the release using release_handler:install_release
+         i. Apply the resolved config to the running node (Only Elixir)
        e. Make the release permanent using release_handler:make_permanent
-         i. Return original empty sys.config (Only ELixir)
 
     Note that only upgrades are permitted in this project, and in the event of
      failure, the system will revert to a full deployment.
 
   4. ATTENTION:
-     The sys.config file contains all application configurations and is not loaded during a
-     hot HotUpgrade. For Elixir applications, Config Provider and Runtime are codes that executes
-     when the application is starting and are required for fetching information.
-     To address this, several steps are included in this module to load the new
-     version of sys.config and utilize the RPC channel to execute runtime.exs and the config
-     provider. It's important to note that these actions occur within the current version,
-     meaning the system is not immediately prepared to execute hot upgrades when configuration
-     changes occur.
+     For Elixir applications, `runtime.exs` and the Config Providers only execute when the
+     application boots, never during a hot upgrade. Worse, `release_handler` actively undoes
+     their result: `change_appl_data/3` rebuilds the environment of EVERY loaded application
+     from the build time sys.config, so everything `runtime.exs` produced is gone the moment
+     the release is installed.
+
+     This module therefore resolves that configuration itself, running the providers over the
+     RPC channel, and applies it with `:application.set_env/2` - the primitive
+     `Config.Provider` uses on a cold start through `Application.put_all_env/2`. Nothing is
+     serialized on the way, which matters because a resolved configuration can hold values with
+     no textual term syntax, such as the closure in
+     `customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]`
+     for an Ecto Repo. Writing one to sys.config prints it as `#Fun<...>`, and OTP does not
+     report that: the file no longer parses, `change_appl_data/3` falls back to an empty config
+     and every application silently reverts to its compile time environment.
+
+     The configuration is applied twice, which is harmless and deliberate. A hook spliced into
+     the relup (see `install_runtime_config_hook/2`) applies it from inside
+     `install_release/2`, before any `suspend` or `code_change` observes the reset environment,
+     and `apply_runtime_config/2` applies it again afterwards so the upgrade never depends on
+     the hook being in place.
+
+     Note that the providers execute within the current version, meaning the system is not
+     immediately prepared to execute hot upgrades when configuration changes occur.
 
   References:
 
@@ -56,11 +73,18 @@ defmodule Deployer.HotUpgrade.Application do
   @check_timeout 300_000
   @behaviour Deployer.HotUpgrade.Adapter
   @events_topic "deployex::hotupgrade::events"
+  @runtime_config_key {:deployex, :runtime_config}
 
   alias Deployer.HotUpgrade.Check
   alias Deployer.HotUpgrade.Execute
   alias Deployer.HotUpgrade.Jellyfish
   alias Foundation.Rpc
+
+  @typedoc """
+  The configuration produced by `runtime.exs` and the Config Providers of the version being
+  installed. Same shape as sys.config itself: `[{app, [{key, value}]}]`.
+  """
+  @type runtime_config :: [{app :: atom(), env :: keyword()}]
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -152,12 +176,13 @@ defmodule Deployer.HotUpgrade.Application do
          :ok <- make_relup(data),
          :ok <- notify_progress(data.sname, "Checking release can be installed"),
          :ok <- check_install_release(data),
-         :ok <- notify_progress(data.sname, "Updating sys.config file"),
-         :ok <- update_sys_config_from_installed_version(data),
+         :ok <- notify_progress(data.sname, "Resolving the runtime configuration"),
+         {:ok, runtime_config} <- resolve_runtime_config(data),
+         :ok <- install_runtime_config_hook(data, runtime_config),
          :ok <- notify_progress(data.sname, "Installing release"),
          :ok <- install_release(data),
-         :ok <- notify_progress(data.sname, "Returning original sys.config file"),
-         :ok <- return_original_sys_config(data),
+         :ok <- notify_progress(data.sname, "Applying the runtime configuration"),
+         :ok <- apply_runtime_config(data, runtime_config),
          :ok <- notify_make_permanent(data.make_permanent_async, data.sname, data.to_version),
          :ok <- permfy(data),
          :ok <- notify_complete_ok(data.make_permanent_async, data.sname) do
@@ -502,58 +527,119 @@ defmodule Deployer.HotUpgrade.Application do
     releases |> Enum.map(fn {_name, version, _modules, status} -> {status, version} end)
   end
 
-  @spec update_sys_config_from_installed_version(Execute.t()) :: :ok | {:error, any()}
-  def update_sys_config_from_installed_version(%Execute{
+  @doc """
+  Resolve the configuration of the version being installed.
+
+  Reads the build time sys.config of the new version and runs its `runtime.exs` and Config
+  Providers over RPC, producing exactly the configuration the application would have had on a
+  cold boot. The file itself is only read, never written.
+  """
+  @spec resolve_runtime_config(Execute.t()) :: {:ok, runtime_config()} | {:error, any()}
+  def resolve_runtime_config(%Execute{
         node: node,
         language: "elixir",
         current_path: current_path,
         to_version: to_version
       }) do
-    rel_vsn_dir = "#{current_path}/releases/#{to_version}"
-    sys_config_path = "#{rel_vsn_dir}/sys.config"
-    original_sys_config_file = "#{rel_vsn_dir}/original.sys.config"
-    # Read the build time config from build.config
-    {:ok, [sys_config]} = :file.consult(sys_config_path)
-    # In this step, it will run the runtime.exs and Config Providers for the current version
-    sys_config =
-      sys_config
-      |> Keyword.get(:elixir)
-      |> Keyword.get(:config_provider_init)
-      |> Map.get(:providers)
-      |> Enum.reduce(sys_config, fn {mod, arg}, cfg ->
-        Rpc.call(node, mod, :load, [cfg, arg], @rpc_timeout)
-      end)
+    sys_config_path = "#{current_path}/releases/#{to_version}/sys.config"
 
-    with :ok <- File.rename(sys_config_path, original_sys_config_file),
-         :ok <-
-           File.write(sys_config_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [sys_config])) do
-      :ok
+    case :file.consult(sys_config_path) do
+      {:ok, [sys_config]} ->
+        run_config_providers(node, sys_config)
+
+      reason ->
+        Logger.error("Error while reading #{sys_config_path}, reason: #{inspect(reason)}")
+
+        {:error, {:unreadable_sys_config, reason}}
+    end
+  end
+
+  def resolve_runtime_config(_data), do: {:ok, []}
+
+  @doc """
+  Splice a hook into the generated relup that applies the resolved configuration from inside
+  `release_handler:install_release/2`.
+
+  `change_appl_data/3` rebuilds the environment of every application from the build time
+  sys.config, and only then does `eval_script/5` run the relup instructions. An instruction at
+  the head of the script therefore executes once the environment has been reset and before any
+  `suspend`, `code_change` or `resume` can observe it.
+
+  The configuration cannot travel in the relup, which `release_handler` also reads with
+  `:file.consult/1`, and an anonymous function has no textual term syntax. It is stashed in
+  `:persistent_term` over RPC instead, which survives `change_appl_data/3` because it is not
+  application environment, and the relup carries only abstract forms, which are plain terms:
+
+      {apply, {erl_eval, exprs, [Forms, []]}}
+
+  evaluating `application:set_env(persistent_term:get(Key), [{persistent, true}])`. Nothing is
+  compiled and no module is loaded into the target, so this does not depend on the OTP version
+  the managed application was built with.
+
+  This is an optimisation. When it fails the upgrade carries on and `apply_runtime_config/2`
+  still applies the configuration once the release is installed.
+  """
+  @spec install_runtime_config_hook(Execute.t(), runtime_config()) :: :ok
+  def install_runtime_config_hook(_data, []), do: :ok
+
+  def install_runtime_config_hook(
+        %Execute{node: node, current_path: current_path, to_version: to_version},
+        runtime_config
+      ) do
+    relup_path = "#{current_path}/releases/#{to_version}/relup"
+
+    with :ok <- stash_runtime_config(node, runtime_config),
+         :ok <- splice_runtime_config_hook(relup_path) do
+      Logger.info("Runtime config hook added to the relup at: #{relup_path}")
     else
       {:error, reason} ->
-        Logger.error(
-          "Error while updating sys.config to: #{to_version}, reason: #{inspect(reason)}"
+        Logger.warning(
+          "Could not add the runtime config hook, reason: #{inspect(reason)}. The configuration " <>
+            "is applied after the release is installed instead."
         )
+    end
+
+    :ok
+  end
+
+  @doc """
+  Apply the resolved configuration to the running node.
+
+  `release_handler:install_release/2` rebuilds the environment of every application from the
+  build time sys.config, so the values produced by `runtime.exs` and the Config Providers have
+  to be set again afterwards.
+
+  `:application.set_env/2` is the primitive Elixir itself uses on a cold start:
+  `Config.Provider.boot/1` calls `Application.put_all_env(config, persistent: true)`, a straight
+  delegation to it, whenever the release does not reboot after config. Nothing is serialized, so
+  values with no textual term syntax are carried without trouble.
+  """
+  @spec apply_runtime_config(Execute.t(), runtime_config()) :: :ok | {:error, any()}
+  def apply_runtime_config(_data, []), do: :ok
+
+  def apply_runtime_config(%Execute{node: node}, runtime_config) do
+    case Rpc.call(
+           node,
+           :application,
+           :set_env,
+           [runtime_config, [persistent: true]],
+           @rpc_timeout
+         ) do
+      :ok ->
+        Logger.info("Applied runtime config for apps: #{inspect(Keyword.keys(runtime_config))}")
+
+        # Setting the same values twice is harmless, the relup hook may already have applied
+        # them, but the stash must not outlive the upgrade
+        _ = Rpc.call(node, :persistent_term, :erase, [@runtime_config_key], @rpc_timeout)
+
+        :ok
+
+      reason ->
+        Logger.error("Error while applying runtime config, reason: #{inspect(reason)}")
 
         {:error, reason}
     end
   end
-
-  def update_sys_config_from_installed_version(_data), do: :ok
-
-  @spec return_original_sys_config(Execute.t()) :: :ok | {:error, any()}
-  def return_original_sys_config(%Execute{
-        language: "elixir",
-        current_path: current_path,
-        to_version: to_version
-      }) do
-    rel_vsn_dir = "#{current_path}/releases/#{to_version}"
-    sys_config_path = "#{rel_vsn_dir}/sys.config"
-    original_sys_config_file = "#{rel_vsn_dir}/original.sys.config"
-
-    File.rename(original_sys_config_file, sys_config_path)
-  end
-
-  def return_original_sys_config(_data), do: :ok
 
   @spec root_dir(node :: node()) :: any()
   def root_dir(node), do: Rpc.call(node, :code, :root_dir, [], @rpc_timeout)
@@ -619,6 +705,89 @@ defmodule Deployer.HotUpgrade.Application do
       status: :error,
       message: message
     })
+  end
+
+  # Run runtime.exs and the Config Providers for the version being installed. They execute over
+  # RPC inside the still running old version, so a provider that assumes a cold system fails
+  # here. Mirror Config.Provider.run_providers/2 and require a list back, otherwise the failure
+  # reason would be carried forward as if it were the configuration.
+  @spec run_config_providers(node(), keyword()) :: {:ok, runtime_config()} | {:error, any()}
+  defp run_config_providers(node, sys_config) do
+    sys_config
+    |> Keyword.get(:elixir)
+    |> Keyword.get(:config_provider_init)
+    |> Map.get(:providers)
+    |> Enum.reduce_while({:ok, sys_config}, fn {mod, arg}, {:ok, config} ->
+      case Rpc.call(node, mod, :load, [config, arg], @rpc_timeout) do
+        new_config when is_list(new_config) ->
+          {:cont, {:ok, new_config}}
+
+        reason ->
+          Logger.error("""
+          Config provider #{inspect(mod)} did not return a configuration on node #{node}, got: \
+          #{inspect(reason)}. Providers run inside the already running old version, so they must \
+          tolerate a started system: one that starts a process the application already owns fails \
+          here with {:already_started, pid} even though it works on a cold boot.\
+          """)
+
+          {:halt, {:error, {:config_provider_failed, mod, reason}}}
+      end
+    end)
+  end
+
+  @spec stash_runtime_config(node(), runtime_config()) :: :ok | {:error, any()}
+  defp stash_runtime_config(node, runtime_config) do
+    case Rpc.call(
+           node,
+           :persistent_term,
+           :put,
+           [@runtime_config_key, runtime_config],
+           @rpc_timeout
+         ) do
+      :ok -> :ok
+      reason -> {:error, {:stash_failed, reason}}
+    end
+  end
+
+  @spec splice_runtime_config_hook(binary()) :: :ok | {:error, any()}
+  defp splice_runtime_config_hook(relup_path) do
+    instruction = {:apply, {:erl_eval, :exprs, [runtime_config_hook_forms(), []]}}
+
+    case :file.consult(relup_path) do
+      {:ok, [{to_vsn, up, down}]} ->
+        patched = {to_vsn, Enum.map(up, &prepend_instruction(&1, instruction)), down}
+        File.write(relup_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [patched]))
+
+      reason ->
+        {:error, {:unreadable_relup, reason}}
+    end
+  end
+
+  # An emulator upgrade restarts the VM and the configuration is resolved again on boot, so
+  # there is nothing to apply and the script must keep restart_new_emulator at its head
+  defp prepend_instruction({from_vsn, descr, [:restart_new_emulator | _] = script}, _instruction),
+    do: {from_vsn, descr, script}
+
+  defp prepend_instruction({from_vsn, descr, script}, instruction),
+    do: {from_vsn, descr, [instruction | script]}
+
+  # Abstract forms for:
+  #   application:set_env(persistent_term:get(Key), [{persistent, true}])
+  # Forms are plain terms, so unlike the configuration they survive the relup file, and
+  # erl_eval is in stdlib so nothing has to be compiled or loaded into the target node.
+  @spec runtime_config_hook_forms() :: [tuple()]
+  defp runtime_config_hook_forms do
+    l = 0
+    {app, key} = @runtime_config_key
+
+    [
+      {:call, l, {:remote, l, {:atom, l, :application}, {:atom, l, :set_env}},
+       [
+         {:call, l, {:remote, l, {:atom, l, :persistent_term}, {:atom, l, :get}},
+          [{:tuple, l, [{:atom, l, app}, {:atom, l, key}]}]},
+         {:cons, l, {:tuple, l, [{:atom, l, :persistent}, {:atom, l, true}]}, {nil, l}}
+       ]}
+    ]
   end
 
   defp check_jellyfish_files(files, from_version, to_version) do

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -821,67 +821,40 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     assert :ok = UpgradeApp.permfy(%Execute{make_permanent_async: true})
   end
 
-  @tag :capture_log
-  test "return_original_sys_config/1 Elixir success", %{
-    current_path: current_path,
-    to_version: to_version
-  } do
-    current_releases_version_path = "#{current_path}/releases/#{to_version}"
-
-    File.mkdir_p!(current_releases_version_path)
-
-    File.write("#{current_releases_version_path}/original.sys.config", "empty")
-    File.rm("#{current_releases_version_path}/sys.config")
-
-    assert :ok =
-             UpgradeApp.return_original_sys_config(%Execute{
-               language: "elixir",
-               current_path: current_path,
-               to_version: to_version
-             })
-
-    assert File.exists?("#{current_releases_version_path}/sys.config")
-  end
-
-  test "return_original_sys_config/1 Erlang success", %{
-    current_path: current_path,
-    to_version: to_version
-  } do
-    assert :ok =
-             UpgradeApp.return_original_sys_config(%Execute{
-               language: "erlang",
-               current_path: current_path,
-               to_version: to_version
-             })
-  end
-
-  @tag :capture_log
-  test "update_sys_config_from_installed_version/1 Elixir success", %{
+  test "resolve_runtime_config/1 Elixir success", %{
     node: node,
     current_path: current_path,
     to_version: to_version
   } do
     current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
 
     File.mkdir_p!(current_releases_version_path)
-    File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+    original_sys_config = File.read!(sys_config_path)
 
     Foundation.RpcMock
-    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-      :ok
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      Keyword.put(cfg, :from_runtime_exs, answer: 42)
     end)
 
-    assert :ok =
-             UpgradeApp.update_sys_config_from_installed_version(%Execute{
+    assert {:ok, config} =
+             UpgradeApp.resolve_runtime_config(%Execute{
                node: node,
                language: "elixir",
                current_path: current_path,
                to_version: to_version
              })
+
+    assert config[:from_runtime_exs] == [answer: 42]
+    assert config[:logger][:level] == :info
+
+    # sys.config is only read, the release directory must come out untouched
+    assert File.read!(sys_config_path) == original_sys_config
+    refute File.exists?("#{current_releases_version_path}/original.sys.config")
   end
 
-  @tag :skip
-  test "update_sys_config_from_installed_version/1 Elixir error", %{
+  test "resolve_runtime_config/1 Elixir carries values sys.config could never hold", %{
     node: node,
     current_path: current_path,
     to_version: to_version
@@ -891,36 +864,275 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
 
+    # The exact value an Ecto Repo gets for a verify_peer TLS connection. Writing it to
+    # sys.config prints it as #Fun<...> and the file stops parsing
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+
+    repo_config = [
+      url: "postgres://user:pass@host:5432/db",
+      ssl_opts: [verify: :verify_peer, customize_hostname_check: [match_fun: match_fun]]
+    ]
+
     Foundation.RpcMock
-    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-      :ok
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      Keyword.update!(cfg, :testapp, &Keyword.put(&1, Testapp.Repo, repo_config))
     end)
 
-    with_mock File, [:passthrough], rename: fn _source, _destination -> {:error, :any} end do
-      assert capture_log(fn ->
-               assert {:error, :any} =
-                        UpgradeApp.update_sys_config_from_installed_version(%Execute{
-                          node: node,
-                          language: "elixir",
-                          current_path: current_path,
-                          to_version: to_version
-                        })
-             end) =~ "Error while updating sys.config to: #{to_version}, reason: :any"
-    end
+    assert {:ok, config} =
+             UpgradeApp.resolve_runtime_config(%Execute{
+               node: node,
+               language: "elixir",
+               current_path: current_path,
+               to_version: to_version
+             })
+
+    assert config[:testapp][Testapp.Repo] == repo_config
+    fun = config[:testapp][Testapp.Repo][:ssl_opts][:customize_hostname_check][:match_fun]
+    assert fun.({:dns_id, ~c"a.example.com"}, {:dNSName, ~c"*.example.com"})
   end
 
-  test "update_sys_config_from_installed_version/1 Erlang success", %{
+  @tag :capture_log
+  test "resolve_runtime_config/1 Elixir fails when a config provider crashes", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+
+    # Providers run over RPC inside the still running old version. One that starts a process
+    # the application already owns works on a cold boot and fails here
+    badrpc =
+      {:badrpc,
+       {:EXIT,
+        {{:badmatch, {:error, {:already_started, self()}}},
+         [{Testapp.SecretsProvider, :load, 2, [file: ~c"lib/secrets.ex", line: 54]}]}}}
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout -> badrpc end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:config_provider_failed, _mod, ^badrpc}} =
+                 UpgradeApp.resolve_runtime_config(%Execute{
+                   node: node,
+                   language: "elixir",
+                   current_path: current_path,
+                   to_version: to_version
+                 })
+      end)
+
+    assert log =~ "did not return a configuration"
+    assert log =~ "already_started"
+  end
+
+  @tag :capture_log
+  test "resolve_runtime_config/1 Elixir fails when sys.config cannot be read", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    File.mkdir_p!("#{current_path}/releases/#{to_version}")
+
+    assert capture_log(fn ->
+             assert {:error, {:unreadable_sys_config, _reason}} =
+                      UpgradeApp.resolve_runtime_config(%Execute{
+                        node: node,
+                        language: "elixir",
+                        current_path: current_path,
+                        to_version: to_version
+                      })
+           end) =~ "Error while reading"
+  end
+
+  test "resolve_runtime_config/1 Erlang success", %{
     node: node,
     new_path: new_path,
     to_version: to_version
   } do
-    assert :ok =
-             UpgradeApp.update_sys_config_from_installed_version(%Execute{
+    assert {:ok, []} =
+             UpgradeApp.resolve_runtime_config(%Execute{
                node: node,
                language: "erlang",
                new_path: new_path,
                to_version: to_version
              })
+  end
+
+  test "install_runtime_config_hook/2 makes no rpc call when there is nothing to apply", %{
+    node: node
+  } do
+    Foundation.RpcMock
+    |> stub(:call, fn _node, _module, _function, _args, _timeout ->
+      flunk("no rpc call expected")
+    end)
+
+    assert :ok = UpgradeApp.install_runtime_config_hook(%Execute{node: node}, [])
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 stashes the config and heads the relup script", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+
+    original_script = [
+      {:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}},
+      {:suspend, [:test_app_sm]},
+      {:code_change, :up, [{:test_app_sm, []}]},
+      {:resume, [:test_app_sm]}
+    ]
+
+    File.write!(
+      relup_path,
+      :io_lib.format(~c"~tp.~n", [{~c"0.2.0", [{~c"0.1.0", ~c"", original_script}], []}])
+    )
+
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+    runtime_config = [testapp: [{Testapp.Repo, [ssl_opts: [match_fun: match_fun]]}]]
+    test_pid = self()
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, args, @expected_timeout ->
+      send(test_pid, {:stashed, args})
+      :ok
+    end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{node: node, current_path: current_path, to_version: to_version},
+               runtime_config
+             )
+
+    # The configuration itself cannot travel in the relup, it goes over RPC
+    assert_receive {:stashed, [{:deployex, :runtime_config}, ^runtime_config]}
+
+    # release_handler reads the relup with :file.consult/1 too, so the patched file must parse
+    assert {:ok, [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}]} = :file.consult(relup_path)
+
+    # Heading the script puts it after change_appl_data/3 and before suspend/code_change
+    assert [{:apply, {:erl_eval, :exprs, [forms, []]}} | ^original_script] = script
+
+    # The forms must evaluate to the set_env call, with no module loaded into the target
+    :persistent_term.put({:deployex, :runtime_config}, runtime_config)
+    on_exit(fn -> :persistent_term.erase({:deployex, :runtime_config}) end)
+    on_exit(fn -> Application.delete_env(:testapp, Testapp.Repo) end)
+
+    assert {:value, :ok, _bindings} = :erl_eval.exprs(forms, [])
+    assert Application.get_env(:testapp, Testapp.Repo)[:ssl_opts][:match_fun] == match_fun
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 leaves an emulator restart script untouched", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+
+    script = [:restart_new_emulator, {:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}}]
+
+    File.write!(
+      relup_path,
+      :io_lib.format(~c"~tp.~n", [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}])
+    )
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{node: node, current_path: current_path, to_version: to_version},
+               testapp: [{Testapp.Repo, []}]
+             )
+
+    # The VM restarts and Config.Provider resolves the configuration again on boot
+    assert {:ok, [{_to, [{_from, _descr, ^script}], _}]} = :file.consult(relup_path)
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 does not fail the upgrade when the relup is missing", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    assert capture_log(fn ->
+             assert :ok =
+                      UpgradeApp.install_runtime_config_hook(
+                        %Execute{node: node, current_path: current_path, to_version: to_version},
+                        testapp: [{Testapp.Repo, []}]
+                      )
+           end) =~ "Could not add the runtime config hook"
+  end
+
+  test "apply_runtime_config/2 makes no rpc call when there is nothing to apply", %{node: node} do
+    Foundation.RpcMock
+    |> stub(:call, fn _node, _module, _function, _args, _timeout ->
+      flunk("no rpc call expected")
+    end)
+
+    assert :ok = UpgradeApp.apply_runtime_config(%Execute{node: node}, [])
+  end
+
+  @tag :capture_log
+  test "apply_runtime_config/2 applies the whole config in a single call", %{node: node} do
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+    test_pid = self()
+
+    runtime_config = [
+      testapp: [
+        {Testapp.Repo, [ssl_opts: [customize_hostname_check: [match_fun: match_fun]]]},
+        {Testapp.Mailer, [adapter: Swoosh.Adapters.Local]}
+      ]
+    ]
+
+    Foundation.RpcMock
+    |> stub(:call, fn
+      ^node, :application, :set_env, args, @expected_timeout ->
+        send(test_pid, {:set_env, args})
+        :ok
+
+      ^node, :persistent_term, :erase, args, @expected_timeout ->
+        send(test_pid, {:erase, args})
+        true
+    end)
+
+    assert :ok = UpgradeApp.apply_runtime_config(%Execute{node: node}, runtime_config)
+
+    # Same primitive and shape Config.Provider uses at boot via Application.put_all_env/2
+    assert_receive {:set_env, [^runtime_config, [persistent: true]]}
+    refute_receive {:set_env, _args}
+
+    # The relup hook stash must not outlive the upgrade
+    assert_receive {:erase, [{:deployex, :runtime_config}]}
+  end
+
+  @tag :capture_log
+  test "apply_runtime_config/2 error", %{node: node} do
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :application, :set_env, _args, @expected_timeout ->
+      {:badrpc, :nodedown}
+    end)
+
+    assert capture_log(fn ->
+             assert {:error, {:badrpc, :nodedown}} =
+                      UpgradeApp.apply_runtime_config(%Execute{node: node},
+                        testapp: [{Testapp.Repo, []}]
+                      )
+           end) =~ "Error while applying runtime config, reason: {:badrpc, :nodedown}"
   end
 
   @tag :capture_log
@@ -952,7 +1164,16 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, _params, @expected_timeout ->
+        true
+
+      ^node, :application, :set_env, _params, @expected_timeout ->
         :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
@@ -1021,7 +1242,16 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, _params, @expected_timeout ->
+        true
+
+      ^node, :application, :set_env, _params, @expected_timeout ->
         :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
@@ -1067,13 +1297,14 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Checking release can be installed"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Resolving the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Returning original sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Applying the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_complete, ^node, ^sname, :ok,
@@ -1112,7 +1343,16 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, _params, @expected_timeout ->
+        true
+
+      ^node, :application, :set_env, _params, @expected_timeout ->
         :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
@@ -1151,13 +1391,14 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Checking release can be installed"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Resolving the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Returning original sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Applying the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Making release 0.2.0 permanent"},
@@ -1197,7 +1438,16 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, _params, @expected_timeout ->
+        true
+
+      ^node, :application, :set_env, _params, @expected_timeout ->
         :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
@@ -1236,13 +1486,14 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Checking release can be installed"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Resolving the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Returning original sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Applying the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Making release 0.2.0 permanent"},
@@ -1282,7 +1533,16 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, _params, @expected_timeout ->
+        true
+
+      ^node, :application, :set_env, _params, @expected_timeout ->
         :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
@@ -1324,14 +1584,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                                "Checking release can be installed"},
                               1_000
 
-               assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+               assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                               "Resolving the runtime configuration"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname,
-                               "Returning original sys.config file"},
+                               "Applying the runtime configuration"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname,
@@ -1374,7 +1635,16 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, _params, @expected_timeout ->
+        true
+
+      ^node, :application, :set_env, _params, @expected_timeout ->
         :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
@@ -1424,14 +1694,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                                "Checking release can be installed"},
                               1_000
 
-               assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+               assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                               "Resolving the runtime configuration"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname,
-                               "Returning original sys.config file"},
+                               "Applying the runtime configuration"},
                               1_000
 
                assert_receive {:hot_upgrade_complete, ^node, ^sname, :error,


### PR DESCRIPTION
Replaces #258 and #259, which should be closed. Branched from `main`.

## The bug

A hot upgrade silently wiped the runtime configuration of **every** application on the node whenever any config value had no textual term syntax.

To carry `runtime.exs` across an upgrade, DeployEx wrote the resolved configuration back into the new version's `sys.config`. That only works for values `:file.consult/1` can read back. This one, which is what an Ecto Repo gets for a `verify_peer` TLS connection, cannot be:

```elixir
customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
```

`pkix_verify_hostname_match_fun/1` returns a **closure**. `:io_lib.format(~c"~tp", ...)` prints it as `#Fun<public_key.6.43236260>`:

```
:file.consult -> {:error, {N, :erl_parse, [~c"syntax error before: ", ~c"Fun"]}}
```

`sys.config` is a single term, so one such value anywhere invalidates the whole file. And OTP does not report it. `release_handler.erl:2339`:

```erlang
Config = case consult(filename:join(Dir, "sys.config"), Masters) of
             {ok, [Conf]} -> Conf;
             _ -> []                      %% parse error swallowed
         end,
application_controller:change_application_data(Appls, Config)
```

`do_change_apps/3` then maps over every loaded application and rebuilds each one's env via `merge_app_env(Env, ConfEnv)` where `ConfEnv` is always `[]`, so each falls back to its `.app` file defaults. `install_release/2` still returns `{ok, _, _}`. The upgrade reports success while logger level, endpoint config, mailer, storage adapter and everything else from `runtime.exs` is gone.

## The fix

**sys.config is now only read, never written.** The providers still run over RPC, and the result is applied with `:application.set_env/2` - the primitive `Config.Provider` uses on a cold start through `Application.put_all_env/2`, which has no serialization step. That is precisely why these applications boot fine every day and only broke under hot upgrade.

This deletes the rename to `original.sys.config`, the write, and `return_original_sys_config/1` entirely. A failed upgrade can no longer strand a generated `sys.config` for the next attempt's `:file.consult/1` to choke on.

### Applied twice, deliberately

`change_appl_data/3` resets the environment **before** `eval_script/5` runs the relup (`release_handler.erl:1735-1738`), and `{apply, {M,F,A}}` is a relup instruction (`release_handler_1.erl:463`). So a hook at the **head** of the script applies the config before any `suspend` or `code_change` observes the reset environment, and `apply_runtime_config/2` applies it again after `install_release/2` so the upgrade never depends on the hook.

The configuration cannot travel in the relup either - `release_handler` consults that too (`release_handler.erl:2215`). It is stashed in `:persistent_term` over RPC, which survives `change_appl_data/3` because it is not application environment, and the relup carries only abstract forms, which are plain terms:

```erlang
{apply,{erl_eval,exprs,
    [[{call,0,{remote,0,{atom,0,application},{atom,0,set_env}},
        [{call,0,{remote,0,{atom,0,persistent_term},{atom,0,get}},
             [{tuple,0,[{atom,0,deployex},{atom,0,runtime_config}]}]},
         {cons,0,{tuple,0,[{atom,0,persistent},{atom,0,true}]},{nil,0}}]}],
     []]}}
```

Nothing is compiled and no module is loaded into the target. That is not incidental - a beam compiled by DeployEx does not survive version skew:

```
VM: OTP 28 -> load_binary {module,dx_hook} OK
VM: OTP 27 -> load_binary {error,badfile} FAILED   beam_load.c: corrupt atom table
VM: OTP 26 -> load_binary {error,badfile} FAILED   beam_load.c: corrupt atom table
```

It fails even one major back, and managed applications bring their own OTP version. `erl_eval` and `persistent_term` are stock, so the forms route is version neutral.

### Why not represent the function in sys.config

`fun M:F/A` does parse through `:file.consult`, and an external fun like `&:lists.reverse/1` round trips correctly. But this is a compiler generated local lambda (`type: :local`, `name: :"-pkix_verify_hostname_match_fun/1-fun-0-"`). Writing it that way parses and yields a fun, then raises `UndefinedFunctionError` on first call, because external fun references resolve against the export table. That converts a loud failure at upgrade time into a TLS handshake crash at the first reconnect.

### Config provider validation

Provider results were folded in unchecked, so an RPC failure or a crashing provider was carried forward as if it were the configuration. Now mirrors `Config.Provider.run_providers/2` and requires a list back, naming the provider:

```
Config provider Holidex.AwsSecretsManagerProvider did not return a configuration on node
..., got: {:badrpc, {:EXIT, {{:badmatch, {:error, {:already_started, #PID<...>}}}, ...}}}.
Providers run inside the already running old version, so they must tolerate a started
system: one that starts a process the application already owns fails here with
{:already_started, pid} even though it works on a cold boot.
```

## Reproduction

`resolve_runtime_config/1 Elixir carries values sys.config could never hold` runs the real `:public_key.pkix_verify_hostname_match_fun(:https)` through the providers and asserts the resulting fun is callable.

Also covered: sys.config is byte identical afterwards and no `original.sys.config` is left behind, the patched relup still parses with `:file.consult/1`, the instruction heads the script ahead of the original instructions, the forms evaluate and land the value in the application environment, `restart_new_emulator` scripts are untouched, a missing relup degrades to a warning without failing the upgrade, the stash is erased afterwards, and a crashing provider aborts with a named error.

## Risk assessment

**Impact:** hot upgrades keep the runtime configuration instead of silently reverting every application to its `.app` file defaults. `sys.config` is no longer modified, so the release directory is left exactly as found.

**Blast radius:** `apps/deployer/lib/deployer/hot_upgrade/application.ex` only. `update_sys_config_from_installed_version/1` and `return_original_sys_config/1` are replaced by `resolve_runtime_config/1`, `install_runtime_config_hook/2` and `apply_runtime_config/2`; both removed functions were internal to this module. The relup generated by `systools:make_relup/4` is rewritten in place, after `check_install_release/1` has already validated it. Erlang releases return `{:ok, []}` and skip every new step. No changes to `foundation`, `sentinel`, `host` or `deployex_web`, nor to the deployment engine.

**Regression risk:** low. Applications whose configuration was already serializable get the same values by a different route, and applying them twice is idempotent. The relup hook is an optimisation: every failure path logs a warning and returns `:ok`, leaving `apply_runtime_config/2` to do the work. Emulator upgrades are left untouched, since the VM restart resolves the configuration again on boot.

**Rollback:** plain commit revert. No data or configuration migration.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and the `deployer` suite (173 tests, 0 failures, no skips) pass locally. The previously skipped test covered the `sys.config` rename, which no longer exists. `mix dialyzer` was not run locally because the PLT is stale and needs a full rebuild; CI covers it.

Not covered locally: a real `install_release/2` executing the spliced instruction on a live node. That needs a staging upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
