### PR TITLE
docs(guides): automate TLS certificates and move the guides to Debian 13

### DIFF
--- a/guides/docs/aws-elixir/README.md
+++ b/guides/docs/aws-elixir/README.md
@@ -98,15 +98,15 @@ For initial installations or updates to deployex, follow these steps:
 *__PS__*: make sure you have the pair myappname-web-ec2.pem saved in `~/.ssh/`
 
 ```bash
-ssh -i "myappname-web-ec2.pem" ubuntu@ec2-52-67-178-12.sa-east-1.compute.amazonaws.com
-ubuntu@ip-10-0-1-56:~$
+ssh -i "myappname-web-ec2.pem" admin@ec2-52-67-178-12.sa-east-1.compute.amazonaws.com
+admin@ip-10-0-1-56:~$
 ```
 
 After getting access to EC2, you need to grant root permissions:
 
 ```bash
-ubuntu@ip-10-0-1-56:~$ sudo su
-root@ip-10-0-1-56:/home/ubuntu$
+admin@ip-10-0-1-56:~$ sudo su
+root@ip-10-0-1-56:/home/root$
 ```
 
 Since the secrets are already updated, we are going to install them in the appropriate addresses
@@ -128,14 +128,14 @@ If you are updating DeployEx, you may need to update the `deployex.sh` script. T
 ```bash
 version=0.3.0
 rm deployex.sh
-wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/ubuntu
+wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/root
 chmod a+x deployex.sh
 ```
 
 Run the script to install (or update) deployex:
 
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --install deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --install deployex.yaml
 #           Removing Deployex              #
 ...
 # Clean and create a new directory         #
@@ -152,13 +152,13 @@ vi deployex.yaml
 version: "0.9.1"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
-os_target: "ubuntu-24.04"
+os_target: "ubuntu-24.04"                                # DeployEx release artifact, the only one published. It runs on Debian 13 as well
 ...
 ```
 
 Once the file is updated, run the update command:
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --update deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --update deployex.yaml
 ```
 
 > [!IMPORTANT]
@@ -206,69 +206,21 @@ Here are some useful resources with suggestions on how to automate the upload of
 > Before proceeding, make sure that the DNS is correctly configured to point to the AWS instance.
 
 
- For HTTPS, you can use free certificates from [Let's encrypt](https://letsencrypt.org/getting-started/). In this example, we'll use [cert bot for ubuntu](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) to obtain and configure the certificates:
+HTTPS is set up automatically while the instance boots. `cloud-config.tpl` installs `certbot`, serves plain HTTP with a `/.well-known/acme-challenge/` location, and `setup-tls.sh` obtains the certificate and enables the HTTPS server blocks. No ssh session is needed.
+
+The certificate is requested for `${hostname}` and `${deployex_hostname}`, so both must resolve to the instance **before** it boots, otherwise the HTTP-01 challenge fails. When that happens the instance stays on HTTP and the reason is written to `/var/log/cloud-init-output.log`; fix the DNS and re-run `/root/setup-tls.sh`.
+
+Certbot never edits the nginx configuration here. It only obtains the certificate, and the TLS server blocks are written by `cloud-config.tpl` referencing the well known paths:
 
 ```bash
-sudo su
-apt update
-apt install snapd
-snap install --classic certbot
-ln -s /snap/bin/certbot /usr/bin/certbot
+ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
 ```
 
-Before installing the certificate, make a backup of the current Nginx configuration file located at `/etc/nginx/sites-available/default`. Certbot may modify this file, so keeping a local copy ensures you can restore it if needed. Once the backup is created, run the following command:
-```bash
-certbot --nginx
-```
-
-This command will install Certbot and automatically configure Nginx to use the obtained certificates. After Nginx is configured, the certificate paths will be set up and will look something like this:
-
-```bash
-vi /etc/nginx/sites-available/default
- ...
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-```
-
-Update your configuration file to include the Let's Encrypt certificate paths. Find the section where it mentions:
-
-```bash
-           # Add here the letsencrypt paths
-```
-replace this comment with the actual certificate paths:
-```bash
-               proxy_set_header Upgrade $http_upgrade;
-               proxy_set_header Connection "upgrade";
-
-               proxy_pass http://deployex;
-           }
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-       }
-```
-
-Also, ensure that port 443 is enabled for both servers. For example:
-
-```bash
-      server {
-          listen 443 ssl; # managed by Certbot
-```
-
-After modifying the configuration file, save the changes and restart Nginx:
-
-```bash
-sudo su
-vi /etc/nginx/sites-available/default
-# modify and save file
-systemctl reload nginx
-```
+That means the template stays the source of truth. Anything certbot wrote into the config would otherwise be lost the next time terraform replaces the instance, which any change to `cloud-config.tpl` does.
 
 > [!NOTE]
-> After the changes, It may require a reboot.
+> `setup-tls.sh` runs on every boot and is safe to re-run. `--keep-until-expiring` leaves a still valid certificate alone, which matters because Let's Encrypt allows only 5 identical certificates per week and instance replacement is routine. The certificate does not survive a replacement, so it is reissued on the next boot.
 
 [tls]: https://github.com/thiagoesteves/deployex/blob/main/devops/scripts/certificates/otp-28/tls-distribution-certs
 [main]: https://github.com/thiagoesteves/deployex/blob/main/guides/docs/aws-elixir/terraform/environments/prod/main_example.tf_

--- a/guides/docs/aws-elixir/terraform/environments/prod/main_example.tf_
+++ b/guides/docs/aws-elixir/terraform/environments/prod/main_example.tf_
@@ -12,5 +12,6 @@ module "standard_account" {
   replicas          = 3
   ec2_instance_type = "t2.medium"
   deployex_dns      = "deployex.myappname.com"
+  certbot_email      = "ops@myappname.com"
   deployex_version  = "0.9.1"
 }

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -205,7 +205,7 @@ write_files:
           }
       }
 
-  - path: /root/nginx-tls.conf
+  - path: /home/root/nginx-tls.conf
     owner: root:root
     permissions: "0644"
     content: |
@@ -307,7 +307,7 @@ write_files:
            --email ${certbot_email} \
            --agree-tos --non-interactive --keep-until-expiring \
            --deploy-hook "systemctl reload nginx"; then
-        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+        install -o root -g root -m 0644 /home/root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
 
         if nginx -t; then
           systemctl reload nginx

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -7,11 +7,11 @@
 #
 packages:
  - certbot
+ - yq
  - unzip
  - nginx
  - logrotate
  - awscli
- - jq
  - amazon-ssm-agent
 
 write_files:
@@ -333,10 +333,6 @@ runcmd:
   - systemctl enable amazon-ssm-agent
   # RDS server certificate chain, used by the Ecto repo to verify the database
   - curl -o /etc/ssl/certs/rds-global.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
-  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
-  # not ship by default
-  - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-  - chmod a+x /usr/local/bin/yq
   # Install OTP certificates from AWS Secrets Manager
   - /home/root/install-otp-certificates.sh
   # Download and install Deployex

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -85,7 +85,7 @@ write_files:
               enable_restart: true
               warning_threshold_percent: 75
               restart_threshold_percent: 90
-  - path: /home/root/config.json
+  - path: /home/root/cloud-watch-config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -284,7 +284,7 @@ write_files:
           }
       }
 
-  - path: /root/setup-tls.sh
+  - path: /home/root/setup-tls.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -323,22 +323,34 @@ write_files:
         exit 1
       fi
 runcmd:
+  # Set the hostname so the environment is obvious on the box and in logs
+  - hostnamectl set-hostname myappname-${account_name}-debian
+  - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
+  # AWS CLI, used by install-otp-certificates.sh to read from Secrets Manager
   - cd /tmp
-  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o"  "awscliv2.zip"
+  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o" "awscliv2.zip"
   - unzip "awscliv2.zip"
   - ./aws/install
   - ./aws/install --update
-  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
+  # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
+  # Install OTP certificates from AWS Secrets Manager
+  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex
   - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
   - chmod a+x /home/root/deployex.sh
   - /home/root/deployex.sh --install /home/root/deployex.yaml
+  # Install and configure CloudWatch agent
   - wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
   - dpkg -i -E ./amazon-cloudwatch-agent.deb
-  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/config.json -s
+  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/cloud-watch-config.json -s
+  # Enable Nginx
   - systemctl enable nginx
   - systemctl restart nginx
-  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
-  - /root/setup-tls.sh
+  # nginx is serving HTTP at this point, which is all the HTTP-01 challenge needs
+  - /home/root/setup-tls.sh
+  # Reboot to apply all changes
+  - sleep 5
   - reboot

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -6,12 +6,13 @@
 #    /var/log/cloud-init-output.log
 #
 packages:
+ - certbot
  - unzip
  - nginx
  - logrotate
 
 write_files:
