### PR TITLE
fix(deployer): apply the runtime configuration through a relup hook instead of sys.config

### DIFF
--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -48,8 +48,24 @@ defmodule Deployer.HotUpgrade.Application do
      (see `install_runtime_config_hook/2`), which runs inside `install_release/2` right after
      the environment has been reset and before any `suspend` or `code_change` observes it.
 
-     Note that the providers execute within the current version, meaning the system is not
-     immediately prepared to execute hot upgrades when configuration changes occur.
+     What that means for a configuration change between versions:
+
+     * A changed or removed key is picked up. `change_appl_data/3` calls `del_env/1` before
+       `add_env/2`, rebuilding the environment of each application from the new `.app` file and
+       the new build time sys.config, and `change_application_data/2` replaces `conf_data`
+       rather than merging it. So a key deleted in the new version does not survive, not even
+       through the `persistent: true` used here, and the hook only adds back what the new
+       version actually resolves.
+
+     * A changed `runtime.exs` is picked up, since the new version's sys.config points the
+       `Config.Reader` provider at the new version's file, which `unpack_release/1` has already
+       written to disk. It is evaluated by the code the running node has loaded, so it must not
+       depend on modules or language features that only arrive with the new release.
+
+     * A changed Config Provider is NOT picked up. The provider modules execute over RPC on the
+       running node, which is still on the old version - `install_release/2` has not run yet.
+       The old implementation is what resolves the configuration, so a fix to a provider only
+       takes effect after a full deployment has made it the running version.
 
   References:
 

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -603,6 +603,10 @@ defmodule Deployer.HotUpgrade.Application do
           "Error while adding the runtime config hook to: #{relup_path}, reason: #{inspect(reason)}"
         )
 
+        # Nothing will consume the stash now, and it holds whatever the Config Providers
+        # produced, secrets included
+        _ = Rpc.call(node, :persistent_term, :erase, [@runtime_config_key], @rpc_timeout)
+
         {:error, reason}
     end
   end
@@ -710,21 +714,30 @@ defmodule Deployer.HotUpgrade.Application do
     do: {from_vsn, descr, [instruction | script]}
 
   # Abstract forms for:
-  #   application:set_env(persistent_term:get(Key), [{persistent, true}])
+  #   application:set_env(persistent_term:get(Key), [{persistent, true}]),
+  #   persistent_term:erase(Key)
+  #
   # Forms are plain terms, so unlike the configuration they survive the relup file, and
   # erl_eval is in stdlib so nothing has to be compiled or loaded into the target node.
+  #
+  # The hook erases its own stash as its last act. The resolved configuration holds whatever
+  # the Config Providers produced, secrets included, so it must not outlive the upgrade that
+  # needed it.
   @spec runtime_config_hook_forms() :: [tuple()]
   defp runtime_config_hook_forms do
     l = 0
-    {app, key} = @runtime_config_key
+
+    key_form =
+      {:tuple, l,
+       [{:atom, l, elem(@runtime_config_key, 0)}, {:atom, l, elem(@runtime_config_key, 1)}]}
 
     [
       {:call, l, {:remote, l, {:atom, l, :application}, {:atom, l, :set_env}},
        [
-         {:call, l, {:remote, l, {:atom, l, :persistent_term}, {:atom, l, :get}},
-          [{:tuple, l, [{:atom, l, app}, {:atom, l, key}]}]},
+         {:call, l, {:remote, l, {:atom, l, :persistent_term}, {:atom, l, :get}}, [key_form]},
          {:cons, l, {:tuple, l, [{:atom, l, :persistent}, {:atom, l, true}]}, {nil, l}}
-       ]}
+       ]},
+      {:call, l, {:remote, l, {:atom, l, :persistent_term}, {:atom, l, :erase}}, [key_form]}
     ]
   end
 

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -17,23 +17,39 @@ defmodule Deployer.HotUpgrade.Application do
        a. Unpack a release using release_handler:unpack_release
        b. Create a relup file using systools:make_relup
        c. Check Install release using release_handler:check_install_release
-         i. Request via RPC to run  ConfigProvider and Runtime and populate sys.config (Only ELixir)
+         i. Request via RPC to run ConfigProvider and Runtime and resolve the config (Only Elixir)
+         ii. Add a hook to the relup that applies that config during the install (Only Elixir)
        d. Install the release using release_handler:install_release
        e. Make the release permanent using release_handler:make_permanent
-         i. Return original empty sys.config (Only ELixir)
 
     Note that only upgrades are permitted in this project, and in the event of
      failure, the system will revert to a full deployment.
 
   4. ATTENTION:
