### PR TITLE
feat(foundation): give the deployment record an identity, an outcome and a duration

### DIFF
--- a/apps/foundation/lib/foundation/catalog.ex
+++ b/apps/foundation/lib/foundation/catalog.ex
@@ -282,10 +282,21 @@ defmodule Foundation.Catalog do
   @doc """
   Add a version to the version history
 
+  Returns the stored record, whose `id` identifies it for `update_version/1`.
   """
   @impl true
-  @spec add_version(map()) :: :ok
+  @spec add_version(map()) :: {:ok, Catalog.Version.t()}
   def add_version(version), do: default().add_version(version)
+
+  @doc """
+  Update a version already in the history
+
+  A full deployment records the version before the node has started, so its outcome is only
+  known later. This rewrites that record in place rather than appending a second one.
+  """
+  @impl true
+  @spec update_version(map()) :: {:ok, Catalog.Version.t()} | {:error, :not_found}
+  def update_version(version), do: default().update_version(version)
 
   @doc """
   Retrieve the ghosted version history for the respective application

--- a/apps/foundation/lib/foundation/catalog/adapter.ex
+++ b/apps/foundation/lib/foundation/catalog/adapter.ex
@@ -23,7 +23,8 @@ defmodule Foundation.Catalog.Adapter do
   @callback current_path(String.t()) :: String.t() | nil
   @callback previous_path(String.t()) :: String.t() | nil
   @callback versions(String.t(), Keyword.t()) :: list()
-  @callback add_version(map()) :: :ok
+  @callback add_version(map()) :: {:ok, Catalog.Version.t()}
+  @callback update_version(map()) :: {:ok, Catalog.Version.t()} | {:error, :not_found}
   @callback ghosted_versions(String.t()) :: list()
   @callback add_ghosted_version(map()) :: {:ok, list()}
   @callback add_user_session_token(Accounts.UserToken.t()) :: :ok

--- a/apps/foundation/lib/foundation/catalog/local.ex
+++ b/apps/foundation/lib/foundation/catalog/local.ex
@@ -289,6 +289,7 @@ defmodule Foundation.Catalog.Local do
       name
       |> history_version_path()
       |> list()
+      |> Enum.map(&normalize_version/1)
       |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
 
     if sname do
@@ -300,16 +301,39 @@ defmodule Foundation.Catalog.Local do
 
   @impl true
   def add_version(%{name: name} = version) do
+    # The record is written before the outcome is known and updated afterwards, so it is
+    # keyed rather than appended anonymously. The list is ordered by inserted_at, not by
+    # file name, so keying this way does not change the history order
+    id = version.id || "#{System.os_time(:microsecond)}.term"
+    version = %{version | id: id}
+
     name
     |> history_version_path()
-    |> insert_by_timestamp(version)
+    |> insert_by_key(id, version)
+
+    {:ok, version}
   end
+
+  @impl true
+  def update_version(%{name: name, id: id} = version) when is_binary(id) do
+    path = history_version_path(name)
+
+    if File.exists?("#{path}/#{id}") do
+      insert_by_key(path, id, version)
+      {:ok, version}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  def update_version(_version), do: {:error, :not_found}
 
   @impl true
   def ghosted_versions(name) do
     name
     |> ghosted_version_path()
     |> list()
+    |> Enum.map(&normalize_version/1)
   end
 
   @impl true
@@ -388,6 +412,16 @@ defmodule Foundation.Catalog.Local do
     file = "#{System.os_time(:microsecond)}.term"
     File.write!("#{path}/#{file}", :erlang.term_to_binary(data))
   end
+
+  # A record written by an earlier version decodes without the fields added since, and
+  # reading one of those would raise a KeyError. DeployEx hot upgrades itself and then reads
+  # the history it wrote before the upgrade, so this is the normal path rather than an edge
+  # case. struct/2 fills the missing fields with their defaults and ignores unknown ones
+  defp normalize_version(%Catalog.Version{} = version) do
+    struct(Catalog.Version, Map.delete(version, :__struct__))
+  end
+
+  defp normalize_version(version), do: version
 
   defp insert_by_key(path, key, data) do
     File.write!("#{path}/#{key}", :erlang.term_to_binary(data))

--- a/apps/foundation/lib/foundation/catalog/version.ex
+++ b/apps/foundation/lib/foundation/catalog/version.ex
@@ -1,24 +1,44 @@
 defmodule Foundation.Catalog.Version do
   @moduledoc """
   Structure to handle the application version