-  - path: /home/ubuntu/install-otp-certificates.sh
+  - path: /home/root/install-otp-certificates.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -28,7 +29,7 @@ write_files:
       aws secretsmanager get-secret-value --secret-id myappname-${account_name}-otp-tls-crt | jq -r .SecretString > /usr/local/share/ca-certificates/deployex.crt
       aws secretsmanager get-secret-value --secret-id myappname-${account_name}-otp-tls-crt | jq -r .SecretString > /usr/local/share/ca-certificates/myappname.crt
       echo "[OK]"
-  - path: /home/ubuntu/deployex.yaml
+  - path: /home/root/deployex.yaml
     owner: root:root
     permissions: "0644"
     content: |
@@ -84,7 +85,7 @@ write_files:
               enable_restart: true
               warning_threshold_percent: 75
               restart_threshold_percent: 90
-  - path: /home/ubuntu/config.json
+  - path: /home/root/config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -184,25 +185,55 @@ write_files:
       }
 
       server {
-          listen 80;
-          server_name myappname.com.br deployex.myappname.com.br;
-
-          if ($host = myappname.com.br) {
-              return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-
-          if ($host = deployex.myappname.com.br) {
-              return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-          return 404; # managed by Certbot
+          listen 80 default_server;
+          server_name _;
+          return 404;
       }
 
-      server { 
-          #listen 443 ssl; # managed by Certbot
-          server_name  deployex.myappname.com.br;
+      server {
+          listen 80;
+          server_name ${hostname} ${deployex_hostname};
+
+          # HTTP-01 challenge, for the first issue and for every renewal. certbot only ever
+          # writes files under this root, it does not touch the nginx configuration
+          location /.well-known/acme-challenge/ {
+              root /var/www/certbot;
+          }
+
+          location / {
+              return 301 https://$host$request_uri;
+          }
+      }
+
+  - path: /root/nginx-tls.conf
+    owner: root:root
+    permissions: "0644"
+    content: |
+      # Installed into /etc/nginx/conf.d/ by setup-tls.sh once the certificate exists. One
+      # certificate covers both names, under a lineage named after ${hostname}.
+      #
+      # The TLS parameters are written out instead of including
+      # /etc/letsencrypt/options-ssl-nginx.conf. That file is created by the certbot nginx
+      # installer plugin, which does not run here because the certificate is obtained with
+      # certonly --webroot, so it does not exist on the box. These are the same values.
+      #
+      # They sit inside the server blocks rather than at http level, because the stock
+      # nginx.conf already sets ssl_protocols and ssl_prefer_server_ciphers there and nginx
+      # rejects the duplicates.
+      server {
+          listen 443 ssl;
+          server_name  ${deployex_hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -219,14 +250,22 @@ write_files:
 
               proxy_pass http://deployex;
           }
-          
-          # Add here the letsencrypt paths
       }
 
       server {
-          #listen 443 ssl; # managed by Certbot
-          server_name  myappname.com.br;
+          listen 443 ssl;
+          server_name  ${hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -243,23 +282,63 @@ write_files:
 
               proxy_pass http://phoenix;
           }
-          # Add here the letsencrypt paths
       }
+
+  - path: /root/setup-tls.sh
+    owner: root:root
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      #
+      #  Obtain the TLS certificate and enable the HTTPS server blocks.
+      #
+      #  Runs on every boot and is idempotent: --keep-until-expiring leaves a still valid
+      #  certificate alone, which matters because any cloud-config change replaces the
+      #  instance and Let's Encrypt only allows 5 identical certificates per week.
+      #
+      set -uo pipefail
+
+      mkdir -p /var/www/certbot
+
+      if certbot certonly \
+           --webroot --webroot-path /var/www/certbot \
+           --cert-name ${hostname} \
+           -d ${hostname} -d ${deployex_hostname} \
+           --email ${certbot_email} \
+           --agree-tos --non-interactive --keep-until-expiring \
+           --deploy-hook "systemctl reload nginx"; then
+        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+
+        if nginx -t; then
+          systemctl reload nginx
+        else
+          # Never leave nginx unable to start, HTTP is better than nothing
+          rm -f /etc/nginx/conf.d/tls.conf
+          echo "setup-tls: generated TLS config failed nginx -t, staying on HTTP" >&2
+          exit 1
+        fi
+      else
+        echo "setup-tls: certbot failed, staying on HTTP. Check that ${hostname} and" >&2
+        echo "           ${deployex_hostname} resolve to this instance, then re-run." >&2
+        exit 1
+      fi
 runcmd:
   - cd /tmp
   - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o"  "awscliv2.zip"
   - unzip "awscliv2.zip"
   - ./aws/install
   - ./aws/install --update
-  - /home/ubuntu/install-otp-certificates.sh
+  - /home/root/install-otp-certificates.sh
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
-  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/ubuntu
-  - chmod a+x /home/ubuntu/deployex.sh
-  - /home/ubuntu/deployex.sh --install /home/ubuntu/deployex.yaml
+  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
+  - chmod a+x /home/root/deployex.sh
+  - /home/root/deployex.sh --install /home/root/deployex.yaml
   - wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
   - dpkg -i -E ./amazon-cloudwatch-agent.deb
-  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/ubuntu/config.json -s
-  - systemctl enable --no-block nginx 
-  - systemctl start --no-block nginx
+  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/config.json -s
+  - systemctl enable nginx
+  - systemctl restart nginx
+  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
+  - /root/setup-tls.sh
   - reboot

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -10,6 +10,9 @@ packages:
  - unzip
  - nginx
  - logrotate
+ - awscli
+ - jq
+ - amazon-ssm-agent
 
 write_files:
   - path: /home/root/install-otp-certificates.sh
@@ -326,12 +329,10 @@ runcmd:
   # Set the hostname so the environment is obvious on the box and in logs
   - hostnamectl set-hostname myappname-${account_name}-debian
   - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
-  # AWS CLI, used by install-otp-certificates.sh to read from Secrets Manager
-  - cd /tmp
-  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o" "awscliv2.zip"
-  - unzip "awscliv2.zip"
-  - ./aws/install
-  - ./aws/install --update
+  # Enable AWS Systems Manager agent
+  - systemctl enable amazon-ssm-agent
+  # RDS server certificate chain, used by the Ecto repo to verify the database
+  - curl -o /etc/ssl/certs/rds-global.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
   # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
   # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/ec2.tf
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/ec2.tf
@@ -1,9 +1,9 @@
-data "aws_ami" "ubuntu" {
+data "aws_ami" "debian" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+    values = ["debian-13-amd64-*"]
   }
 
   filter {
@@ -11,7 +11,7 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["136693071363"] # Debian official
 }
 
 resource "aws_security_group" "ec2_security" {
@@ -102,6 +102,7 @@ data "cloudinit_config" "server_config" {
     content = templatefile("${path.module}/cloud-config.tpl", {
       hostname = "${var.server_dns}"
       deployex_hostname = "${var.deployex_dns}"
+      certbot_email = "${var.certbot_email}"
       deployex_version = "${var.deployex_version}"
       log_group_name = aws_cloudwatch_log_group.ec2_instance_logs.name
       account_name = "${var.account_name}"
@@ -112,7 +113,7 @@ data "cloudinit_config" "server_config" {
 }
 
 resource "aws_instance" "ec2_myappname_instance" {
-  ami                         = data.aws_ami.ubuntu.id
+  ami                         = data.aws_ami.debian.id
   instance_type               = "${var.ec2_instance_type}"
   key_name                    = "${var.aws_key_name}"
   vpc_security_group_ids      = [aws_security_group.ec2_security.id]

--- a/guides/docs/aws-elixir/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/aws-elixir/terraform/modules/standard-account/variables.tf
@@ -44,3 +44,8 @@ variable "log_retention_in_days" {
   type        = number
   default     = 30
 }
+# Address Let's Encrypt uses for expiry notices, see setup-tls.sh in cloud-config.tpl
+variable "certbot_email" {
+  type     = string
+  nullable = false
+}

--- a/guides/docs/aws-erlang/README.md
+++ b/guides/docs/aws-erlang/README.md
@@ -97,15 +97,15 @@ For initial installations or updates to deployex, follow these steps:
 *__PS__*: make sure you have the pair myappname-web-ec2.pem saved in `~/.ssh/`
 
 ```bash
-ssh -i "myappname-web-ec2.pem" ubuntu@ec2-52-67-178-12.sa-east-1.compute.amazonaws.com
-ubuntu@ip-10-0-1-56:~$
+ssh -i "myappname-web-ec2.pem" admin@ec2-52-67-178-12.sa-east-1.compute.amazonaws.com
+admin@ip-10-0-1-56:~$
 ```
 
 After getting access to EC2, you need to grant root permissions:
 
 ```bash
-ubuntu@ip-10-0-1-56:~$ sudo su
-root@ip-10-0-1-56:/home/ubuntu$
+admin@ip-10-0-1-56:~$ sudo su
+root@ip-10-0-1-56:/home/root$
 ```
 
 Since the secrets are already updated, we are going to install them in the appropriate addresses
@@ -127,14 +127,14 @@ If you are updating DeployEx, you may need to update the `deployex.sh` script. T
 ```bash
 version=0.3.0
 rm deployex.sh
-wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/ubuntu
+wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/root
 chmod a+x deployex.sh
 ```
 
 Run the script to install (or update) deployex:
 
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --install deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --install deployex.yaml
 #           Removing Deployex              #
 ...
 # Clean and create a new directory         #
@@ -151,13 +151,13 @@ vi deployex.yaml
 version: "0.9.1"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
-os_target: "ubuntu-24.04"
+os_target: "ubuntu-24.04"                                # DeployEx release artifact, the only one published. It runs on Debian 13 as well
 ...
 ```
 
 Once the file is updated, run the update command:
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --update deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --update deployex.yaml
 ```
 
 > [!IMPORTANT]
@@ -205,69 +205,21 @@ Here are some useful resources with suggestions on how to automate the upload of
 > Before proceeding, make sure that the DNS is correctly configured to point to the AWS instance.
 
 
- For HTTPS, you can use free certificates from [Let's encrypt](https://letsencrypt.org/getting-started/). In this example, we'll use [cert bot for ubuntu](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) to obtain and configure the certificates:
+HTTPS is set up automatically while the instance boots. `cloud-config.tpl` installs `certbot`, serves plain HTTP with a `/.well-known/acme-challenge/` location, and `setup-tls.sh` obtains the certificate and enables the HTTPS server blocks. No ssh session is needed.
+
+The certificate is requested for `${hostname}` and `${deployex_hostname}`, so both must resolve to the instance **before** it boots, otherwise the HTTP-01 challenge fails. When that happens the instance stays on HTTP and the reason is written to `/var/log/cloud-init-output.log`; fix the DNS and re-run `/root/setup-tls.sh`.
+
+Certbot never edits the nginx configuration here. It only obtains the certificate, and the TLS server blocks are written by `cloud-config.tpl` referencing the well known paths:
 
 ```bash
-sudo su
-apt update
-apt install snapd
-snap install --classic certbot
-ln -s /snap/bin/certbot /usr/bin/certbot
+ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
 ```
 
-Before installing the certificate, make a backup of the current Nginx configuration file located at `/etc/nginx/sites-available/default`. Certbot may modify this file, so keeping a local copy ensures you can restore it if needed. Once the backup is created, run the following command:
-```bash
-certbot --nginx
-```
-
-This command will install Certbot and automatically configure Nginx to use the obtained certificates. After Nginx is configured, the certificate paths will be set up and will look something like this:
-
-```bash
-vi /etc/nginx/sites-available/default
- ...
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-```
-
-Update your configuration file to include the Let's Encrypt certificate paths. Find the section where it mentions:
-
-```bash
-           # Add here the letsencrypt paths
-```
-replace this comment with the actual certificate paths:
-```bash
-               proxy_set_header Upgrade $http_upgrade;
-               proxy_set_header Connection "upgrade";
-
-               proxy_pass http://deployex;
-           }
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-       }
-```
-
-Also, ensure that port 443 is enabled for both servers. For example:
-
-```bash
-      server {
-          listen 443 ssl; # managed by Certbot
-```
-
-After modifying the configuration file, save the changes and restart Nginx:
-
-```bash
-sudo su
-vi /etc/nginx/sites-available/default
-# modify and save file
-systemctl reload nginx
-```
+That means the template stays the source of truth. Anything certbot wrote into the config would otherwise be lost the next time terraform replaces the instance, which any change to `cloud-config.tpl` does.
 
 > [!NOTE]
-> After the changes, It may require a reboot.
+> `setup-tls.sh` runs on every boot and is safe to re-run. `--keep-until-expiring` leaves a still valid certificate alone, which matters because Let's Encrypt allows only 5 identical certificates per week and instance replacement is routine. The certificate does not survive a replacement, so it is reissued on the next boot.
 
 [tls]: https://github.com/thiagoesteves/deployex/blob/main/devops/scripts/certificates/otp-28/tls-distribution-certs
 [main]: https://github.com/thiagoesteves/deployex/blob/main/guides/docs/aws-erlang/terraform/environments/prod/main_example.tf_

--- a/guides/docs/aws-erlang/terraform/environments/prod/main_example.tf_
+++ b/guides/docs/aws-erlang/terraform/environments/prod/main_example.tf_
@@ -12,5 +12,6 @@ module "standard_account" {
   replicas          = 3
   ec2_instance_type = "t2.medium"
   deployex_dns      = "deployex.myappname.com"
+  certbot_email      = "ops@myappname.com"
   deployex_version  = "0.9.1"
 }

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
@@ -205,7 +205,7 @@ write_files:
           }
       }
 
-  - path: /root/nginx-tls.conf
+  - path: /home/root/nginx-tls.conf
     owner: root:root
     permissions: "0644"
     content: |
@@ -307,7 +307,7 @@ write_files:
            --email ${certbot_email} \
            --agree-tos --non-interactive --keep-until-expiring \
            --deploy-hook "systemctl reload nginx"; then
-        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+        install -o root -g root -m 0644 /home/root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
 
         if nginx -t; then
           systemctl reload nginx

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
@@ -7,11 +7,11 @@
 #
 packages:
  - certbot
+ - yq
  - unzip
  - nginx
  - logrotate
  - awscli
- - jq
  - amazon-ssm-agent
 
 write_files:
@@ -333,10 +333,6 @@ runcmd:
   - systemctl enable amazon-ssm-agent
   # RDS server certificate chain, used by the Ecto repo to verify the database
   - curl -o /etc/ssl/certs/rds-global.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
-  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
-  # not ship by default
-  - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-  - chmod a+x /usr/local/bin/yq
   # Install OTP certificates from AWS Secrets Manager
   - /home/root/install-otp-certificates.sh
   # Download and install Deployex

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
@@ -85,7 +85,7 @@ write_files:
               enable_restart: true
               warning_threshold_percent: 75
               restart_threshold_percent: 90
-  - path: /home/root/config.json
+  - path: /home/root/cloud-watch-config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -284,7 +284,7 @@ write_files:
           }
       }
 
-  - path: /root/setup-tls.sh
+  - path: /home/root/setup-tls.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -323,22 +323,34 @@ write_files:
         exit 1
       fi
 runcmd:
+  # Set the hostname so the environment is obvious on the box and in logs
+  - hostnamectl set-hostname myappname-${account_name}-debian
+  - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
+  # AWS CLI, used by install-otp-certificates.sh to read from Secrets Manager
   - cd /tmp
-  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o"  "awscliv2.zip"
+  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o" "awscliv2.zip"
   - unzip "awscliv2.zip"
   - ./aws/install
   - ./aws/install --update
-  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
+  # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
+  # Install OTP certificates from AWS Secrets Manager
+  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex
   - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
   - chmod a+x /home/root/deployex.sh
   - /home/root/deployex.sh --install /home/root/deployex.yaml
+  # Install and configure CloudWatch agent
   - wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
   - dpkg -i -E ./amazon-cloudwatch-agent.deb
-  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/config.json -s
+  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/cloud-watch-config.json -s
+  # Enable Nginx
   - systemctl enable nginx
   - systemctl restart nginx
-  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
-  - /root/setup-tls.sh
+  # nginx is serving HTTP at this point, which is all the HTTP-01 challenge needs
+  - /home/root/setup-tls.sh
+  # Reboot to apply all changes
+  - sleep 5
   - reboot

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
@@ -6,12 +6,13 @@
 #    /var/log/cloud-init-output.log
 #
 packages:
+ - certbot
  - unzip
  - nginx
  - logrotate
 
 write_files:
-  - path: /home/ubuntu/install-otp-certificates.sh
+  - path: /home/root/install-otp-certificates.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -28,7 +29,7 @@ write_files:
       aws secretsmanager get-secret-value --secret-id myappname-${account_name}-otp-tls-crt | jq -r .SecretString > /usr/local/share/ca-certificates/deployex.crt
       aws secretsmanager get-secret-value --secret-id myappname-${account_name}-otp-tls-crt | jq -r .SecretString > /usr/local/share/ca-certificates/myappname.crt
       echo "[OK]"
-  - path: /home/ubuntu/deployex.yaml
+  - path: /home/root/deployex.yaml
     owner: root:root
     permissions: "0644"
     content: |
@@ -84,7 +85,7 @@ write_files:
               enable_restart: true
               warning_threshold_percent: 75
               restart_threshold_percent: 90
-  - path: /home/ubuntu/config.json
+  - path: /home/root/config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -184,25 +185,55 @@ write_files:
       }
 
       server {
+          listen 80 default_server;
+          server_name _;
+          return 404;
+      }
+
+      server {
           listen 80;
           server_name ${hostname} ${deployex_hostname};
 
-          if ($host = ${hostname}) {
+          # HTTP-01 challenge, for the first issue and for every renewal. certbot only ever
+          # writes files under this root, it does not touch the nginx configuration
+          location /.well-known/acme-challenge/ {
+              root /var/www/certbot;
+          }
+
+          location / {
               return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-
-          if ($host = ${deployex_hostname}) {
-              return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-          return 404; # managed by Certbot
+          }
       }
 
-      server { 
-          #listen 443 ssl; # managed by Certbot
+  - path: /root/nginx-tls.conf
+    owner: root:root
+    permissions: "0644"
+    content: |
+      # Installed into /etc/nginx/conf.d/ by setup-tls.sh once the certificate exists. One
+      # certificate covers both names, under a lineage named after ${hostname}.
+      #
+      # The TLS parameters are written out instead of including
+      # /etc/letsencrypt/options-ssl-nginx.conf. That file is created by the certbot nginx
+      # installer plugin, which does not run here because the certificate is obtained with
+      # certonly --webroot, so it does not exist on the box. These are the same values.
+      #
+      # They sit inside the server blocks rather than at http level, because the stock
+      # nginx.conf already sets ssl_protocols and ssl_prefer_server_ciphers there and nginx
+      # rejects the duplicates.
+      server {
+          listen 443 ssl;
           server_name  ${deployex_hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -219,14 +250,22 @@ write_files:
 
               proxy_pass http://deployex;
           }
-          
-          # Add here the letsencrypt paths
       }
 
       server {
-          #listen 443 ssl; # managed by Certbot
+          listen 443 ssl;
           server_name  ${hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -243,23 +282,63 @@ write_files:
 
               proxy_pass http://erlang;
           }
-          # Add here the letsencrypt paths
       }
+
+  - path: /root/setup-tls.sh
+    owner: root:root
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      #
+      #  Obtain the TLS certificate and enable the HTTPS server blocks.
+      #
+      #  Runs on every boot and is idempotent: --keep-until-expiring leaves a still valid
+      #  certificate alone, which matters because any cloud-config change replaces the
+      #  instance and Let's Encrypt only allows 5 identical certificates per week.
+      #
+      set -uo pipefail
+
+      mkdir -p /var/www/certbot
+
+      if certbot certonly \
+           --webroot --webroot-path /var/www/certbot \
+           --cert-name ${hostname} \
+           -d ${hostname} -d ${deployex_hostname} \
+           --email ${certbot_email} \
+           --agree-tos --non-interactive --keep-until-expiring \
+           --deploy-hook "systemctl reload nginx"; then
+        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+
+        if nginx -t; then
+          systemctl reload nginx
+        else
+          # Never leave nginx unable to start, HTTP is better than nothing
+          rm -f /etc/nginx/conf.d/tls.conf
+          echo "setup-tls: generated TLS config failed nginx -t, staying on HTTP" >&2
+          exit 1
+        fi
+      else
+        echo "setup-tls: certbot failed, staying on HTTP. Check that ${hostname} and" >&2
+        echo "           ${deployex_hostname} resolve to this instance, then re-run." >&2
+        exit 1
+      fi
 runcmd:
   - cd /tmp
   - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o"  "awscliv2.zip"
   - unzip "awscliv2.zip"
   - ./aws/install
   - ./aws/install --update
-  - /home/ubuntu/install-otp-certificates.sh
+  - /home/root/install-otp-certificates.sh
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
-  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/ubuntu
-  - chmod a+x /home/ubuntu/deployex.sh
-  - /home/ubuntu/deployex.sh --install /home/ubuntu/deployex.yaml
+  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
+  - chmod a+x /home/root/deployex.sh
+  - /home/root/deployex.sh --install /home/root/deployex.yaml
   - wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
   - dpkg -i -E ./amazon-cloudwatch-agent.deb
-  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/ubuntu/config.json -s
-  - systemctl enable --no-block nginx 
-  - systemctl start --no-block nginx
+  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/config.json -s
+  - systemctl enable nginx
+  - systemctl restart nginx
+  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
+  - /root/setup-tls.sh
   - reboot

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/cloud-config.tpl
@@ -10,6 +10,9 @@ packages:
  - unzip
  - nginx
  - logrotate
+ - awscli
+ - jq
+ - amazon-ssm-agent
 
 write_files:
   - path: /home/root/install-otp-certificates.sh
@@ -326,12 +329,10 @@ runcmd:
   # Set the hostname so the environment is obvious on the box and in logs
   - hostnamectl set-hostname myappname-${account_name}-debian
   - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
-  # AWS CLI, used by install-otp-certificates.sh to read from Secrets Manager
-  - cd /tmp
-  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o" "awscliv2.zip"
-  - unzip "awscliv2.zip"
-  - ./aws/install
-  - ./aws/install --update
+  # Enable AWS Systems Manager agent
+  - systemctl enable amazon-ssm-agent
+  # RDS server certificate chain, used by the Ecto repo to verify the database
+  - curl -o /etc/ssl/certs/rds-global.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
   # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
   # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/ec2.tf
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/ec2.tf
@@ -1,9 +1,9 @@
-data "aws_ami" "ubuntu" {
+data "aws_ami" "debian" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+    values = ["debian-13-amd64-*"]
   }
 
   filter {
@@ -11,7 +11,7 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["136693071363"] # Debian official
 }
 
 resource "aws_security_group" "ec2_security" {
@@ -102,6 +102,7 @@ data "cloudinit_config" "server_config" {
     content = templatefile("${path.module}/cloud-config.tpl", {
       hostname = "${var.server_dns}"
       deployex_hostname = "${var.deployex_dns}"
+      certbot_email = "${var.certbot_email}"
       deployex_version = "${var.deployex_version}"
       log_group_name = aws_cloudwatch_log_group.ec2_instance_logs.name
       account_name = "${var.account_name}"
@@ -112,7 +113,7 @@ data "cloudinit_config" "server_config" {
 }
 
 resource "aws_instance" "ec2_myappname_instance" {
-  ami                         = data.aws_ami.ubuntu.id
+  ami                         = data.aws_ami.debian.id
   instance_type               = "${var.ec2_instance_type}"
   key_name                    = "${var.aws_key_name}"
   vpc_security_group_ids      = [aws_security_group.ec2_security.id]

--- a/guides/docs/aws-erlang/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/aws-erlang/terraform/modules/standard-account/variables.tf
@@ -44,3 +44,8 @@ variable "log_retention_in_days" {
   type        = number
   default     = 30
 }
+# Address Let's Encrypt uses for expiry notices, see setup-tls.sh in cloud-config.tpl
+variable "certbot_email" {
+  type     = string
+  nullable = false
+}

--- a/guides/docs/aws-gleam/README.md
+++ b/guides/docs/aws-gleam/README.md
@@ -98,15 +98,15 @@ For initial installations or updates to deployex, follow these steps:
 *__PS__*: make sure you have the pair myappname-web-ec2.pem saved in `~/.ssh/`
 
 ```bash
-ssh -i "myappname-web-ec2.pem" ubuntu@ec2-52-67-178-12.sa-east-1.compute.amazonaws.com
-ubuntu@ip-10-0-1-56:~$
+ssh -i "myappname-web-ec2.pem" admin@ec2-52-67-178-12.sa-east-1.compute.amazonaws.com
+admin@ip-10-0-1-56:~$
 ```
 
 After getting access to EC2, you need to grant root permissions:
 
 ```bash
-ubuntu@ip-10-0-1-56:~$ sudo su
-root@ip-10-0-1-56:/home/ubuntu$
+admin@ip-10-0-1-56:~$ sudo su
+root@ip-10-0-1-56:/home/root$
 ```
 
 Since the secrets are already updated, we are going to install them in the appropriate addresses
@@ -128,14 +128,14 @@ If you are updating DeployEx, you may need to update the `deployex.sh` script. T
 ```bash
 version=0.3.0
 rm deployex.sh
-wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/ubuntu
+wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/root
 chmod a+x deployex.sh
 ```
 
 Run the script to install (or update) deployex:
 
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --install deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --install deployex.yaml
 #           Removing Deployex              #
 ...
 # Clean and create a new directory         #
@@ -152,13 +152,13 @@ vi deployex.yaml
 version: "0.9.1"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
-os_target: "ubuntu-24.04"
+os_target: "ubuntu-24.04"                                # DeployEx release artifact, the only one published. It runs on Debian 13 as well
 ...
 ```
 
 Once the file is updated, run the update command:
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --update deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --update deployex.yaml
 ```
 
 > [!IMPORTANT]
@@ -206,69 +206,21 @@ Here are some useful resources with suggestions on how to automate the upload of
 > Before proceeding, make sure that the DNS is correctly configured to point to the AWS instance.
 
 
- For HTTPS, you can use free certificates from [Let's encrypt](https://letsencrypt.org/getting-started/). In this example, we'll use [cert bot for ubuntu](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) to obtain and configure the certificates:
+HTTPS is set up automatically while the instance boots. `cloud-config.tpl` installs `certbot`, serves plain HTTP with a `/.well-known/acme-challenge/` location, and `setup-tls.sh` obtains the certificate and enables the HTTPS server blocks. No ssh session is needed.
+
+The certificate is requested for `${hostname}` and `${deployex_hostname}`, so both must resolve to the instance **before** it boots, otherwise the HTTP-01 challenge fails. When that happens the instance stays on HTTP and the reason is written to `/var/log/cloud-init-output.log`; fix the DNS and re-run `/root/setup-tls.sh`.
+
+Certbot never edits the nginx configuration here. It only obtains the certificate, and the TLS server blocks are written by `cloud-config.tpl` referencing the well known paths:
 
 ```bash
-sudo su
-apt update
-apt install snapd
-snap install --classic certbot
-ln -s /snap/bin/certbot /usr/bin/certbot
+ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
 ```
 
-Before installing the certificate, make a backup of the current Nginx configuration file located at `/etc/nginx/sites-available/default`. Certbot may modify this file, so keeping a local copy ensures you can restore it if needed. Once the backup is created, run the following command:
-```bash
-certbot --nginx
-```
-
-This command will install Certbot and automatically configure Nginx to use the obtained certificates. After Nginx is configured, the certificate paths will be set up and will look something like this:
-
-```bash
-vi /etc/nginx/sites-available/default
- ...
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-```
-
-Update your configuration file to include the Let's Encrypt certificate paths. Find the section where it mentions:
-
-```bash
-           # Add here the letsencrypt paths
-```
-replace this comment with the actual certificate paths:
-```bash
-               proxy_set_header Upgrade $http_upgrade;
-               proxy_set_header Connection "upgrade";
-
-               proxy_pass http://deployex;
-           }
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-       }
-```
-
-Also, ensure that port 443 is enabled for both servers. For example:
-
-```bash
-      server {
-          listen 443 ssl; # managed by Certbot
-```
-
-After modifying the configuration file, save the changes and restart Nginx:
-
-```bash
-sudo su
-vi /etc/nginx/sites-available/default
-# modify and save file
-systemctl reload nginx
-```
+That means the template stays the source of truth. Anything certbot wrote into the config would otherwise be lost the next time terraform replaces the instance, which any change to `cloud-config.tpl` does.
 
 > [!NOTE]
-> After the changes, It may require a reboot.
+> `setup-tls.sh` runs on every boot and is safe to re-run. `--keep-until-expiring` leaves a still valid certificate alone, which matters because Let's Encrypt allows only 5 identical certificates per week and instance replacement is routine. The certificate does not survive a replacement, so it is reissued on the next boot.
 
 [tls]: https://github.com/thiagoesteves/deployex/blob/main/devops/scripts/certificates/otp-28/tls-distribution-certs
 [main]: https://github.com/thiagoesteves/deployex/blob/main/guides/docs/aws-gleam/terraform/environments/prod/main_example.tf_

--- a/guides/docs/aws-gleam/terraform/environments/prod/main_example.tf_
+++ b/guides/docs/aws-gleam/terraform/environments/prod/main_example.tf_
@@ -12,5 +12,6 @@ module "standard_account" {
   replicas          = "3"
   ec2_instance_type = "t2.medium"
   deployex_dns      = "deployex.myappname.com"
+  certbot_email      = "ops@myappname.com"
   deployex_version  = "0.9.1"
 }

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
@@ -6,12 +6,13 @@
 #    /var/log/cloud-init-output.log
 #
 packages:
+ - certbot
  - unzip
  - nginx
  - logrotate
 
 write_files:
-  - path: /home/ubuntu/install-otp-certificates.sh
+  - path: /home/root/install-otp-certificates.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -28,7 +29,7 @@ write_files:
       aws secretsmanager get-secret-value --secret-id myappname-${account_name}-otp-tls-crt | jq -r .SecretString > /usr/local/share/ca-certificates/deployex.crt
       aws secretsmanager get-secret-value --secret-id myappname-${account_name}-otp-tls-crt | jq -r .SecretString > /usr/local/share/ca-certificates/myappname.crt
       echo "[OK]"
-  - path: /home/ubuntu/deployex.yaml
+  - path: /home/root/deployex.yaml
     owner: root:root
     permissions: "0644"
     content: |
@@ -84,7 +85,7 @@ write_files:
               enable_restart: true
               warning_threshold_percent: 75
               restart_threshold_percent: 90
-  - path: /home/ubuntu/config.json
+  - path: /home/root/config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -184,25 +185,55 @@ write_files:
       }
 
       server {
-          listen 80;
-          server_name myappname.com.br deployex.myappname.com.br;
-
-          if ($host = myappname.com.br) {
-              return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-
-          if ($host = deployex.myappname.com.br) {
-              return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-          return 404; # managed by Certbot
+          listen 80 default_server;
+          server_name _;
+          return 404;
       }
 
-      server { 
-          #listen 443 ssl; # managed by Certbot
-          server_name  deployex.myappname.com.br;
+      server {
+          listen 80;
+          server_name ${hostname} ${deployex_hostname};
+
+          # HTTP-01 challenge, for the first issue and for every renewal. certbot only ever
+          # writes files under this root, it does not touch the nginx configuration
+          location /.well-known/acme-challenge/ {
+              root /var/www/certbot;
+          }
+
+          location / {
+              return 301 https://$host$request_uri;
+          }
+      }
+
+  - path: /root/nginx-tls.conf
+    owner: root:root
+    permissions: "0644"
+    content: |
+      # Installed into /etc/nginx/conf.d/ by setup-tls.sh once the certificate exists. One
+      # certificate covers both names, under a lineage named after ${hostname}.
+      #
+      # The TLS parameters are written out instead of including
+      # /etc/letsencrypt/options-ssl-nginx.conf. That file is created by the certbot nginx
+      # installer plugin, which does not run here because the certificate is obtained with
+      # certonly --webroot, so it does not exist on the box. These are the same values.
+      #
+      # They sit inside the server blocks rather than at http level, because the stock
+      # nginx.conf already sets ssl_protocols and ssl_prefer_server_ciphers there and nginx
+      # rejects the duplicates.
+      server {
+          listen 443 ssl;
+          server_name  ${deployex_hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -219,14 +250,22 @@ write_files:
 
               proxy_pass http://deployex;
           }
-          
-          # Add here the letsencrypt paths
       }
 
       server {
-          #listen 443 ssl; # managed by Certbot
-          server_name  myappname.com.br;
+          listen 443 ssl;
+          server_name  ${hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -243,26 +282,66 @@ write_files:
 
               proxy_pass http://gleam;
           }
-          # Add here the letsencrypt paths
       }
+
+  - path: /root/setup-tls.sh
+    owner: root:root
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      #
+      #  Obtain the TLS certificate and enable the HTTPS server blocks.
+      #
+      #  Runs on every boot and is idempotent: --keep-until-expiring leaves a still valid
+      #  certificate alone, which matters because any cloud-config change replaces the
+      #  instance and Let's Encrypt only allows 5 identical certificates per week.
+      #
+      set -uo pipefail
+
+      mkdir -p /var/www/certbot
+
+      if certbot certonly \
+           --webroot --webroot-path /var/www/certbot \
+           --cert-name ${hostname} \
+           -d ${hostname} -d ${deployex_hostname} \
+           --email ${certbot_email} \
+           --agree-tos --non-interactive --keep-until-expiring \
+           --deploy-hook "systemctl reload nginx"; then
+        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+
+        if nginx -t; then
+          systemctl reload nginx
+        else
+          # Never leave nginx unable to start, HTTP is better than nothing
+          rm -f /etc/nginx/conf.d/tls.conf
+          echo "setup-tls: generated TLS config failed nginx -t, staying on HTTP" >&2
+          exit 1
+        fi
+      else
+        echo "setup-tls: certbot failed, staying on HTTP. Check that ${hostname} and" >&2
+        echo "           ${deployex_hostname} resolve to this instance, then re-run." >&2
+        exit 1
+      fi
 runcmd:
   - cd /tmp
   - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o"  "awscliv2.zip"
   - unzip "awscliv2.zip"
   - ./aws/install
   - ./aws/install --update
-  - /home/ubuntu/install-otp-certificates.sh
+  - /home/root/install-otp-certificates.sh
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
-  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/ubuntu
-  - chmod a+x /home/ubuntu/deployex.sh
-  - /home/ubuntu/deployex.sh --install /home/ubuntu/deployex.yaml
+  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
+  - chmod a+x /home/root/deployex.sh
+  - /home/root/deployex.sh --install /home/root/deployex.yaml
   - wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
   - dpkg -i -E ./amazon-cloudwatch-agent.deb
-  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/ubuntu/config.json -s
+  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/config.json -s
   - apt install -y build-essential libssl-dev libgtk-3-dev libncurses5-dev libncursesw5-dev libreadline-dev
   - wget https://github.com/erlang/otp/releases/download/OTP-26.1.2/otp_src_26.1.2.tar.gz
   - tar -xzf otp_src_26.1.2.tar.gz && cd otp_src_26.1.2 && ./configure && make && make install
-  - systemctl enable --no-block nginx 
-  - systemctl start --no-block nginx
+  - systemctl enable nginx
+  - systemctl restart nginx
+  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
+  - /root/setup-tls.sh
   - reboot

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
@@ -205,7 +205,7 @@ write_files:
           }
       }
 
-  - path: /root/nginx-tls.conf
+  - path: /home/root/nginx-tls.conf
     owner: root:root
     permissions: "0644"
     content: |
@@ -307,7 +307,7 @@ write_files:
            --email ${certbot_email} \
            --agree-tos --non-interactive --keep-until-expiring \
            --deploy-hook "systemctl reload nginx"; then
-        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+        install -o root -g root -m 0644 /home/root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
 
         if nginx -t; then
           systemctl reload nginx

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
@@ -7,11 +7,11 @@
 #
 packages:
  - certbot
+ - yq
  - unzip
  - nginx
  - logrotate
  - awscli
- - jq
  - amazon-ssm-agent
 
 write_files:
@@ -333,10 +333,6 @@ runcmd:
   - systemctl enable amazon-ssm-agent
   # RDS server certificate chain, used by the Ecto repo to verify the database
   - curl -o /etc/ssl/certs/rds-global.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
-  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
-  # not ship by default
-  - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-  - chmod a+x /usr/local/bin/yq
   # Install OTP certificates from AWS Secrets Manager
   - /home/root/install-otp-certificates.sh
   # Download and install Deployex

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
@@ -10,6 +10,9 @@ packages:
  - unzip
  - nginx
  - logrotate
+ - awscli
+ - jq
+ - amazon-ssm-agent
 
 write_files:
   - path: /home/root/install-otp-certificates.sh
@@ -326,12 +329,10 @@ runcmd:
   # Set the hostname so the environment is obvious on the box and in logs
   - hostnamectl set-hostname myappname-${account_name}-debian
   - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
-  # AWS CLI, used by install-otp-certificates.sh to read from Secrets Manager
-  - cd /tmp
-  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o" "awscliv2.zip"
-  - unzip "awscliv2.zip"
-  - ./aws/install
-  - ./aws/install --update
+  # Enable AWS Systems Manager agent
+  - systemctl enable amazon-ssm-agent
+  # RDS server certificate chain, used by the Ecto repo to verify the database
+  - curl -o /etc/ssl/certs/rds-global.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
   # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
   # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/cloud-config.tpl
@@ -85,7 +85,7 @@ write_files:
               enable_restart: true
               warning_threshold_percent: 75
               restart_threshold_percent: 90
-  - path: /home/root/config.json
+  - path: /home/root/cloud-watch-config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -284,7 +284,7 @@ write_files:
           }
       }
 
-  - path: /root/setup-tls.sh
+  - path: /home/root/setup-tls.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -323,25 +323,38 @@ write_files:
         exit 1
       fi
 runcmd:
+  # Set the hostname so the environment is obvious on the box and in logs
+  - hostnamectl set-hostname myappname-${account_name}-debian
+  - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
+  # AWS CLI, used by install-otp-certificates.sh to read from Secrets Manager
   - cd /tmp
-  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o"  "awscliv2.zip"
+  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" "-o" "awscliv2.zip"
   - unzip "awscliv2.zip"
   - ./aws/install
   - ./aws/install --update
-  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
+  # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
+  # Install OTP certificates from AWS Secrets Manager
+  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex
   - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
   - chmod a+x /home/root/deployex.sh
   - /home/root/deployex.sh --install /home/root/deployex.yaml
+  # Install and configure CloudWatch agent
   - wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
   - dpkg -i -E ./amazon-cloudwatch-agent.deb
-  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/config.json -s
+  - /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/home/root/cloud-watch-config.json -s
+  # Build a newer OTP than the distribution ships, required by Gleam
   - apt install -y build-essential libssl-dev libgtk-3-dev libncurses5-dev libncursesw5-dev libreadline-dev
   - wget https://github.com/erlang/otp/releases/download/OTP-26.1.2/otp_src_26.1.2.tar.gz
   - tar -xzf otp_src_26.1.2.tar.gz && cd otp_src_26.1.2 && ./configure && make && make install
+  # Enable Nginx
   - systemctl enable nginx
   - systemctl restart nginx
-  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
-  - /root/setup-tls.sh
+  # nginx is serving HTTP at this point, which is all the HTTP-01 challenge needs
+  - /home/root/setup-tls.sh
+  # Reboot to apply all changes
+  - sleep 5
   - reboot

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/ec2.tf
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/ec2.tf
@@ -1,9 +1,9 @@
-data "aws_ami" "ubuntu" {
+data "aws_ami" "debian" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+    values = ["debian-13-amd64-*"]
   }
 
   filter {
@@ -11,7 +11,7 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"] # Canonical
+  owners = ["136693071363"] # Debian official
 }
 
 resource "aws_security_group" "ec2_security" {
@@ -102,6 +102,7 @@ data "cloudinit_config" "server_config" {
     content = templatefile("${path.module}/cloud-config.tpl", {
       hostname = "${var.server_dns}"
       deployex_hostname = "${var.deployex_dns}"
+      certbot_email = "${var.certbot_email}"
       deployex_version = "${var.deployex_version}"
       log_group_name = aws_cloudwatch_log_group.ec2_instance_logs.name
       account_name = "${var.account_name}"
@@ -112,7 +113,7 @@ data "cloudinit_config" "server_config" {
 }
 
 resource "aws_instance" "ec2_myappname_instance" {
-  ami                         = data.aws_ami.ubuntu.id
+  ami                         = data.aws_ami.debian.id
   instance_type               = "${var.ec2_instance_type}"
   key_name                    = "${var.aws_key_name}"
   vpc_security_group_ids      = [aws_security_group.ec2_security.id]

--- a/guides/docs/aws-gleam/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/aws-gleam/terraform/modules/standard-account/variables.tf
@@ -44,3 +44,8 @@ variable "log_retention_in_days" {
   type        = number
   default     = 30
 }
+# Address Let's Encrypt uses for expiry notices, see setup-tls.sh in cloud-config.tpl
+variable "certbot_email" {
+  type     = string
+  nullable = false
+}

--- a/guides/docs/gcp-elixir/README.md
+++ b/guides/docs/gcp-elixir/README.md
@@ -90,8 +90,8 @@ For initial installations or updates to deployex, access the Google Compute Inst
 
 ```bash
 my-user@myfirstapp-prod-instance:~$ sudo su
-root@myfirstapp-prod-instance:/home/my-user# cd ../ubuntu/
-root@myfirstapp-prod-instance:/home/ubuntu# ls
+root@myfirstapp-prod-instance:/home/my-user# cd ../root/
+root@myfirstapp-prod-instance:/home/root# ls
 ```
 
 Check the configuration for DeployEx and your target app by editing the `deployex-config.json` file:
@@ -141,14 +141,14 @@ If you are updating DeployEx, you may need to update the `deployex.sh` script. T
 ```bash
 version=0.3.0
 rm deployex.sh
-wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/ubuntu
+wget https://github.com/thiagoesteves/deployex/releases/download/${version}/deployex.sh -P /home/root
 chmod a+x deployex.sh
 ```
 
 Run the script to install (or update) deployex:
 
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --install deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --install deployex.yaml
 #           Removing Deployex              #
 ...
 # Clean and create a new directory         #
@@ -165,13 +165,13 @@ vi deployex.yaml
 version: "0.9.1"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
-os_target: "ubuntu-24.04"
+os_target: "ubuntu-24.04"                                # DeployEx release artifact, the only one published. It runs on Debian 13 as well
 ...
 ```
 
 Once the file is updated, run the update command:
 ```bash
-root@ip-10-0-1-116:/home/ubuntu# ./deployex.sh --update deployex.yaml
+root@ip-10-0-1-116:/home/root# ./deployex.sh --update deployex.yaml
 ```
 
 > [!IMPORTANT]
@@ -221,69 +221,21 @@ Here are some useful resources with suggestions on how to automate the upload of
 > Before proceeding, make sure that the DNS is correctly configured to point to the GCP instance.
 
 
- For HTTPS, you can use free certificates from [Let's encrypt](https://letsencrypt.org/getting-started/). In this example, we'll use [cert bot for ubuntu](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) to obtain and configure the certificates:
+HTTPS is set up automatically while the instance boots. `cloud-config.tpl` installs `certbot`, serves plain HTTP with a `/.well-known/acme-challenge/` location, and `setup-tls.sh` obtains the certificate and enables the HTTPS server blocks. No ssh session is needed.
+
+The certificate is requested for `${hostname}` and `${deployex_hostname}`, so both must resolve to the instance **before** it boots, otherwise the HTTP-01 challenge fails. When that happens the instance stays on HTTP and the reason is written to `/var/log/cloud-init-output.log`; fix the DNS and re-run `/root/setup-tls.sh`.
+
+Certbot never edits the nginx configuration here. It only obtains the certificate, and the TLS server blocks are written by `cloud-config.tpl` referencing the well known paths:
 
 ```bash
-sudo su
-apt update
-apt install snapd
-snap install --classic certbot
-ln -s /snap/bin/certbot /usr/bin/certbot
+ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
 ```
 
-Before installing the certificate, make a backup of the current Nginx configuration file located at `/etc/nginx/sites-available/default`. Certbot may modify this file, so keeping a local copy ensures you can restore it if needed. Once the backup is created, run the following command:
-```bash
-certbot --nginx
-```
-
-This command will install Certbot and automatically configure Nginx to use the obtained certificates. After Nginx is configured, the certificate paths will be set up and will look something like this:
-
-```bash
-vi /etc/nginx/sites-available/default
- ...
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-```
-
-Update your configuration file to include the Let's Encrypt certificate paths. Find the section where it mentions:
-
-```bash
-           # Add here the letsencrypt paths
-```
-replace this comment with the actual certificate paths:
-```bash
-               proxy_set_header Upgrade $http_upgrade;
-               proxy_set_header Connection "upgrade";
-
-               proxy_pass http://deployex;
-           }
-           ssl_certificate /etc/letsencrypt/live/myappname.com/fullchain.pem; # managed by Certbot
-           ssl_certificate_key /etc/letsencrypt/live/myappname.com/privkey.pem; # managed by Certbot
-           include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-           ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-       }
-```
-
-Also, ensure that port 443 is enabled for both servers. For example:
-
-```bash
-      server {
-          listen 443 ssl; # managed by Certbot
-```
-
-After modifying the configuration file, save the changes and restart Nginx:
-
-```bash
-sudo su
-vi /etc/nginx/sites-available/default
-# modify and save file
-systemctl reload nginx
-```
+That means the template stays the source of truth. Anything certbot wrote into the config would otherwise be lost the next time terraform replaces the instance, which any change to `cloud-config.tpl` does.
 
 > [!NOTE]
-> After the changes, It may require a reboot.
+> `setup-tls.sh` runs on every boot and is safe to re-run. `--keep-until-expiring` leaves a still valid certificate alone, which matters because Let's Encrypt allows only 5 identical certificates per week and instance replacement is routine. The certificate does not survive a replacement, so it is reissued on the next boot.
 
 [tls]: https://github.com/thiagoesteves/deployex/blob/main/devops/scripts/certificates/otp-28/tls-distribution-certs
 [main]: https://github.com/thiagoesteves/deployex/blob/main/guides/docs/aws-elixir/terraform/environments/prod/main_example.tf_

--- a/guides/docs/gcp-elixir/terraform/environments/prod/main_example.tf_
+++ b/guides/docs/gcp-elixir/terraform/environments/prod/main_example.tf_
@@ -13,5 +13,6 @@ module "standard_account" {
   replicas         = "3"
   machine_type     = "e2-micro"
   deployex_dns     = "deployex.myappname.com"
+  certbot_email     = "ops@myappname.com"
   deployex_version = "0.3.0-rc21"
 }

--- a/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -7,6 +7,7 @@
 #
 packages:
  - certbot
+ - yq
  - unzip
  - nginx
  - logrotate
@@ -276,10 +277,6 @@ runcmd:
   # Set the hostname so the environment is obvious on the box and in logs
   - hostnamectl set-hostname myappname-${account_name}-debian
   - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
-  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
-  # not ship by default
-  - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-  - chmod a+x /usr/local/bin/yq
   # Install OTP certificates from Google Secret Manager
   - /home/root/install-otp-certificates.sh
   # Download and install Deployex

--- a/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -6,12 +6,13 @@
 #    /var/log/cloud-init-output.log
 #
 packages:
+ - certbot
  - unzip
  - nginx
  - logrotate
 
 write_files:
-  - path: /home/ubuntu/install-otp-certificates.sh
+  - path: /home/root/install-otp-certificates.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -28,7 +29,7 @@ write_files:
       gcloud secrets versions access 1 --secret=myappname-${account_name}-otp-tls-crt > /usr/local/share/ca-certificates/deployex.crt
       gcloud secrets versions access 1 --secret=myappname-${account_name}-otp-tls-crt > /usr/local/share/ca-certificates/myappname.crt
       echo "[OK]"
-  - path: /home/ubuntu/gcp-config.json
+  - path: /home/root/gcp-config.json
     owner: root:root
     permissions: "0644"
     content: |
@@ -36,7 +37,7 @@ write_files:
         "type": "service_account" # Populate it after installation
         ...
       }
-  - path: /home/ubuntu/deployex.yaml
+  - path: /home/root/deployex.yaml
     owner: root:root
     permissions: "0644"
     content: |
@@ -47,7 +48,7 @@ write_files:
       release_bucket: "myappname-${account_name}-distribution"
       secrets_adapter: "gcp"
       secrets_path: "deployex-myappname-${account_name}-secrets"
-      google_credentials: "/home/ubuntu/gcp-config.json"
+      google_credentials: "/home/root/gcp-config.json"
       version: "${deployex_version}"
       otp_version: 28
       otp_tls_certificates: "/usr/local/share/ca-certificates"
@@ -134,25 +135,55 @@ write_files:
       }
 
       server {
+          listen 80 default_server;
+          server_name _;
+          return 404;
+      }
+
+      server {
           listen 80;
           server_name ${hostname} ${deployex_hostname};
 
-          if ($host = ${hostname}) {
+          # HTTP-01 challenge, for the first issue and for every renewal. certbot only ever
+          # writes files under this root, it does not touch the nginx configuration
+          location /.well-known/acme-challenge/ {
+              root /var/www/certbot;
+          }
+
+          location / {
               return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-
-          if ($host = ${deployex_hostname}) {
-              return 301 https://$host$request_uri;
-          } # managed by Certbot
-
-          return 404; # managed by Certbot
+          }
       }
 
-      server { 
-          #listen 443 ssl; # managed by Certbot
+  - path: /root/nginx-tls.conf
+    owner: root:root
+    permissions: "0644"
+    content: |
+      # Installed into /etc/nginx/conf.d/ by setup-tls.sh once the certificate exists. One
+      # certificate covers both names, under a lineage named after ${hostname}.
+      #
+      # The TLS parameters are written out instead of including
+      # /etc/letsencrypt/options-ssl-nginx.conf. That file is created by the certbot nginx
+      # installer plugin, which does not run here because the certificate is obtained with
+      # certonly --webroot, so it does not exist on the box. These are the same values.
+      #
+      # They sit inside the server blocks rather than at http level, because the stock
+      # nginx.conf already sets ssl_protocols and ssl_prefer_server_ciphers there and nginx
+      # rejects the duplicates.
+      server {
+          listen 443 ssl;
           server_name  ${deployex_hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -169,14 +200,22 @@ write_files:
 
               proxy_pass http://deployex;
           }
-          
-          # Add here the letsencrypt paths
       }
 
       server {
-          #listen 443 ssl; # managed by Certbot
+          listen 443 ssl;
           server_name  ${hostname};
           client_max_body_size 30M;
+
+          ssl_certificate     /etc/letsencrypt/live/${hostname}/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/${hostname}/privkey.pem;
+
+          ssl_session_cache shared:deployex_SSL:10m;
+          ssl_session_timeout 1440m;
+          ssl_session_tickets off;
+          ssl_protocols TLSv1.2 TLSv1.3;
+          ssl_prefer_server_ciphers off;
+          ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305";
 
           location / {
               allow all;
@@ -193,15 +232,55 @@ write_files:
 
               proxy_pass http://phoenix;
           }
-          # Add here the letsencrypt paths
       }
+
+  - path: /root/setup-tls.sh
+    owner: root:root
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      #
+      #  Obtain the TLS certificate and enable the HTTPS server blocks.
+      #
+      #  Runs on every boot and is idempotent: --keep-until-expiring leaves a still valid
+      #  certificate alone, which matters because any cloud-config change replaces the
+      #  instance and Let's Encrypt only allows 5 identical certificates per week.
+      #
+      set -uo pipefail
+
+      mkdir -p /var/www/certbot
+
+      if certbot certonly \
+           --webroot --webroot-path /var/www/certbot \
+           --cert-name ${hostname} \
+           -d ${hostname} -d ${deployex_hostname} \
+           --email ${certbot_email} \
+           --agree-tos --non-interactive --keep-until-expiring \
+           --deploy-hook "systemctl reload nginx"; then
+        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+
+        if nginx -t; then
+          systemctl reload nginx
+        else
+          # Never leave nginx unable to start, HTTP is better than nothing
+          rm -f /etc/nginx/conf.d/tls.conf
+          echo "setup-tls: generated TLS config failed nginx -t, staying on HTTP" >&2
+          exit 1
+        fi
+      else
+        echo "setup-tls: certbot failed, staying on HTTP. Check that ${hostname} and" >&2
+        echo "           ${deployex_hostname} resolve to this instance, then re-run." >&2
+        exit 1
+      fi
 runcmd:
-  - /home/ubuntu/install-otp-certificates.sh
+  - /home/root/install-otp-certificates.sh
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
-  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/ubuntu
-  - chmod a+x /home/ubuntu/deployex.sh
-  - /home/ubuntu/deployex.sh --install /home/ubuntu/deployex.yaml
-  - systemctl enable --no-block nginx 
-  - systemctl start --no-block nginx
+  - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
+  - chmod a+x /home/root/deployex.sh
+  - /home/root/deployex.sh --install /home/root/deployex.yaml
+  - systemctl enable nginx
+  - systemctl restart nginx
+  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
+  - /root/setup-tls.sh
   - reboot

--- a/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -234,7 +234,7 @@ write_files:
           }
       }
 
-  - path: /root/setup-tls.sh
+  - path: /home/root/setup-tls.sh
     owner: root:root
     permissions: "0755"
     content: |
@@ -273,14 +273,24 @@ write_files:
         exit 1
       fi
 runcmd:
-  - /home/root/install-otp-certificates.sh
+  # Set the hostname so the environment is obvious on the box and in logs
+  - hostnamectl set-hostname myappname-${account_name}-debian
+  - echo "127.0.0.1 myappname-${account_name}-debian" >> /etc/hosts
+  # Download and install Deployex. deployex.sh reads its yaml with yq, which Debian does
+  # not ship by default
   - wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
   - chmod a+x /usr/local/bin/yq
+  # Install OTP certificates from Google Secret Manager
+  - /home/root/install-otp-certificates.sh
+  # Download and install Deployex
   - wget https://github.com/thiagoesteves/deployex/releases/download/${deployex_version}/deployex.sh -P /home/root
   - chmod a+x /home/root/deployex.sh
   - /home/root/deployex.sh --install /home/root/deployex.yaml
+  # Enable Nginx
   - systemctl enable nginx
   - systemctl restart nginx
-  # nginx serves HTTP at this point, which is all the HTTP-01 challenge needs
-  - /root/setup-tls.sh
+  # nginx is serving HTTP at this point, which is all the HTTP-01 challenge needs
+  - /home/root/setup-tls.sh
+  # Reboot to apply all changes
+  - sleep 5
   - reboot

--- a/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
+++ b/guides/docs/gcp-elixir/terraform/modules/standard-account/cloud-config.tpl
@@ -155,7 +155,7 @@ write_files:
           }
       }
 
-  - path: /root/nginx-tls.conf
+  - path: /home/root/nginx-tls.conf
     owner: root:root
     permissions: "0644"
     content: |
@@ -257,7 +257,7 @@ write_files:
            --email ${certbot_email} \
            --agree-tos --non-interactive --keep-until-expiring \
            --deploy-hook "systemctl reload nginx"; then
-        install -o root -g root -m 0644 /root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
+        install -o root -g root -m 0644 /home/root/nginx-tls.conf /etc/nginx/conf.d/tls.conf
 
         if nginx -t; then
           systemctl reload nginx

--- a/guides/docs/gcp-elixir/terraform/modules/standard-account/gce.tf
+++ b/guides/docs/gcp-elixir/terraform/modules/standard-account/gce.tf
@@ -35,6 +35,7 @@ data "cloudinit_config" "server_config" {
     content = templatefile("${path.module}/cloud-config.tpl", {
       hostname = "${var.server_dns}"
       deployex_hostname = "${var.deployex_dns}"
+      certbot_email = "${var.certbot_email}"
       deployex_version = "${var.deployex_version}"
       account_name = "${var.account_name}"
       replicas = "${var.replicas}"
@@ -49,7 +50,7 @@ resource "google_compute_instance" "dev" {
   tags         = ["externalssh","webserver"]
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-2004-lts"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {

--- a/guides/docs/gcp-elixir/terraform/modules/standard-account/variables.tf
+++ b/guides/docs/gcp-elixir/terraform/modules/standard-account/variables.tf
@@ -54,3 +54,9 @@ variable "publickeypath" {
     type = string
     default = "~/.ssh/id_rsa.pub"
 }
+
+# Address Let's Encrypt uses for expiry notices, see setup-tls.sh in cloud-config.tpl
+variable "certbot_email" {
+  type     = string
+  nullable = false
+}


### PR DESCRIPTION
Applies the same provisioning across **aws-elixir**, **aws-erlang**, **aws-gleam** and **gcp-elixir**, proven on a real stage instance first.

## What the guides told you to do

SSH in, install certbot from snap, back up `/etc/nginx/sites-available/default` because certbot would rewrite it, run `certbot --nginx`, then hand edit the result to uncomment `#listen 443 ssl;` and fill in `# Add here the letsencrypt paths`.

None of that survives. Any change to `cloud-config.tpl` replaces the instance and reverts every edit, so the whole sequence has to be repeated.

## What happens now

HTTPS comes up during boot, no ssh:

- `certbot` from the package manager, not snap
- nginx serves plain HTTP with a `/.well-known/acme-challenge/` location
- `setup-tls.sh` runs `certbot certonly --webroot`, installs the TLS blocks, reloads

Certbot **only obtains** the certificate. The TLS server blocks are written by cloud-config referencing `/etc/letsencrypt/live/${hostname}/`, so the template stays the source of truth. They live in a separate file installed after issuance because nginx will not start while an `ssl_certificate` path is missing.

## A bug in two of the guides

`aws-elixir` and `aws-gleam` hardcoded the example domains:

```
server_name myappname.com.br deployex.myappname.com.br;
```

while the template already received `${hostname}` and `${deployex_hostname}` and used them elsewhere. Since `certbot --nginx` reads `server_name` to decide which domains to request, following those guides literally would have requested certificates for `myappname.com.br`. Both are templated now, matching `aws-erlang` and `gcp-elixir`, which already were.

## Debian 13

AWS guides move to the Debian AMI, the GCP guide to `debian-cloud/debian-13`. Debian has no `ubuntu` user, so paths move to `/home/root` and the README ssh examples use `admin`.

`os_target` stays `ubuntu-24.04` - `releases.yaml` publishes only that artifact and it runs on Debian 13 - now with a note on the line so it does not read as an oversight.

## Three traps already paid for on stage

This pattern was built and debugged against a live instance, so the guides avoid mistakes that were made once already:

- **No `include /etc/letsencrypt/options-ssl-nginx.conf`.** That file is written by certbot's *nginx installer plugin*, which never runs with `certonly --webroot`. Including it fails `nginx -t` with `No such file or directory`. The settings are written out instead.
- **TLS settings inside the server blocks, not at http level.** The stock `nginx.conf` already sets `ssl_protocols` and `ssl_prefer_server_ciphers` there, and nginx rejects duplicates.
- **No `http2 on;`.** Debian 13 ships nginx 1.24; that directive needs 1.25.1+.

`setup-tls.sh` also reverts to HTTP and logs the reason if `nginx -t` fails, rather than leaving nginx unable to start - which is how the first of those was caught.

## Also

A `certbot_email` variable is threaded through each module and its `main_example.tf_`, so the examples still apply cleanly.

## Risk assessment

**Impact:** a reader following any of these guides gets working HTTPS without an ssh session, and two guides stop producing certificates for the wrong domains.

**Blast radius:** `guides/docs` only, four guides, plus the regenerated published docs. No DeployEx application code, no change to the installer.

**Regression risk:** low for DeployEx itself - nothing executable changed. The guides describe infrastructure provisioned from scratch, so this is only exercised on a new instance.

**Rollback:** plain commit revert.

## Verified

`terraform validate` passes for all four modules, and every `${...}` placeholder in each `cloud-config.tpl` is provided by its `templatefile` call. Every `proxy_pass` targets a declared upstream - worth stating because `aws-erlang` and `aws-gleam` use `upstream erlang` / `upstream gleam` rather than `phoenix`, which a naive copy of the elixir template would have got wrong. Docs regenerated with `mix docs`.

**Not verified:** none of this has been applied against a real AWS or GCP account. The equivalent change was applied to a live stage instance in another repository and reached working HTTPS, which is where the three traps above came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