-     The sys.config file contains all application configurations and is not loaded during a
-     hot HotUpgrade. For Elixir applications, Config Provider and Runtime are codes that executes
-     when the application is starting and are required for fetching information.
-     To address this, several steps are included in this module to load the new
-     version of sys.config and utilize the RPC channel to execute runtime.exs and the config
-     provider. It's important to note that these actions occur within the current version,
-     meaning the system is not immediately prepared to execute hot upgrades when configuration
-     changes occur.
+     For Elixir applications, `runtime.exs` and the Config Providers only execute when the
+     application boots, never during a hot upgrade. Worse, `release_handler` actively undoes
+     their result: `change_appl_data/3` rebuilds the environment of EVERY loaded application
+     from the build time sys.config, so everything `runtime.exs` produced is gone the moment
+     the release is installed.
+
+     This module therefore resolves that configuration itself over the RPC channel and applies
+     it with `:application.set_env/2`, the primitive `Config.Provider` uses on a cold start
+     through `Application.put_all_env/2`.
+
+     Writing the resolved configuration back into sys.config, which is what this module used
+     to do, only works for values `:file.consult/1` can read back. A resolved configuration can
+     hold values with no textual term syntax, such as the closure in
+     `customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]`
+     for an Ecto Repo. That is printed as `#Fun<...>`, the file stops parsing, and OTP does not
+     report it: `change_appl_data/3` falls back to an empty config and every application
+     silently reverts to its compile time environment while the upgrade reports success.
+
+     sys.config is now only read. The configuration is applied by a hook spliced into the relup
+     (see `install_runtime_config_hook/2`), which runs inside `install_release/2` right after
+     the environment has been reset and before any `suspend` or `code_change` observes it.
+
+     Note that the providers execute within the current version, meaning the system is not
+     immediately prepared to execute hot upgrades when configuration changes occur.
 
   References:
 
@@ -56,11 +72,18 @@ defmodule Deployer.HotUpgrade.Application do
   @check_timeout 300_000
   @behaviour Deployer.HotUpgrade.Adapter
   @events_topic "deployex::hotupgrade::events"
+  @runtime_config_key {:deployex, :runtime_config}
 
   alias Deployer.HotUpgrade.Check
   alias Deployer.HotUpgrade.Execute
   alias Deployer.HotUpgrade.Jellyfish
   alias Foundation.Rpc
+
+  @typedoc """
+  The configuration produced by `runtime.exs` and the Config Providers of the version being
+  installed. Same shape as sys.config itself: `[{app, [{key, value}]}]`.
+  """
+  @type runtime_config :: [{app :: atom(), env :: keyword()}]
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -152,12 +175,12 @@ defmodule Deployer.HotUpgrade.Application do
          :ok <- make_relup(data),
          :ok <- notify_progress(data.sname, "Checking release can be installed"),
          :ok <- check_install_release(data),
-         :ok <- notify_progress(data.sname, "Updating sys.config file"),
-         :ok <- update_sys_config_from_installed_version(data),
+         :ok <- notify_progress(data.sname, "Resolving the runtime configuration"),
+         {:ok, runtime_config} <- resolve_runtime_config(data),
+         :ok <- notify_progress(data.sname, "Adding the runtime configuration to the relup"),
+         :ok <- install_runtime_config_hook(data, runtime_config),
          :ok <- notify_progress(data.sname, "Installing release"),
          :ok <- install_release(data),
-         :ok <- notify_progress(data.sname, "Returning original sys.config file"),
-         :ok <- return_original_sys_config(data),
          :ok <- notify_make_permanent(data.make_permanent_async, data.sname, data.to_version),
          :ok <- permfy(data),
          :ok <- notify_complete_ok(data.make_permanent_async, data.sname) do
@@ -502,51 +525,87 @@ defmodule Deployer.HotUpgrade.Application do
     releases |> Enum.map(fn {_name, version, _modules, status} -> {status, version} end)
   end
 