+
+  A record is written when a deployment starts and updated once its outcome is known, so
+  `id` identifies it across both writes. The two deployment types learn their outcome at
+  different points: a hot upgrade knows it as soon as `install_release/2` returns, while a
+  full deployment only knows it when the node reports running and the rollback timer is
+  cancelled, so it is stored as `:started` until then.
+
+  Records written by earlier versions do not carry the newer fields. They are normalised on
+  read (see `Foundation.Catalog.Local`), which matters because DeployEx hot upgrades itself
+  and immediately reads the history it wrote before the upgrade.
   """
+  @type outcome :: :started | :ok | :rolled_back | :error
+
   @type t :: %__MODULE__{
+          id: String.t() | nil,
           version: String.t() | nil,
+          from_version: String.t() | nil,
           hash: String.t() | nil,
           pre_commands: list(),
           name: String.t(),
           sname: String.t(),
           deployment: :full_deployment | :hot_upgrade,
+          outcome: outcome() | nil,
+          duration_ms: non_neg_integer() | nil,
           inserted_at: NaiveDateTime.t() | nil
         }
 
   @derive Jason.Encoder
 
-  defstruct version: nil,
+  defstruct id: nil,
+            version: nil,
+            from_version: nil,
             hash: nil,
             pre_commands: [],
             name: "",
             sname: "",
             deployment: :full_deployment,
+            outcome: nil,
+            duration_ms: nil,
             inserted_at: nil
 end

--- a/apps/foundation/test/catalog/catalog_test.exs
+++ b/apps/foundation/test/catalog/catalog_test.exs
@@ -22,8 +22,62 @@ defmodule Foundation.CatalogTest do
 
   test "add_version/1", %{name: name} do
     version = %Catalog.Version{version: "0.0.0", name: name}
-    assert :ok = Catalog.add_version(version)
-    assert [^version] = Catalog.versions(name, [])
+    assert {:ok, %Catalog.Version{id: id} = stored} = Catalog.add_version(version)
+    assert is_binary(id)
+    assert [^stored] = Catalog.versions(name, [])
+  end
+
+  test "update_version/1 rewrites the record in place", %{name: name} do
+    # A full deployment records the version before the node has started, so the outcome is
+    # only known later and must not append a second entry
+    {:ok, stored} =
+      Catalog.add_version(%Catalog.Version{
+        version: "0.0.0",
+        name: name,
+        outcome: :started,
+        inserted_at: NaiveDateTime.utc_now()
+      })
+
+    assert {:ok, _updated} =
+             Catalog.update_version(%{stored | outcome: :ok, duration_ms: 1234})
+
+    assert [%Catalog.Version{outcome: :ok, duration_ms: 1234, id: id}] =
+             Catalog.versions(name, [])
+
+    assert id == stored.id
+  end
+
+  test "update_version/1 without a stored record", %{name: name} do
+    assert {:error, :not_found} =
+             Catalog.update_version(%Catalog.Version{version: "0.0.0", name: name, id: "nope"})
+
+    assert {:error, :not_found} =
+             Catalog.update_version(%Catalog.Version{version: "0.0.0", name: name})
+  end
+
+  test "versions/2 reads records written before the newer fields existed", %{name: name} do
+    # DeployEx hot upgrades itself and then reads the history it wrote beforehand, so a
+    # record decoded without the newer keys must not raise
+    legacy = %{
+      __struct__: Catalog.Version,
+      version: "0.0.0",
+      hash: nil,
+      pre_commands: [],
+      name: name,
+      sname: "#{name}-abc123",
+      deployment: :full_deployment,
+      inserted_at: NaiveDateTime.utc_now()
+    }
+
+    path = "#{Application.get_env(:foundation, :var_path)}/storage/#{name}/deployex/history"
+    File.mkdir_p!(path)
+    File.write!("#{path}/legacy.term", :erlang.term_to_binary(legacy))
+
+    assert [%Catalog.Version{} = version] = Catalog.versions(name, [])
+    assert version.version == "0.0.0"
+    assert version.outcome == nil
+    assert version.from_version == nil
+    assert version.duration_ms == nil
   end
 
   test "ghosted_versions/0", %{name: name} do


### PR DESCRIPTION
Groundwork for the deployment report. Foundation only - **nothing populates the new fields yet**, so behaviour is unchanged.

## Why an update path is needed at all

The two deployment types learn their outcome at different points:

```
full_deployment/3   worker.ex:595   set_current_version_map(...)   <- BEFORE the node starts
                    worker.ex:294   notify "deployment_complete"   <- outcome known HERE
                                                                      (:application_running,
                                                                       rollback timer cancelled)

hot_upgrade/3       worker.ex:640   set_current_version_map(...)   <- AFTER execute/1 returned
                                                                      outcome already known
```

A hot upgrade can record its outcome when it writes. A full deployment cannot - at line 595 the node has not booted and the rollback timer has not been cancelled. So recording an outcome means writing `:started` first and **rewriting the same record** later, not appending a second entry.

## What changed

`Catalog.Version` gains `id`, `from_version`, `outcome` and `duration_ms`.

`add_version/1` returns the stored record so the caller holds its `id`, and keys the file by that id rather than an anonymous timestamp. History order is unaffected - `versions/2` sorts by `inserted_at`, and nothing parses the file name.

`update_version/1` rewrites a record already in the history, or returns `{:error, :not_found}`.

## The part that matters most: reading old records

Records are stored as `:erlang.term_to_binary` per file (`local.ex:387`) and read back with `non_executable_binary_to_term`. A record written by an earlier version decodes into a map **without the new keys**, so `version.outcome` would raise `KeyError`.

That is the normal path, not an edge case: DeployEx hot upgrades itself and then immediately reads the history it wrote *before* the upgrade. `versions/2` and `ghosted_versions/1` now normalise each record through `struct/2`, which fills missing fields with their defaults.

There is a test that writes a record in the old shape directly to disk and reads it back, so this stays covered.

## Risk assessment

**Impact:** none visible. The new fields are `nil` on every record until the engine populates them.

**Blast radius:** `apps/foundation` only - `Catalog.Version`, the `Catalog.Local` store, and the adapter and delegation. `add_version/1` changes its return from `:ok` to `{:ok, version}`; the sole caller is `Status.set_current_version_map/3`, which ignores the value. No changes to `deployer`, `sentinel`, `host` or `deployex_web`.

**Regression risk:** low. The stored term gains fields and the file name changes from a bare timestamp to the record id, neither of which is read by anything. Normalisation is a no-op for records that already carry every field.

**Rollback:** plain commit revert. Records written meanwhile stay readable, since older code ignores unknown keys when pattern matching the struct.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and the full umbrella suite (foundation 234 + 25 doctests, host 21, deployer 172, sentinel 84, deployex_web 175 + 6 doctests - 0 failures) pass locally. `mix dialyzer` not run locally; the PLT is stale and CI covers it.

## Next

Populating the fields, in its own PR since it touches the deployment engine:

- `worker.ex` writes `:started` at 595 and updates to `:ok` at 294, `:rolled_back` on the rollback timer
- hot upgrade records `from_version`, `duration_ms` and `outcome` directly
- relup summary and `which_releases/1` into the record - both need `execute/1` to return more than `:ok`
- enriched `deployment_complete` notification payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
