### PR TITLE
fix(web): correct the hot upgrade confirmation, it does not terminate anything

### DIFF
--- a/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
@@ -702,10 +702,10 @@ defmodule DeployexWeb.HotUpgradeLive do
               </div>
             </div>
 
-            <div class="bg-error/10 border border-error/20 rounded-lg p-4">
+            <div class="bg-warning/10 border border-warning/20 rounded-lg p-4">
               <div class="flex gap-3">
                 <svg
-                  class="w-5 h-5 text-error flex-shrink-0 mt-0.5"
+                  class="w-5 h-5 text-warning flex-shrink-0 mt-0.5"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -719,12 +719,15 @@ defmodule DeployexWeb.HotUpgradeLive do
                   </path>
                 </svg>
                 <div class="space-y-2">
-                  <p class="font-semibold text-error">Warning: Destructive Operation</p>
+                  <p class="font-semibold text-warning">Before you apply</p>
                   <ul class="text-sm text-base-content/80 space-y-1 list-disc list-inside">
-                    <li>All running application instances will be terminated</li>
-                    <li>Deployments will restart sequentially</li>
-                    <li>This may cause temporary service interruption</li>
-                    <li>This action cannot be undone</li>
+                    <li>DeployEx keeps running, its code is replaced in place</li>
+                    <li>Processes with a code_change callback have their state migrated live</li>
+                    <li>Monitored applications are not affected, they run on separate nodes</li>
+                    <li>
+                      A failure does not roll back on its own. DeployEx stays up and logs the
+                      error, and restarting the service returns it to the last permanent version
+                    </li>
                   </ul>
                 </div>
               </div>

--- a/apps/deployex_web/test/deployex_web/live/hot_upgrade/upload_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/hot_upgrade/upload_test.exs
@@ -192,9 +192,15 @@ defmodule DeployexWeb.HotUpgrade.UploadTest do
           live |> element("#hotupgrade-apply-deployex", "Apply Hot Upgrade") |> render_click()
 
         assert html =~ "Hot upgrade"
-        assert html =~ "Warning: Destructive Operation"
-        assert html =~ "All running application instances will be terminated"
+        assert html =~ "Before you apply"
         assert html =~ "Yes, Apply Hot Upgrade"
+
+        # release_handler swaps code in the running VM, so nothing is stopped. The confirmation
+        # used to claim the opposite, contradicting the release card on the same page
+        assert html =~ "DeployEx keeps running"
+        assert html =~ "does not roll back on its own"
+        refute html =~ "All running application instances will be terminated"
+        refute html =~ "Warning: Destructive Operation"
       end
     end
 


### PR DESCRIPTION
## The page contradicted itself

Both of these were on `/hotupgrade`:

```heex
<!-- index.ex:561, the release card -->
<li>This will perform a hot upgrade without restarting the application</li>

<!-- index.ex:723, the confirmation modal -->
<p class="font-semibold text-error">Warning: Destructive Operation</p>
<li>All running application instances will be terminated</li>
<li>Deployments will restart sequentially</li>
<li>This may cause temporary service interruption</li>
```

You read "without restarting the application", click Apply, and are told everything will be terminated.

## The card was right

`do_execute/1` is `unpack_release` → `make_relup` → `check_install_release` → resolve config → `install_release` → `make_permanent`. Nothing is stopped or restarted. `release_handler` swaps code in the running VM - that is the entire point of the feature.

The wording came from the full restart confirmation in `applications/index.ex`, where every line **is** accurate: `:full_restart` calls `Monitor.stop_service/2` and `Catalog.cleanup/1` and restarts replicas one at a time, which is literally "deployments will restart sequentially". **That modal is untouched.**

## The failure case, which was also wrong

This page only calls `deployex_check/1` and `deployex_execute/2` - it is exclusively the **DeployEx self upgrade**. So the fallback at `worker.ex:653` (`Hot Upgrade failed, running for full deployment`) does not apply; there is no engine worker behind it. `deployex.ex` does this and nothing else:

```elixir
else
  {:error, reason} = error ->
    Logger.error("Hot upgrade failed: #{inspect(reason)}")
    error
end
```

No rollback, no restart, no full deployment. DeployEx stays up on whatever it has. If it failed after `install_release` the new release is `current` but not `permanent`, so restarting the service returns it to the last permanent version - which is what the modal now says.

## New wording

> **Before you apply**
> - DeployEx keeps running, its code is replaced in place
> - Processes with a code_change callback have their state migrated live
> - Monitored applications are not affected, they run on separate nodes
> - A failure does not roll back on its own. DeployEx stays up and logs the error, and restarting the service returns it to the last permanent version

Panel restyled from `error` to `warning`. The confirm button stays `danger_button` - the operation is consequential (live `code_change/3`, no clean undo) and deserves a deliberate click, it just is not destructive.

## Risk assessment

**Impact:** the confirmation describes what a hot upgrade actually does, including what happens when it fails.

**Blast radius:** one template and its test in `deployex_web`. Text and styling classes only - no change to the event, the action, or any server side code. The full restart modal in `applications/index.ex` keeps its wording.

**Regression risk:** low, nothing executable changed.

**Rollback:** plain commit revert.

## Checks

`mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` and the `deployex_web` suite (177 tests, 6 doctests, 0 failures). The existing modal test asserted the old wording, so it now asserts the corrected claims and `refute`s the old ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