-  @spec update_sys_config_from_installed_version(Execute.t()) :: :ok | {:error, any()}
-  def update_sys_config_from_installed_version(%Execute{
+  @doc """
+  Resolve the configuration of the version being installed.
+
+  Reads the build time sys.config of the new version and runs its `runtime.exs` and Config
+  Providers over RPC, producing exactly the configuration the application would have had on a
+  cold boot. The file is only read, never written.
+  """
+  @spec resolve_runtime_config(Execute.t()) :: {:ok, runtime_config()} | {:error, any()}
+  def resolve_runtime_config(%Execute{
         node: node,
         language: "elixir",
         current_path: current_path,
         to_version: to_version
       }) do
-    rel_vsn_dir = "#{current_path}/releases/#{to_version}"
-    sys_config_path = "#{rel_vsn_dir}/sys.config"
-    original_sys_config_file = "#{rel_vsn_dir}/original.sys.config"
-    # Read the build time config from build.config
-    {:ok, [sys_config]} = :file.consult(sys_config_path)
+    sys_config_path = "#{current_path}/releases/#{to_version}/sys.config"
 
-    # In this step, it will run the runtime.exs and Config Providers for the current version
-    with {:ok, sys_config} <- run_config_providers(node, sys_config),
-         :ok <- File.rename(sys_config_path, original_sys_config_file),
-         :ok <-
-           File.write(sys_config_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [sys_config])) do
+    # Read the build time config, then run runtime.exs and the Config Providers on top of it
+    case :file.consult(sys_config_path) do
+      {:ok, [sys_config]} ->
+        run_config_providers(node, sys_config)
+
+      reason ->
+        Logger.error("Error while reading #{sys_config_path}, reason: #{inspect(reason)}")
+
+        {:error, {:unreadable_sys_config, reason}}
+    end
+  end
+
+  def resolve_runtime_config(_data), do: {:ok, []}
+
+  @doc """
+  Add a hook to the generated relup that applies the resolved configuration from inside
+  `release_handler:install_release/2`.
+
+  The configuration used to be written back into sys.config, but that only works for values
+  `:file.consult/1` can read back. An anonymous function has no textual term syntax and is
+  printed as `#Fun<...>`, which OTP does not report: the file stops parsing,
+  `change_appl_data/3` falls back to an empty config and every application silently reverts to
+  its compile time environment.
+
+  `change_appl_data/3` rebuilds that environment before `eval_script/5` runs the relup, so an
+  instruction at the head of the script executes once the environment has been reset and
+  before any `suspend`, `code_change` or `resume` can observe it.
+
+  The configuration cannot travel in the relup either, which `release_handler` also reads with
+  `:file.consult/1`. It is stashed in `:persistent_term` over RPC, which survives
+  `change_appl_data/3` because it is not application environment, and the relup carries only
+  abstract forms, which are plain terms:
+
+      {apply, {erl_eval, exprs, [Forms, []]}}
+
+  evaluating `application:set_env(persistent_term:get(Key), [{persistent, true}])`. That is the
+  primitive `Config.Provider` uses on a cold start through `Application.put_all_env/2`, and
+  nothing is serialized on the way. No module is compiled or loaded into the target, so this
+  does not depend on the OTP version the managed application was built with.
+  """
+  @spec install_runtime_config_hook(Execute.t(), runtime_config()) :: :ok | {:error, any()}
+  def install_runtime_config_hook(_data, []), do: :ok
+
+  def install_runtime_config_hook(
+        %Execute{node: node, current_path: current_path, to_version: to_version},
+        runtime_config
+      ) do
+    relup_path = "#{current_path}/releases/#{to_version}/relup"
+
+    with :ok <- stash_runtime_config(node, runtime_config),
+         :ok <- splice_runtime_config_hook(relup_path) do
+      Logger.info("Runtime config hook added to the relup at: #{relup_path}")
+
       :ok
     else
       {:error, reason} ->
+        # Installing without the hook would reset every application to its compile time
+        # environment, so fail here and let the engine run a full deployment instead
         Logger.error(
-          "Error while updating sys.config to: #{to_version}, reason: #{inspect(reason)}"
+          "Error while adding the runtime config hook to: #{relup_path}, reason: #{inspect(reason)}"
         )
 
         {:error, reason}
     end
   end
-
-  def update_sys_config_from_installed_version(_data), do: :ok
-
-  @spec return_original_sys_config(Execute.t()) :: :ok | {:error, any()}
-  def return_original_sys_config(%Execute{
-        language: "elixir",
-        current_path: current_path,
-        to_version: to_version
-      }) do
-    rel_vsn_dir = "#{current_path}/releases/#{to_version}"
-    sys_config_path = "#{rel_vsn_dir}/sys.config"
-    original_sys_config_file = "#{rel_vsn_dir}/original.sys.config"
-
-    File.rename(original_sys_config_file, sys_config_path)
-  end
-
-  def return_original_sys_config(_data), do: :ok
 
   @spec root_dir(node :: node()) :: any()
   def root_dir(node), do: Rpc.call(node, :code, :root_dir, [], @rpc_timeout)
@@ -612,6 +671,61 @@ defmodule Deployer.HotUpgrade.Application do
       status: :error,
       message: message
     })
+  end
+
+  @spec stash_runtime_config(node(), runtime_config()) :: :ok | {:error, any()}
+  defp stash_runtime_config(node, runtime_config) do
+    case Rpc.call(
+           node,
+           :persistent_term,
+           :put,
+           [@runtime_config_key, runtime_config],
+           @rpc_timeout
+         ) do
+      :ok -> :ok
+      reason -> {:error, {:stash_failed, reason}}
+    end
+  end
+
+  @spec splice_runtime_config_hook(binary()) :: :ok | {:error, any()}
+  defp splice_runtime_config_hook(relup_path) do
+    instruction = {:apply, {:erl_eval, :exprs, [runtime_config_hook_forms(), []]}}
+
+    case :file.consult(relup_path) do
+      {:ok, [{to_vsn, up, down}]} ->
+        patched = {to_vsn, Enum.map(up, &prepend_instruction(&1, instruction)), down}
+        File.write(relup_path, :io_lib.format(~c"%% coding: utf-8~n~tp.~n", [patched]))
+
+      reason ->
+        {:error, {:unreadable_relup, reason}}
+    end
+  end
+
+  # An emulator upgrade restarts the VM, which resolves the configuration again on boot, so
+  # there is nothing to apply and the script must keep restart_new_emulator at its head
+  defp prepend_instruction({from_vsn, descr, [:restart_new_emulator | _] = script}, _instruction),
+    do: {from_vsn, descr, script}
+
+  defp prepend_instruction({from_vsn, descr, script}, instruction),
+    do: {from_vsn, descr, [instruction | script]}
+
+  # Abstract forms for:
+  #   application:set_env(persistent_term:get(Key), [{persistent, true}])
+  # Forms are plain terms, so unlike the configuration they survive the relup file, and
+  # erl_eval is in stdlib so nothing has to be compiled or loaded into the target node.
+  @spec runtime_config_hook_forms() :: [tuple()]
+  defp runtime_config_hook_forms do
+    l = 0
+    {app, key} = @runtime_config_key
+
+    [
+      {:call, l, {:remote, l, {:atom, l, :application}, {:atom, l, :set_env}},
+       [
+         {:call, l, {:remote, l, {:atom, l, :persistent_term}, {:atom, l, :get}},
+          [{:tuple, l, [{:atom, l, app}, {:atom, l, key}]}]},
+         {:cons, l, {:tuple, l, [{:atom, l, :persistent}, {:atom, l, true}]}, {nil, l}}
+       ]}
+    ]
   end
 
   # Run runtime.exs and the Config Providers for the version being installed.

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1050,6 +1050,55 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
   end
 
   @tag :capture_log
