### PR TITLE
fix(deployer): fail the upgrade when a config provider does not return a configuration

### DIFF
--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -514,17 +514,10 @@ defmodule Deployer.HotUpgrade.Application do
     original_sys_config_file = "#{rel_vsn_dir}/original.sys.config"
     # Read the build time config from build.config
     {:ok, [sys_config]} = :file.consult(sys_config_path)
-    # In this step, it will run the runtime.exs and Config Providers for the current version
-    sys_config =
-      sys_config
-      |> Keyword.get(:elixir)
-      |> Keyword.get(:config_provider_init)
-      |> Map.get(:providers)
-      |> Enum.reduce(sys_config, fn {mod, arg}, cfg ->
-        Rpc.call(node, mod, :load, [cfg, arg], @rpc_timeout)
-      end)
 
-    with :ok <- File.rename(sys_config_path, original_sys_config_file),
+    # In this step, it will run the runtime.exs and Config Providers for the current version
+    with {:ok, sys_config} <- run_config_providers(node, sys_config),
+         :ok <- File.rename(sys_config_path, original_sys_config_file),
          :ok <-
            File.write(sys_config_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [sys_config])) do
       :ok
@@ -619,6 +612,38 @@ defmodule Deployer.HotUpgrade.Application do
       status: :error,
       message: message
     })
+  end
+
+  # Run runtime.exs and the Config Providers for the version being installed.
+  #
+  # They execute over RPC inside the still running old version, so a provider that assumes a
+  # cold system fails here: one that starts a process the application already owns comes back
+  # as {:badrpc, {:EXIT, {{:badmatch, {:error, {:already_started, pid}}}, _}}} even though it
+  # works on boot. Mirror Config.Provider.run_providers/2 and require a list back, otherwise
+  # the failure reason is carried forward as if it were the configuration and ends up written
+  # into sys.config.
+  @spec run_config_providers(node(), keyword()) :: {:ok, keyword()} | {:error, any()}
+  defp run_config_providers(node, sys_config) do
+    sys_config
+    |> Keyword.get(:elixir)
+    |> Keyword.get(:config_provider_init)
+    |> Map.get(:providers)
+    |> Enum.reduce_while({:ok, sys_config}, fn {mod, arg}, {:ok, config} ->
+      case Rpc.call(node, mod, :load, [config, arg], @rpc_timeout) do
+        new_config when is_list(new_config) ->
+          {:cont, {:ok, new_config}}
+
+        reason ->
+          Logger.error("""
+          Config provider #{inspect(mod)} did not return a configuration on node #{node}, got: \
+          #{inspect(reason)}. Providers run inside the already running old version, so they must \
+          tolerate a started system: one that starts a process the application already owns fails \
+          here with {:already_started, pid} even though it works on a cold boot.\
+          """)
+
+          {:halt, {:error, {:config_provider_failed, mod, reason}}}
+      end
+    end)
   end
 
   defp check_jellyfish_files(files, from_version, to_version) do

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -867,8 +867,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
 
     Foundation.RpcMock
-    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-      :ok
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      cfg
     end)
 
     assert :ok =
@@ -892,8 +892,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
 
     Foundation.RpcMock
-    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-      :ok
+    |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+      cfg
     end)
 
     with_mock File, [:passthrough], rename: fn _source, _destination -> {:error, :any} end do
@@ -907,6 +907,50 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                         })
              end) =~ "Error while updating sys.config to: #{to_version}, reason: :any"
     end
