### PR TITLE
ci(hot_upgrade): show from/to versions in the workflow run name

### DIFF
--- a/.github/workflows/hot_upgrade.yaml
+++ b/.github/workflows/hot_upgrade.yaml
@@ -1,5 +1,7 @@
 name: Create Release with Hot Upgrade (Ubuntu 24.04 / Debian 13)
 
+run-name: Hot Upgrade ${{ inputs.from_version }} -> ${{ inputs.target_version }} (OTP ${{ inputs.otp }})
+
 on:
   workflow_dispatch:
     inputs:
@@ -28,6 +30,7 @@ env:
 
 jobs:
   generate_release:
+    name: Release ${{ inputs.from_version }} -> ${{ inputs.target_version }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What

The hot upgrade workflow is dispatched manually with `from_version` and `target_version` inputs, but the Actions run list only showed the static workflow name, so concurrent or historical runs were indistinguishable without opening each one.

- Add a top-level `run-name` carrying both versions plus the OTP choice.
- Name the `generate_release` job with the same version pair, so the versions are visible in the job list too.

Rendered example for a dispatch of `0.9.8` -> `0.9.9` on OTP 28:

- Run: `Hot Upgrade 0.9.8 -> 0.9.9 (OTP 28)`
- Job: `Release 0.9.8 -> 0.9.9`

## Risk assessment

- **Impact:** cosmetic only - changes the run/job labels rendered by GitHub Actions. No step, input, artifact name or release output is touched.
- **Blast radius:** limited to the manually dispatched hot upgrade workflow. No other workflow, no runtime or release code.
- **Regression risk:** low. `run-name` and `jobs.<id>.name` are standard GitHub Actions keys, and the `inputs.*` context is valid in both for a `workflow_dispatch` trigger. Worst case a label renders empty.
- **Rollback plan:** revert this commit; no state or artifacts to clean up.

## Checklist

- [x] Small, focused diff (one file, 2 added lines)
- [x] No leftover debug logs or comments
- [x] Brief what/why summary above
- [ ] Label rendering confirmed on the next manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)