+  test "install_runtime_config_hook/2 restores every application of an umbrella in one call", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+    write_relup!(relup_path)
+
+    # An umbrella release is still one OTP release with one sys.config and one relup, it just
+    # holds several applications. change_appl_data/3 resets all of them, so the hook has to
+    # bring all of them back
+    runtime_config = [
+      core: [{Core.Repo, [url: "postgres://host/db"]}],
+      worker: [poll_ms: 5_000],
+      web: [{Web.Endpoint, [secret_key_base: "s3cret"]}]
+    ]
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{node: node, current_path: current_path, to_version: to_version},
+               runtime_config
+             )
+
+    assert {:ok, [{_to, [{_from, _descr, script}], _}]} = :file.consult(relup_path)
+    assert [{:apply, {:erl_eval, :exprs, [forms, []]}} | _] = script
+
+    :persistent_term.put({:deployex, :runtime_config}, runtime_config)
+    on_exit(fn -> :persistent_term.erase({:deployex, :runtime_config}) end)
+
+    on_exit(fn ->
+      Application.delete_env(:core, Core.Repo)
+      Application.delete_env(:worker, :poll_ms)
+      Application.delete_env(:web, Web.Endpoint)
+    end)
+
+    assert {:value, _last, _bindings} = :erl_eval.exprs(forms, [])
+
+    assert Application.get_env(:core, Core.Repo) == [url: "postgres://host/db"]
+    assert Application.get_env(:worker, :poll_ms) == 5_000
+    assert Application.get_env(:web, Web.Endpoint) == [secret_key_base: "s3cret"]
+  end
+
+  @tag :capture_log
   test "install_runtime_config_hook/2 leaves an emulator restart script untouched", %{
     node: node,
     current_path: current_path,

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1041,8 +1041,12 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     on_exit(fn -> :persistent_term.erase({:deployex, :runtime_config}) end)
     on_exit(fn -> Application.delete_env(:testapp, Testapp.Repo) end)
 
-    assert {:value, :ok, _bindings} = :erl_eval.exprs(forms, [])
+    assert {:value, _last, _bindings} = :erl_eval.exprs(forms, [])
     assert Application.get_env(:testapp, Testapp.Repo)[:ssl_opts][:match_fun] == match_fun
+
+    # The stash holds whatever the Config Providers produced, secrets included, so the hook
+    # must erase it rather than leave it on the node
+    assert :persistent_term.get({:deployex, :runtime_config}, :erased) == :erased
   end
 
   @tag :capture_log
@@ -1082,8 +1086,17 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     current_path: current_path,
     to_version: to_version
   } do
+    test_pid = self()
+
     Foundation.RpcMock
-    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+    |> stub(:call, fn
+      ^node, :persistent_term, :put, _args, @expected_timeout ->
+        :ok
+
+      ^node, :persistent_term, :erase, args, @expected_timeout ->
+        send(test_pid, {:erased, args})
+        true
+    end)
 
     # Installing without the hook would reset every application, so this must not be silent
     assert capture_log(fn ->
@@ -1093,6 +1106,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                         testapp: [{Testapp.Repo, []}]
                       )
            end) =~ "Error while adding the runtime config hook"
+
+    # Nothing will consume the stash now, so it must not be left on the node
+    assert_receive {:erased, [{:deployex, :runtime_config}]}
   end
 
   @tag :capture_log

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -150,6 +150,13 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     }
   end
 
+  # systools:make_relup/4 is stubbed in these tests, so the relup it would have produced on
+  # the target has to be written by hand for the runtime config hook to patch
+  defp write_relup!(path) do
+    script = [{:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}}]
+    File.write!(path, :io_lib.format(~c"~tp.~n", [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}]))
+  end
+
   @tag :capture_log
   test "connect/1 success connecting to the monitored app", %{node: node} do
     with_mock Node, connect: fn ^node -> true end do
@@ -821,67 +828,41 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     assert :ok = UpgradeApp.permfy(%Execute{make_permanent_async: true})
   end
 
-  @tag :capture_log
-  test "return_original_sys_config/1 Elixir success", %{
-    current_path: current_path,
-    to_version: to_version
-  } do
-    current_releases_version_path = "#{current_path}/releases/#{to_version}"
-
-    File.mkdir_p!(current_releases_version_path)
-
-    File.write("#{current_releases_version_path}/original.sys.config", "empty")
-    File.rm("#{current_releases_version_path}/sys.config")
-
-    assert :ok =
-             UpgradeApp.return_original_sys_config(%Execute{
-               language: "elixir",
-               current_path: current_path,
-               to_version: to_version
-             })
-
-    assert File.exists?("#{current_releases_version_path}/sys.config")
-  end
-
-  test "return_original_sys_config/1 Erlang success", %{
-    current_path: current_path,
-    to_version: to_version
-  } do
-    assert :ok =
-             UpgradeApp.return_original_sys_config(%Execute{
-               language: "erlang",
-               current_path: current_path,
-               to_version: to_version
-             })
-  end
-
-  @tag :capture_log
-  test "update_sys_config_from_installed_version/1 Elixir success", %{
+  test "resolve_runtime_config/1 Elixir success", %{
     node: node,
     current_path: current_path,
     to_version: to_version
   } do
     current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    sys_config_path = "#{current_releases_version_path}/sys.config"
 
     File.mkdir_p!(current_releases_version_path)
-    File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    File.cp!("./test/support/files/sys.config", sys_config_path)
+    write_relup!("#{current_releases_version_path}/relup")
+    original_sys_config = File.read!(sys_config_path)
 
     Foundation.RpcMock
     |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
-      cfg
+      Keyword.put(cfg, :from_runtime_exs, answer: 42)
     end)
 