+  end
+
+  @tag :capture_log
+  test "update_sys_config_from_installed_version/1 Elixir fails when a config provider crashes",
+       %{
+         node: node,
+         current_path: current_path,
+         to_version: to_version
+       } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+    original_sys_config = File.read!(sys_config_path)
+
+    # Providers run over RPC inside the still running old version. One that starts a process
+    # the application already owns works on a cold boot and fails here
+    badrpc =
+      {:badrpc,
+       {:EXIT,
+        {{:badmatch, {:error, {:already_started, self()}}},
+         [{Testapp.SecretsProvider, :load, 2, [file: ~c"lib/secrets.ex", line: 54]}]}}}
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, _module, :load, [_cfg, _arg], @expected_timeout -> badrpc end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:config_provider_failed, _mod, ^badrpc}} =
+                 UpgradeApp.update_sys_config_from_installed_version(%Execute{
+                   node: node,
+                   language: "elixir",
+                   current_path: current_path,
+                   to_version: to_version
+                 })
+      end)
+
+    assert log =~ "did not return a configuration"
+    assert log =~ "already_started"
+
+    # The failure must not be carried forward and written into sys.config
+    assert File.read!(sys_config_path) == original_sys_config
+    refute File.exists?("#{current_releases_version_path}/original.sys.config")
   end
 
   test "update_sys_config_from_installed_version/1 Erlang success", %{
@@ -952,8 +996,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1021,8 +1065,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1112,8 +1156,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1197,8 +1241,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1282,8 +1326,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1374,8 +1418,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
 
-      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
-        :ok
+      ^node, _module, :load, [cfg, _arg], @expected_timeout ->
+        cfg
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1021,6 +1021,67 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     end
   end
 
+  @tag :capture_log
+  test "execute/5 Elixir aborts before installing when a config provider fails", %{
+    node: node,
+    sname: sname,
+    app_name: app_name,
+    current_path: current_path,
+    new_path: new_path,
+    from_version: from_version,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
+
+    File.mkdir_p!(current_releases_version_path)
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+    original_sys_config = File.read!(sys_config_path)
+
+    Foundation.RpcMock
+    |> stub(:call, fn
+      ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
+        {:ok, to_version}
+
+      ^node, :code, :root_dir, [], @expected_timeout ->
+        ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
+
+      ^node, :systools, :make_relup, _params, @expected_timeout ->
+        :ok
+
+      ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
+        {:ok, :any, :any}
+
+      ^node, _module, :load, [_cfg, _arg], @expected_timeout ->
+        {:badrpc, {:EXIT, {{:badmatch, {:error, {:already_started, self()}}}, []}}}
+
+      ^node, :release_handler, :install_release, _params, @expected_timeout ->
+        flunk("install_release must not run once the configuration cannot be resolved")
+
+      ^node, :release_handler, :make_permanent, _params, @expected_timeout ->
+        flunk("make_permanent must not run once the configuration cannot be resolved")
+    end)
+
+    with_mock Node, [:passthrough], connect: fn ^node -> true end do
+      assert {:error, {:config_provider_failed, _mod, _reason}} =
+               UpgradeApp.execute(%Execute{
+                 node: node,
+                 sname: sname,
+                 name: app_name,
+                 language: "elixir",
+                 current_path: current_path,
+                 new_path: new_path,
+                 from_version: from_version,
+                 to_version: to_version
+               })
+    end
+
+    # Nothing was installed and nothing was rewritten, so the running node keeps the
+    # configuration it already had and the engine falls back to a full deployment
+    assert File.read!(sys_config_path) == original_sys_config
+    refute File.exists?("#{current_releases_version_path}/original.sys.config")
+  end
+
   test "execute/5 Elixir Application error", %{
     app_name: app_name,
     sname: sname,


### PR DESCRIPTION
Branched from `main`. Small and self-contained: no changes to how `sys.config` is written or restored.

## The problem

The Config Provider results were folded in without being checked:

```elixir
|> Enum.reduce(sys_config, fn {mod, arg}, cfg ->
  Rpc.call(node, mod, :load, [cfg, arg], @rpc_timeout)
end)
```

If the RPC fails or the provider crashes, the returned tuple becomes "the configuration". It is then written into `sys.config` by `:io_lib.format/2`, and `release_handler` reads back a perfectly valid term that simply is not a configuration. Nothing reports an error.

Providers execute over RPC **inside the still running old version**, which is where this shows up in practice. A provider that starts a process the application already owns works on a cold boot and fails during a hot upgrade:

```
{:badrpc, {:EXIT, {{:badmatch, {:error, {:already_started, #PID<...>}}},
 [{MyApp.SecretsProvider, :load, 2, [file: ~c"lib/secrets.ex", line: 54]}]}}}
```

## The fix

Mirror `Config.Provider.run_providers/2` (`config/provider.ex:403`) and require a list back from every provider. Otherwise return `{:error, {:config_provider_failed, module, reason}}` and leave `sys.config` untouched, so the upgrade fails cleanly and the engine falls back to a full deployment.

The log names the provider and points at the likely cause:

```
Config provider MyApp.SecretsProvider did not return a configuration on node
myapp-abc123@host, got: {:badrpc, {:EXIT, {{:badmatch, {:error, {:already_started,
#PID<...>}}}, ...}}}. Providers run inside the already running old version, so they
must tolerate a started system: one that starts a process the application already
owns fails here with {:already_started, pid} even though it works on a cold boot.
```

## Test change worth noting

The Config Provider stubs in the existing tests returned `:ok` rather than a configuration, so those tests never exercised the real code path - `sys_config` became `:ok` and the assertions still passed. They now return the config they are given, as a provider does.

## Reproduction

`update_sys_config_from_installed_version/1 Elixir fails when a config provider crashes` replays the exact `badrpc` shape above and asserts `sys.config` is byte identical afterwards and no `original.sys.config` is left behind. Without the fix the tuple reaches `:io_lib.format/2` and is written to the file.

## Risk assessment

**Impact:** a failing config provider aborts the hot upgrade with a named error and falls back to a full deployment, instead of installing a release with a corrupted configuration. No change for providers that behave.

**Blast radius:** `apps/deployer/lib/deployer/hot_upgrade/application.ex` only, in the Elixir path of `update_sys_config_from_installed_version/1`. Erlang releases do not run config providers and are untouched. No changes to `foundation`, `sentinel`, `host` or `deployex_web`, nor to the deployment engine.

**Regression risk:** low. The `reduce` becomes a `reduce_while` with the same accumulator and identical behaviour when every provider returns a list, which is the contract Elixir already enforces at boot.

**Rollback:** plain commit revert. No data or configuration migration.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and the `deployer` suite (167 tests, 1 pre-existing skip) pass locally. `mix dialyzer` was not run locally because the PLT is stale and needs a full rebuild; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
