### PR TITLE
fix(web): stop password managers filling credentials into the GitHub artifact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG (0.9.X)
 
+## 0.9.10 ()
+
+### Backwards incompatible changes from 0.9.9
+ * None
+
+### Bug fixes
+ * [`PULL-265`](https://github.com/thiagoesteves/deployex/pull/265) Stop password managers filling credentials into the GitHub artifact form
+
+### Enhancements
+ * None
+
 ## 0.9.9 🚀 (2026-08-07)
 
 ### Backwards incompatible changes from 0.9.8

--- a/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
@@ -207,12 +207,16 @@ defmodule DeployexWeb.HotUpgradeLive do
                 Download from GitHub
               </h2>
 
+              <%!-- A text field followed by a password field looks like a sign in form to a
+                    password manager, which then fills the DeployEx credentials into the URL and
+                    token below. The autocomplete hints here and on the inputs keep it away. --%>
               <.form
                 for={@form}
                 id="github-download-form"
                 phx-change="github-download-form-update"
                 phx-submit="download-from-github"
                 class="space-y-4"
+                autocomplete="off"
               >
                 <div class="form-control">
                   <label class="label">
@@ -224,6 +228,9 @@ defmodule DeployexWeb.HotUpgradeLive do
                     value={@form.params["github_url"]}
                     placeholder="https://github.com/user/repo/actions/runs/123/artifacts/456"
                     class="input input-bordered w-full"
+                    autocomplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
                     required
                   />
                   <label class="label">
@@ -237,12 +244,17 @@ defmodule DeployexWeb.HotUpgradeLive do
                   <label class="label">
                     <span class="label-text font-medium">GitHub Token (optional)</span>
                   </label>
+                  <%!-- new-password rather than off: Chrome ignores off for password fields
+                        but will not fill a stored credential into a new-password one --%>
                   <input
                     type="password"
                     name="github_token"
                     value={@form.params["github_token"]}
                     placeholder="ghp_xxxxxxxxxxxx"
                     class="input input-bordered w-full font-mono text-sm"
+                    autocomplete="new-password"
+                    data-1p-ignore
+                    data-lpignore="true"
                   />
                   <label class="label">
                     <span class="label-text-alt text-base-content/60">

--- a/apps/deployex_web/lib/deployex_web/live/user_login_live.ex
+++ b/apps/deployex_web/lib/deployex_web/live/user_login_live.ex
@@ -24,11 +24,20 @@ defmodule DeployexWeb.UserLoginLive do
             </div>
 
             <.simple_form for={@form} id="login_form" action={~p"/users/log_in"} phx-update="ignore">
-              <.input field={@form[:username]} type="text" placeholder="Username" required />
+              <%!-- Naming the credential fields explicitly keeps password managers on this
+                    form instead of guessing at any other text plus password pair in the UI --%>
+              <.input
+                field={@form[:username]}
+                type="text"
+                placeholder="Username"
+                autocomplete="username"
+                required
+              />
               <.input
                 field={@form[:password]}
                 type="password"
-                placeholder="current-password"
+                placeholder="Password"
+                autocomplete="current-password"
                 required
               />
 

--- a/apps/deployex_web/test/deployex_web/live/hot_upgrade/github_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/hot_upgrade/github_test.exs
@@ -37,6 +37,24 @@ defmodule DeployexWeb.HotUpgrade.GithubTest do
     end
 
     @tag :capture_log
+    test "keeps password managers from filling the url and token fields", %{conn: conn} do
+      Deployer.HotUpgradeMock
+      |> expect(:subscribe_events, fn -> :ok end)
+
+      {:ok, live, _html} = live(conn, ~p"/hotupgrade")
+
+      html =
+        live
+        |> element("a", "GitHub URL")
+        |> render_click()
+
+      # A text field followed by a password field reads as a sign in form, and the DeployEx
+      # credentials end up in the artifact URL and the token
+      assert html =~ ~s(autocomplete="off")
+      assert html =~ ~s(autocomplete="new-password")
+    end
+
+    @tag :capture_log
     test "switches back to file upload method", %{conn: conn} do
       Deployer.HotUpgradeMock
       |> expect(:subscribe_events, fn -> :ok end)

--- a/apps/deployex_web/test/deployex_web/live/user_login_live_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/user_login_live_test.exs
@@ -13,6 +13,14 @@ defmodule DeployexWeb.UserLoginLiveTest do
     end
 
     @tag :capture_log
+    test "names the credential fields so password managers stay on this form", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/users/log_in")
+
+      assert html =~ ~s(autocomplete="username")
+      assert html =~ ~s(autocomplete="current-password")
+    end
+
+    @tag :capture_log
     test "redirects if already logged in", %{conn: conn} do
       result =
         conn


### PR DESCRIPTION
## What is happening

This is the browser's password manager, not DeployEx. The GitHub download form in `hot_upgrade/index.ex` is:

```heex
<.form for={@form} id="github-download-form" ...>
  <input type="text"     name="github_url"   ... />
  <input type="password" name="github_token" ... />
```

A text field followed by a password field, inside a form, with no `autocomplete` attributes anywhere. That is precisely the heuristic Chrome, Safari and Firefox use to identify a sign in form. Having saved credentials for the DeployEx origin, the browser fills them in: the admin **username** into the artifact URL and the admin **password** into the token.

It is intermittent because autofill depends on whether credentials are stored for the origin, whether the browser classifies the page as a login page, and prior interaction.

## The fix

`autocomplete="off"` on the form and on the URL field, and `autocomplete="new-password"` on the token field. The distinction matters: Chrome deliberately ignores `off` on password inputs, but it will not fill a *stored* credential into a field marked `new-password`.

`data-1p-ignore` and `data-lpignore` cover 1Password and LastPass, which use their own attributes rather than `autocomplete`.

### Also fixed: the login form

The login form had **no** `autocomplete` hints at all, which is what leaves the browser guessing where credentials belong across the whole UI. Naming them explicitly (`username` / `current-password`) keeps password managers anchored to the real login form.

While there, its password placeholder read `current-password`:

```heex
<.input field={@form[:password]} type="password" placeholder="current-password" required />
```

That looks like an `autocomplete` value that landed in the wrong attribute, and it was rendering as visible placeholder text to anyone signing in. Now `placeholder="Password"` with `autocomplete="current-password"`.

## Testing

Two regression tests assert the attributes are rendered, so they are not dropped later.

Worth stating plainly: **autofill itself cannot be asserted in a headless test.** The tests confirm the markup; whether a given browser and password manager honours it is not something the suite can prove. Verification is manual - with credentials saved for the DeployEx origin, open the GitHub URL tab and confirm both fields stay empty.

## Risk assessment

**Impact:** the artifact URL and token fields are no longer autofilled with the DeployEx admin credentials. The login page shows "Password" instead of "current-password" as its placeholder. No change for anyone not using a password manager.

**Blast radius:** two LiveView templates in `deployex_web`, presentation attributes only. No change to authentication, session handling, form submission, or any server side code.

**Regression risk:** low. The attributes are hints to the browser and do not alter submitted parameters.

**Rollback:** plain commit revert.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors`, `mix sobelow` and the `deployex_web` suite (177 tests, 6 doctests, 0 failures) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