-    assert :ok =
-             UpgradeApp.update_sys_config_from_installed_version(%Execute{
+    assert {:ok, config} =
+             UpgradeApp.resolve_runtime_config(%Execute{
                node: node,
                language: "elixir",
                current_path: current_path,
                to_version: to_version
              })
+
+    assert config[:from_runtime_exs] == [answer: 42]
+    assert config[:logger][:level] == :info
+
+    # sys.config is only read now, the release directory must come out untouched
+    assert File.read!(sys_config_path) == original_sys_config
+    refute File.exists?("#{current_releases_version_path}/original.sys.config")
   end
 
-  @tag :skip
-  test "update_sys_config_from_installed_version/1 Elixir error", %{
+  test "resolve_runtime_config/1 Elixir carries values sys.config could never hold", %{
     node: node,
     current_path: current_path,
     to_version: to_version
@@ -890,27 +871,55 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
+
+    # The exact value an Ecto Repo gets for a verify_peer TLS connection. Written to
+    # sys.config it prints as #Fun<...> and the file stops parsing
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+
+    repo_config = [
+      url: "postgres://user:pass@host:5432/db",
+      ssl_opts: [verify: :verify_peer, customize_hostname_check: [match_fun: match_fun]]
+    ]
 
     Foundation.RpcMock
     |> stub(:call, fn ^node, _module, :load, [cfg, _arg], @expected_timeout ->
-      cfg
+      Keyword.update!(cfg, :testapp, &Keyword.put(&1, Testapp.Repo, repo_config))
     end)
 
-    with_mock File, [:passthrough], rename: fn _source, _destination -> {:error, :any} end do
-      assert capture_log(fn ->
-               assert {:error, :any} =
-                        UpgradeApp.update_sys_config_from_installed_version(%Execute{
-                          node: node,
-                          language: "elixir",
-                          current_path: current_path,
-                          to_version: to_version
-                        })
-             end) =~ "Error while updating sys.config to: #{to_version}, reason: :any"
-    end
+    assert {:ok, config} =
+             UpgradeApp.resolve_runtime_config(%Execute{
+               node: node,
+               language: "elixir",
+               current_path: current_path,
+               to_version: to_version
+             })
+
+    fun = config[:testapp][Testapp.Repo][:ssl_opts][:customize_hostname_check][:match_fun]
+    assert fun.({:dns_id, ~c"a.example.com"}, {:dNSName, ~c"*.example.com"})
   end
 
   @tag :capture_log
-  test "update_sys_config_from_installed_version/1 Elixir fails when a config provider crashes",
+  test "resolve_runtime_config/1 Elixir fails when sys.config cannot be read", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    File.mkdir_p!("#{current_path}/releases/#{to_version}")
+
+    assert capture_log(fn ->
+             assert {:error, {:unreadable_sys_config, _reason}} =
+                      UpgradeApp.resolve_runtime_config(%Execute{
+                        node: node,
+                        language: "elixir",
+                        current_path: current_path,
+                        to_version: to_version
+                      })
+           end) =~ "Error while reading"
+  end
+
+  @tag :capture_log
+  test "resolve_runtime_config/1 Elixir fails when a config provider crashes",
        %{
          node: node,
          current_path: current_path,
@@ -921,6 +930,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", sys_config_path)
+    write_relup!("#{current_releases_version_path}/relup")
     original_sys_config = File.read!(sys_config_path)
 
     # Providers run over RPC inside the still running old version. One that starts a process
@@ -937,7 +947,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     log =
       capture_log(fn ->
         assert {:error, {:config_provider_failed, _mod, ^badrpc}} =
-                 UpgradeApp.update_sys_config_from_installed_version(%Execute{
+                 UpgradeApp.resolve_runtime_config(%Execute{
                    node: node,
                    language: "elixir",
                    current_path: current_path,
@@ -953,18 +963,136 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     refute File.exists?("#{current_releases_version_path}/original.sys.config")
   end
 
-  test "update_sys_config_from_installed_version/1 Erlang success", %{
+  test "resolve_runtime_config/1 Erlang success", %{
     node: node,
     new_path: new_path,
     to_version: to_version
   } do
-    assert :ok =
-             UpgradeApp.update_sys_config_from_installed_version(%Execute{
+    assert {:ok, []} =
+             UpgradeApp.resolve_runtime_config(%Execute{
                node: node,
                language: "erlang",
                new_path: new_path,
                to_version: to_version
              })
+  end
+
+  test "install_runtime_config_hook/2 makes no rpc call when there is nothing to apply", %{
+    node: node
+  } do
+    Foundation.RpcMock
+    |> stub(:call, fn _node, _module, _function, _args, _timeout ->
+      flunk("no rpc call expected")
+    end)
+
+    assert :ok = UpgradeApp.install_runtime_config_hook(%Execute{node: node}, [])
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 stashes the config and heads the relup script", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+
+    original_script = [
+      {:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}},
+      {:suspend, [:test_app_sm]},
+      {:code_change, :up, [{:test_app_sm, []}]},
+      {:resume, [:test_app_sm]}
+    ]
+
+    File.write!(
+      relup_path,
+      :io_lib.format(~c"~tp.~n", [{~c"0.2.0", [{~c"0.1.0", ~c"", original_script}], []}])
+    )
+
+    match_fun = :public_key.pkix_verify_hostname_match_fun(:https)
+    runtime_config = [testapp: [{Testapp.Repo, [ssl_opts: [match_fun: match_fun]]}]]
+    test_pid = self()
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, args, @expected_timeout ->
+      send(test_pid, {:stashed, args})
+      :ok
+    end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{node: node, current_path: current_path, to_version: to_version},
+               runtime_config
+             )
+
+    # The configuration itself cannot travel in the relup, it goes over RPC
+    assert_receive {:stashed, [{:deployex, :runtime_config}, ^runtime_config]}
+
+    # release_handler reads the relup with :file.consult/1 too, so the patched file must parse
+    assert {:ok, [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}]} = :file.consult(relup_path)
+
+    # Heading the script puts it after change_appl_data/3 and before suspend/code_change
+    assert [{:apply, {:erl_eval, :exprs, [forms, []]}} | ^original_script] = script
+
+    # The forms must evaluate to the set_env call, with no module loaded into the target
+    :persistent_term.put({:deployex, :runtime_config}, runtime_config)
+    on_exit(fn -> :persistent_term.erase({:deployex, :runtime_config}) end)
+    on_exit(fn -> Application.delete_env(:testapp, Testapp.Repo) end)
+
+    assert {:value, :ok, _bindings} = :erl_eval.exprs(forms, [])
+    assert Application.get_env(:testapp, Testapp.Repo)[:ssl_opts][:match_fun] == match_fun
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 leaves an emulator restart script untouched", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    current_releases_version_path = "#{current_path}/releases/#{to_version}"
+    relup_path = "#{current_releases_version_path}/relup"
+
+    File.mkdir_p!(current_releases_version_path)
+
+    script = [:restart_new_emulator, {:load_object_code, {:testapp, ~c"0.2.0", [:test_app_sm]}}]
+
+    File.write!(
+      relup_path,
+      :io_lib.format(~c"~tp.~n", [{~c"0.2.0", [{~c"0.1.0", ~c"", script}], []}])
+    )
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    assert :ok =
+             UpgradeApp.install_runtime_config_hook(
+               %Execute{node: node, current_path: current_path, to_version: to_version},
+               testapp: [{Testapp.Repo, []}]
+             )
+
+    # The VM restarts and Config.Provider resolves the configuration again on boot
+    assert {:ok, [{_to, [{_from, _descr, ^script}], _}]} = :file.consult(relup_path)
+  end
+
+  @tag :capture_log
+  test "install_runtime_config_hook/2 fails the upgrade when the relup cannot be read", %{
+    node: node,
+    current_path: current_path,
+    to_version: to_version
+  } do
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :persistent_term, :put, _args, @expected_timeout -> :ok end)
+
+    # Installing without the hook would reset every application, so this must not be silent
+    assert capture_log(fn ->
+             assert {:error, {:unreadable_relup, _reason}} =
+                      UpgradeApp.install_runtime_config_hook(
+                        %Execute{node: node, current_path: current_path, to_version: to_version},
+                        testapp: [{Testapp.Repo, []}]
+                      )
+           end) =~ "Error while adding the runtime config hook"
   end
 
   @tag :capture_log
@@ -981,6 +1109,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
 
     Foundation.RpcMock
     |> stub(:call, fn
@@ -998,6 +1127,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
       ^node, _module, :load, [cfg, _arg], @expected_timeout ->
         cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1036,6 +1168,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", sys_config_path)
+    write_relup!("#{current_releases_version_path}/relup")
     original_sys_config = File.read!(sys_config_path)
 
     Foundation.RpcMock
@@ -1111,6 +1244,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
 
     Foundation.RpcMock
     |> stub(:call, fn
@@ -1128,6 +1262,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
       ^node, _module, :load, [cfg, _arg], @expected_timeout ->
         cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1172,13 +1309,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Checking release can be installed"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Resolving the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Returning original sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Adding the runtime configuration to the relup"},
                      1_000
 
       assert_receive {:hot_upgrade_complete, ^node, ^sname, :ok,
@@ -1202,6 +1341,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
 
     Foundation.RpcMock
     |> stub(:call, fn
@@ -1219,6 +1359,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
       ^node, _module, :load, [cfg, _arg], @expected_timeout ->
         cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1256,13 +1399,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Checking release can be installed"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Resolving the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Returning original sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Adding the runtime configuration to the relup"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Making release 0.2.0 permanent"},
@@ -1287,6 +1432,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
 
     Foundation.RpcMock
     |> stub(:call, fn
@@ -1304,6 +1450,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
       ^node, _module, :load, [cfg, _arg], @expected_timeout ->
         cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1341,13 +1490,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Checking release can be installed"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Resolving the runtime configuration"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                      1_000
 
-      assert_receive {:hot_upgrade_progress, ^node, ^sname, "Returning original sys.config file"},
+      assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                      "Adding the runtime configuration to the relup"},
                      1_000
 
       assert_receive {:hot_upgrade_progress, ^node, ^sname, "Making release 0.2.0 permanent"},
@@ -1372,6 +1523,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
 
     Foundation.RpcMock
     |> stub(:call, fn
@@ -1389,6 +1541,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
       ^node, _module, :load, [cfg, _arg], @expected_timeout ->
         cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1429,14 +1584,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                                "Checking release can be installed"},
                               1_000
 
-               assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+               assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                               "Resolving the runtime configuration"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname,
-                               "Returning original sys.config file"},
+                               "Adding the runtime configuration to the relup"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname,
@@ -1464,6 +1620,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
     File.mkdir_p!(current_releases_version_path)
     File.cp!("./test/support/files/sys.config", "#{current_releases_version_path}/sys.config")
+    write_relup!("#{current_releases_version_path}/relup")
 
     Foundation.RpcMock
     |> stub(:call, fn
@@ -1481,6 +1638,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
       ^node, _module, :load, [cfg, _arg], @expected_timeout ->
         cfg
+
+      ^node, :persistent_term, :put, _params, @expected_timeout ->
+        :ok
 
       ^node, :release_handler, :install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1529,14 +1689,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                                "Checking release can be installed"},
                               1_000
 
-               assert_receive {:hot_upgrade_progress, ^node, ^sname, "Updating sys.config file"},
+               assert_receive {:hot_upgrade_progress, ^node, ^sname,
+                               "Resolving the runtime configuration"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname, "Installing release"},
                               1_000
 
                assert_receive {:hot_upgrade_progress, ^node, ^sname,
-                               "Returning original sys.config file"},
+                               "Adding the runtime configuration to the relup"},
                               1_000
 
                assert_receive {:hot_upgrade_complete, ^node, ^sname, :error,

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -7,6 +7,22 @@ DeployEx supports hot-upgrades for both monitored applications and DeployEx itse
  * The new release modified/deleted/added the `runtime.exs` file
  * The new release modified/deleted/added config_provider files
 
+### What happens to configuration during a hot-upgrade
+
+`runtime.exs` and the Config Providers only run when an application boots, so DeployEx resolves them itself over the RPC channel and applies the result during the install.
+Understanding the order matters, because it decides which of your configuration changes actually take effect.
+
+`release_handler:install_release/2` first rebuilds the environment of **every** loaded application from the new `.app` files and the new build time `sys.config`, and only then runs the relup instructions.
+DeployEx adds a hook at the head of that relup which applies the resolved configuration, so the environment is complete before any process is suspended or has its code changed.
+
+What that means in practice:
+
+ * **Changed or removed keys are applied.** The environment is deleted and rebuilt, not merged, so a key you delete in the new version is really gone after the upgrade.
+ * **A changed `runtime.exs` is applied.** DeployEx reads the new version's file, which has already been unpacked. It is evaluated by the code the running node has loaded, so it must not rely on modules or language features that only arrive with the new release.
+ * **A changed Config Provider is NOT applied.** Provider modules run on the node in its current version, before the new code is installed, so the old implementation is what resolves the configuration. A fix to a provider only takes effect once a full deployment has made it the running version.
+
+The last point is the reason for the `config_provider` entry in the list above, and it applies to the provider's own code, not to the values it produces.
+
 > [!WARNING]
 > [Jellyfish][jyf] allows you to hot-upgrade dependencies, but before performing a hot-upgrade for any dependency, treat it with the same caution as your own application code. Check if the dependency officially supports hot-upgrades between the specific versions you're upgrading, review the changelog for breaking changes or structural modifications (e.g., process state changes, supervision tree changes, API changes), and pay special attention to stateful processes like GenServers, Agents, and ETS tables that may require special handling or coordinated state migration.
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.8"
+  def version, do: "0.9.9-rc1"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
Builds on #261. Branched from `main`.

## The bug

A hot upgrade silently wiped the runtime configuration of **every** application on the node whenever any config value had no textual term syntax.

To carry `runtime.exs` across an upgrade, the resolved configuration was written back into the new version's `sys.config`. That only works for values `:file.consult/1` can read back. This one, which is what an Ecto Repo gets for a `verify_peer` TLS connection, cannot be:

```elixir
customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
```

`pkix_verify_hostname_match_fun/1` returns a **closure**, printed as `#Fun<public_key.6.43236260>`:

```
:file.consult -> {:error, {N, :erl_parse, [~c"syntax error before: ", ~c"Fun"]}}
```

`sys.config` is a single term, so one such value invalidates the whole file. And OTP does not report it (`release_handler.erl:2339`):

```erlang
Config = case consult(filename:join(Dir, "sys.config"), Masters) of
             {ok, [Conf]} -> Conf;
             _ -> []                      %% parse error swallowed
         end,
application_controller:change_application_data(Appls, Config)
```

`do_change_apps/3` then rebuilds every loaded application's env via `merge_app_env(Env, ConfEnv)` where `ConfEnv` is always `[]`, so each falls back to its `.app` file defaults. `install_release/2` still returns `{ok, _, _}`: the upgrade reports success while logger level, endpoint config, mailer, storage adapter and everything else from `runtime.exs` is gone.

## The fix

**sys.config is now only read, never written.** The configuration is applied by a hook spliced into the relup.

`change_appl_data/3` resets the environment **before** `eval_script/5` runs the relup (`release_handler.erl:1735-1738`), and `{apply, {M,F,A}}` is a real instruction (`release_handler_1.erl:463`, literally `apply(M, F, A)`). So an instruction at the **head** of the script runs after the reset and before any `suspend`, `code_change` or `resume` observes it.

The configuration cannot travel in the relup either - `release_handler` consults that too (`release_handler.erl:2215`). It is stashed in `:persistent_term` over RPC, which survives `change_appl_data/3` because it is not application environment, and the relup carries only abstract forms, which are plain terms:

```erlang
{apply,{erl_eval,exprs,
    [[{call,0,{remote,0,{atom,0,application},{atom,0,set_env}},
        [{call,0,{remote,0,{atom,0,persistent_term},{atom,0,get}},
             [{tuple,0,[{atom,0,deployex},{atom,0,runtime_config}]}]},
         {cons,0,{tuple,0,[{atom,0,persistent},{atom,0,true}]},{nil,0}}]}],
     []]}}
```

evaluating `application:set_env(persistent_term:get(Key), [{persistent, true}])` - the primitive `Config.Provider` uses on a cold start through `Application.put_all_env/2`, with no serialization step. That is precisely why these applications boot fine every day and only broke under hot upgrade.

### Why forms rather than a helper module

The obvious approach is `:code.load_binary/3` with a small module. It does not survive version skew:

```
VM: OTP 28 -> load_binary {module,dx_hook} OK
VM: OTP 27 -> load_binary {error,badfile} FAILED   beam_load.c: corrupt atom table
VM: OTP 26 -> load_binary {error,badfile} FAILED   beam_load.c: corrupt atom table
```

It fails even one major back, and managed applications bring their own OTP version. `erl_eval` and `persistent_term` are stock, so nothing needs loading. Verified across the boundary by having OTP 29 read and execute a relup written on OTP 28:

```
VM: OTP 29
  consult OK  0.1.0 -> 0.2.0, head = erl_eval:exprs/2, rest 2 instr
  apply -> {value,ok,[]}
  app env after hook -> {ok,works}
```

### Why not represent the function in sys.config

`fun M:F/A` does parse, and an external fun like `&:lists.reverse/1` round trips correctly. But this is a compiler generated local lambda (`type: :local`, `name: :"-pkix_verify_hostname_match_fun/1-fun-0-"`). Writing it that way parses and yields a fun, then raises `UndefinedFunctionError` on first call, because external fun references resolve against the export table. That converts a loud failure at upgrade time into a TLS handshake crash at the first reconnect.

## Failure behaviour: error, never half-config

Failing to add the hook **fails the upgrade** rather than installing without it. The abort happens before `install_release/1`, so nothing is installed, the running node keeps the configuration it already had, and `worker.ex:653` falls back to a full deployment where the configuration is resolved correctly on boot.

Removing the sys.config rewrite also removes a pre-existing trap: a failure after the rewrite used to strand the generated file, and the next attempt died on `{:ok, [sys_config]} = :file.consult(...)`.

## Reproduction

`resolve_runtime_config/1 Elixir carries values sys.config could never hold` runs the real `:public_key.pkix_verify_hostname_match_fun(:https)` through the providers and asserts the resulting fun is callable.

Also covered: sys.config is byte identical afterwards with no `original.sys.config` left behind, the patched relup still parses with `:file.consult/1`, the instruction heads the script ahead of the original instructions, the forms evaluate and land the value in the application environment, `restart_new_emulator` scripts are untouched, and an unreadable relup fails the upgrade rather than installing silently.

## Risk assessment

**Impact:** hot upgrades keep the runtime configuration instead of silently reverting every application to its `.app` file defaults. `sys.config` is no longer modified, so the release directory is left exactly as found.

**Blast radius:** `apps/deployer/lib/deployer/hot_upgrade/application.ex` only. `update_sys_config_from_installed_version/1` and `return_original_sys_config/1` are replaced by `resolve_runtime_config/1` and `install_runtime_config_hook/2`; both removed functions were internal to this module. The relup generated by `systools:make_relup/4` is rewritten in place, after `check_install_release/1` has already validated it. Erlang releases return `{:ok, []}` and skip both new steps. No changes to `foundation`, `sentinel`, `host` or `deployex_web`, nor to the deployment engine.

**Regression risk:** medium. The mechanism that applies the configuration changes for every Elixir hot upgrade, not only for the values that could not be serialized, and the relup hook cannot be exercised end to end without a live node. Applications whose configuration was already serializable now receive it through `set_env` rather than `sys.config`. Emulator upgrades are left untouched, since the VM restart resolves the configuration again on boot.

**Rollback:** plain commit revert. No data or configuration migration.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and the `deployer` suite (171 tests, 0 failures, no skips) pass locally. `mix dialyzer` was not run locally because the PLT is stale and needs a full rebuild; CI covers it.

**Not covered locally:** a real `install_release/2` executing the spliced instruction on a live node. That needs a staging upgrade, and it is the main thing to watch when testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
