### PR TITLE
feat(foundation): write renewed certificates to disk

### DIFF
--- a/apps/foundation/lib/foundation/certificate.ex
+++ b/apps/foundation/lib/foundation/certificate.ex
@@ -9,6 +9,9 @@ defmodule Foundation.Certificate do
   on demand via `start_certificate_manager/2` and `stop_certificate_manager/1`.
   """
 
+  require Logger
+
+  alias Foundation.Catalog
   alias Foundation.Certificates.Manager.Supervisor
 
   ### ==========================================================================
@@ -28,9 +31,84 @@ defmodule Foundation.Certificate do
     Supervisor.stop_certificate_manager(app_name)
   end
 
+  @doc """
+  Write the stored certificate and private key of an application to disk.
+
+  The certificate is written as a full chain, the leaf followed by the intermediates, which
+  is what a server expects when it has to present the chain itself rather than receive it
+  from a load balancer.
+
+  Files are created with mode 0600 for the private key and 0644 for the certificate, and
+  the parent directories are created if missing.
+
+  DeployEx runs as the unprivileged `deployex` user, so the destination has to be writable
+  by it. A path such as `/etc/ssl` is root owned by default and needs granting first, for
+  example:
+
+      install -d -o deployex -g deployex -m 0750 /etc/ssl/myapp
+
+  Returns `{:error, :not_found}` when no certificate has been issued yet, and
+  `{:error, {:write_failed, path, reason}}` when a file cannot be written, which is most
+  often `:eacces` for exactly that reason.
+
+  ## Examples
+
+      iex> Foundation.Certificate.export_to_files("nerveshub", "/etc/ssl/host.pem", "/etc/ssl/host-key.pem")
+      {:ok, %{certificate_path: "/etc/ssl/host.pem", private_key_path: "/etc/ssl/host-key.pem"}}
+  """
+  @spec export_to_files(
+          app_name :: String.t(),
+          certificate_path :: String.t(),
+          private_key_path :: String.t()
+        ) :: {:ok, map()} | {:error, any()}
+  def export_to_files(app_name, certificate_path, private_key_path) do
+    case Catalog.certificate(app_name) do
+      %Catalog.Certificate{certificate_pem: cert, private_key_pem: key} = certificate
+      when is_binary(cert) and is_binary(key) ->
+        write_certificate_files(certificate, certificate_path, private_key_path)
+
+      _ ->
+        Logger.error("No certificate stored for app: #{app_name}, nothing to export")
+        {:error, :not_found}
+    end
+  end
+
   ### ==========================================================================
   ### Private Functions
   ### ==========================================================================
+
+  defp write_certificate_files(certificate, certificate_path, private_key_path) do
+    # Leaf first, then the intermediates. A server presenting its own chain needs both,
+    # and the order matters to some clients
+    full_chain =
+      [certificate.certificate_pem, certificate.chain_certificate_pem]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.map_join("\n", &String.trim/1)
+      |> Kernel.<>("\n")
+
+    with :ok <- write_file(certificate_path, full_chain, 0o644),
+         :ok <- write_file(private_key_path, certificate.private_key_pem, 0o600) do
+      Logger.info(
+        "Exported certificate to: #{certificate_path} and private key to: #{private_key_path}"
+      )
+
+      {:ok, %{certificate_path: certificate_path, private_key_path: private_key_path}}
+    end
+  end
+
+  defp write_file(path, content, mode) do
+    with :ok <- path |> Path.dirname() |> File.mkdir_p(),
+         :ok <- File.write(path, content),
+         :ok <- File.chmod(path, mode) do
+      :ok
+    else
+      {:error, reason} ->
+        # :eacces here almost always means the directory is not writable by the deployex
+        # user, see the note on export_to_files/3
+        Logger.error("Error while writing #{path}, reason: #{inspect(reason)}")
+        {:error, {:write_failed, path, reason}}
+    end
+  end
 
   @spec initialize_certificate_manager() :: :ok
   def initialize_certificate_manager do

--- a/apps/foundation/lib/foundation/certificate.ex
+++ b/apps/foundation/lib/foundation/certificate.ex
@@ -41,6 +41,10 @@ defmodule Foundation.Certificate do
   Files are created with mode 0600 for the private key and 0644 for the certificate, and
   the parent directories are created if missing.
 
+  Either path may be `nil`, in which case that file is skipped. Writing only the
+  certificate is the useful case, for something that needs to present the chain without
+  holding the key.
+
   DeployEx runs as the unprivileged `deployex` user, so the destination has to be writable
   by it. A path such as `/etc/ssl` is root owned by default and needs granting first, for
   example:
@@ -58,8 +62,8 @@ defmodule Foundation.Certificate do
   """
   @spec export_to_files(
           app_name :: String.t(),
-          certificate_path :: String.t(),
-          private_key_path :: String.t()
+          certificate_path :: String.t() | nil,
+          private_key_path :: String.t() | nil
         ) :: {:ok, map()} | {:error, any()}
   def export_to_files(app_name, certificate_path, private_key_path) do
     case Catalog.certificate(app_name) do
@@ -88,13 +92,18 @@ defmodule Foundation.Certificate do
 
     with :ok <- write_file(certificate_path, full_chain, 0o644),
          :ok <- write_file(private_key_path, certificate.private_key_pem, 0o600) do
-      Logger.info(
-        "Exported certificate to: #{certificate_path} and private key to: #{private_key_path}"
-      )
+      logged =
+        [certificate_path, private_key_path]
+        |> Enum.reject(&is_nil/1)
+        |> Enum.join(" and ")
+
+      Logger.info("Exported certificate for #{inspect(logged)}")
 
       {:ok, %{certificate_path: certificate_path, private_key_path: private_key_path}}
     end
   end
+
+  defp write_file(nil, _content, _mode), do: :ok
 
   defp write_file(path, content, mode) do
     with :ok <- path |> Path.dirname() |> File.mkdir_p(),

--- a/apps/foundation/lib/foundation/certificates/manager/manager.ex
+++ b/apps/foundation/lib/foundation/certificates/manager/manager.ex
@@ -38,7 +38,8 @@ defmodule Foundation.Certificates.Manager do
           acme_provider: atom(),
           acme_options: map(),
           importer: atom(),
-          importer_options: map()
+          importer_options: map(),
+          storage_options: map() | nil
         }
 
   defstruct [
@@ -53,7 +54,8 @@ defmodule Foundation.Certificates.Manager do
     :acme_provider,
     :acme_options,
     :importer,
-    :importer_options
+    :importer_options,
+    :storage_options
   ]
 
   @default_nameservers ["8.8.8.8", "1.1.1.1"]
@@ -185,8 +187,41 @@ defmodule Foundation.Certificates.Manager do
              attrs.chain_certificate_pem,
              private_key_pem,
              importer_options
-           ) do
-      Catalog.certificate_update(app_name, struct(existing_cert, attrs))
+           ),
+         {:ok, cert} <- Catalog.certificate_update(app_name, struct(existing_cert, attrs)) do
+      # After the catalog is updated, so the files carry the certificate that was just
+      # issued rather than the one it replaced
+      store_certificate_files(app_name, cert_config.storage_options)
+
+      {:ok, cert}
+    end
+  end
+
+  # NOTE: a failure here is logged but does not fail the renewal. The certificate has
+  #       already been issued and imported at this point, so failing would leave the
+  #       manager retrying and reissuing against the Let's Encrypt weekly limit for what
+  #       is almost always a directory the deployex user cannot write to.
+  defp store_certificate_files(_app_name, nil), do: :ok
+
+  defp store_certificate_files(_app_name, %{certificate_path: nil, private_key_path: nil}),
+    do: :ok
+
+  defp store_certificate_files(app_name, %{
+         certificate_path: certificate_path,
+         private_key_path: private_key_path
+       }) do
+    case Foundation.Certificate.export_to_files(app_name, certificate_path, private_key_path) do
+      {:ok, _paths} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Certificate renewed for app: #{app_name} but could not be written to disk, " <>
+            "reason: #{inspect(reason)}. The deployex user needs write access to the target " <>
+            "directory."
+        )
+
+        :ok
     end
   end
 

--- a/apps/foundation/lib/foundation/yaml.ex
+++ b/apps/foundation/lib/foundation/yaml.ex
@@ -98,6 +98,21 @@ defmodule Foundation.Yaml do
             }
     end
 
+    defmodule StorageOptions do
+      @moduledoc """
+      Where a renewed certificate is written on the instance.
+
+      Both paths are optional and independent, so a deployment that only needs the
+      certificate does not have to write the private key next to it.
+      """
+      defstruct [:certificate_path, :private_key_path]
+
+      @type t :: %__MODULE__{
+              certificate_path: String.t() | nil,
+              private_key_path: String.t() | nil
+            }
+    end
+
     defstruct [
       :type,
       :domains,
@@ -110,7 +125,8 @@ defmodule Foundation.Yaml do
       :acme_provider,
       :acme_options,
       :importer,
-      :importer_options
+      :importer_options,
+      :storage_options
     ]
 
     @type t :: %__MODULE__{
@@ -125,7 +141,8 @@ defmodule Foundation.Yaml do
             acme_provider: atom() | nil,
             acme_options: __MODULE__.AcmeOptions.t() | nil,
             importer: atom() | nil,
-            importer_options: __MODULE__.ImporterOptions.t() | nil
+            importer_options: __MODULE__.ImporterOptions.t() | nil,
+            storage_options: __MODULE__.StorageOptions.t() | nil
           }
   end
 
@@ -472,7 +489,8 @@ defmodule Foundation.Yaml do
       acme_provider: parse_acme_provider(data["acme_provider"]),
       acme_options: parse_acme_options(data["acme_options"]),
       importer: parse_importer(data["importer"]),
-      importer_options: parse_importer_options(data["importer_options"])
+      importer_options: parse_importer_options(data["importer_options"]),
+      storage_options: parse_storage_options(data["storage_options"])
     }
   end
 
@@ -508,6 +526,15 @@ defmodule Foundation.Yaml do
 
   defp parse_importer("route53"), do: Foundation.Certificates.Importer.Route53
   defp parse_importer(importer), do: raise("Importer #{importer} not supported")
+
+  defp parse_storage_options(nil), do: nil
+
+  defp parse_storage_options(opts) do
+    %Certificate.StorageOptions{
+      certificate_path: opts["certificate_path"],
+      private_key_path: opts["private_key_path"]
+    }
+  end
 
   defp parse_importer_options(nil), do: nil
 

--- a/apps/foundation/test/certificate_test.exs
+++ b/apps/foundation/test/certificate_test.exs
@@ -104,6 +104,27 @@ defmodule Foundation.CertificateTest do
     end
 
     @tag :capture_log
+    test "writes only the file whose path is given", %{dir: dir} do
+      stored = %Foundation.Catalog.Certificate{
+        certificate_pem: "LEAF",
+        private_key_pem: "KEY"
+      }
+
+      cert_only = Path.join(dir, "cert-only.pem")
+      key_only = Path.join(dir, "key-only.pem")
+
+      with_mock Foundation.Catalog, [:passthrough], certificate: fn _ -> stored end do
+        assert {:ok, _} = Certificate.export_to_files("nerveshub", cert_only, nil)
+        assert {:ok, _} = Certificate.export_to_files("nerveshub", nil, key_only)
+      end
+
+      # a nil path skips that file rather than raising on Path.dirname/1
+      assert File.read!(cert_only) == "LEAF\n"
+      assert File.read!(key_only) == "KEY"
+      refute File.exists?(Path.join(dir, "host.pem"))
+    end
+
+    @tag :capture_log
     test "returns not_found when no certificate has been issued", %{
       cert_path: cert_path,
       key_path: key_path

--- a/apps/foundation/test/certificate_test.exs
+++ b/apps/foundation/test/certificate_test.exs
@@ -37,4 +37,102 @@ defmodule Foundation.CertificateTest do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # export_to_files/3
+  # ---------------------------------------------------------------------------
+
+  describe "export_to_files/3" do
+    setup do
+      dir = Path.join(System.tmp_dir!(), "cert-export-#{System.unique_integer([:positive])}")
+      on_exit(fn -> File.rm_rf(dir) end)
+      %{dir: dir, cert_path: Path.join(dir, "host.pem"), key_path: Path.join(dir, "host-key.pem")}
+    end
+
+    @tag :capture_log
+    test "writes the full chain and the private key", %{
+      dir: dir,
+      cert_path: cert_path,
+      key_path: key_path
+    } do
+      stored = %Foundation.Catalog.Certificate{
+        certificate_pem: "-----BEGIN CERTIFICATE-----\nLEAF\n-----END CERTIFICATE-----",
+        chain_certificate_pem:
+          "-----BEGIN CERTIFICATE-----\nINTERMEDIATE\n-----END CERTIFICATE-----",
+        private_key_pem: "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----"
+      }
+
+      with_mock Foundation.Catalog, [:passthrough], certificate: fn "nerveshub" -> stored end do
+        assert {:ok, %{certificate_path: ^cert_path, private_key_path: ^key_path}} =
+                 Certificate.export_to_files("nerveshub", cert_path, key_path)
+      end
+
+      # the parent directory is created, the caller only supplies file paths
+      assert File.dir?(dir)
+
+      chain = File.read!(cert_path)
+      # leaf first, then the intermediates, which is the order a client expects
+      assert chain =~ "LEAF"
+      assert chain =~ "INTERMEDIATE"
+      assert :binary.match(chain, "LEAF") < :binary.match(chain, "INTERMEDIATE")
+
+      assert File.read!(key_path) =~ "KEY"
+
+      # the private key must not be world readable
+      assert %{mode: key_mode} = File.stat!(key_path)
+      assert Bitwise.band(key_mode, 0o777) == 0o600
+      assert %{mode: cert_mode} = File.stat!(cert_path)
+      assert Bitwise.band(cert_mode, 0o777) == 0o644
+    end
+
+    @tag :capture_log
+    test "writes only the leaf when there is no chain", %{
+      cert_path: cert_path,
+      key_path: key_path
+    } do
+      stored = %Foundation.Catalog.Certificate{
+        certificate_pem: "LEAF",
+        chain_certificate_pem: nil,
+        private_key_pem: "KEY"
+      }
+
+      with_mock Foundation.Catalog, [:passthrough], certificate: fn _ -> stored end do
+        assert {:ok, _} = Certificate.export_to_files("nerveshub", cert_path, key_path)
+      end
+
+      assert File.read!(cert_path) == "LEAF\n"
+    end
+
+    @tag :capture_log
+    test "returns not_found when no certificate has been issued", %{
+      cert_path: cert_path,
+      key_path: key_path
+    } do
+      with_mock Foundation.Catalog, [:passthrough],
+        certificate: fn _ -> %Foundation.Catalog.Certificate{} end do
+        assert {:error, :not_found} =
+                 Certificate.export_to_files("nerveshub", cert_path, key_path)
+      end
+
+      refute File.exists?(cert_path)
+    end
+
+    @tag :capture_log
+    test "reports the path when the destination cannot be written", %{dir: dir} do
+      stored = %Foundation.Catalog.Certificate{certificate_pem: "LEAF", private_key_pem: "KEY"}
+
+      # deployex runs unprivileged, so an unwritable target is the expected failure. A
+      # regular file where a directory is needed reproduces it without mocking File, which
+      # the whole test suite depends on, and without relying on the test user not being root
+      File.mkdir_p!(dir)
+      blocker = Path.join(dir, "blocker")
+      File.write!(blocker, "")
+      cert_path = Path.join(blocker, "host.pem")
+
+      with_mock Foundation.Catalog, [:passthrough], certificate: fn _ -> stored end do
+        assert {:error, {:write_failed, ^cert_path, _reason}} =
+                 Certificate.export_to_files("nerveshub", cert_path, Path.join(blocker, "k.pem"))
+      end
+    end
+  end
 end

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -275,7 +275,9 @@ storage_options:
   private_key_path: "/etc/ssl/myapp/host-key.pem"
 ```
 
-Both keys are optional and independent. The certificate is written as a full chain, leaf first followed by the intermediates, with mode `0644`. The private key is written with mode `0600`.
+Both keys are optional and independent: give one and only that file is written. Writing only the certificate is the useful case, for something that needs to present the chain without holding the key. Omitting both, or omitting `storage_options` entirely, disables the export.
+
+The certificate is written as a full chain, leaf first followed by the intermediates, with mode `0644`. The private key is written with mode `0600`.
 
 > [!IMPORTANT]
 > DeployEx runs as the unprivileged `deployex` user, so the destination directory has to be writable by it. Paths such as `/etc/ssl` are root owned and will fail with `:eacces` until permission is granted:

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -205,6 +205,9 @@ applications:
         importer: "route53"                                   # Certificate deployment/import (Supports route53)
         importer_options: 
           certificate_arn: "arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx"
+        storage_options:                                      # Optional, write the certificate to disk on renewal
+          certificate_path: "/etc/ssl/myapp/host.pem"
+          private_key_path: "/etc/ssl/myapp/host-key.pem"
 
   # --------------------------------------------------------------------------
   # Application: myapp
@@ -261,6 +264,31 @@ These fields can be modified and applied at runtime without restarting DeployEx:
 #### Application Certificates
 
 DeployEx supports automatic TLS certificate provisioning, renewal, and deployment using ACME providers such as Let's Encrypt. Certificates are configured per application through the certificates field. This allows applications to manage HTTPS certificates without requiring external automation.
+
+#### Writing the certificate to disk
+
+`importer` hands the certificate to a cloud service, which covers a load balancer terminating TLS but not a process that has to read the certificate from the filesystem. `storage_options` covers that case: give it the paths and DeployEx writes them every time the certificate is renewed.
+
+```yaml
+storage_options:
+  certificate_path: "/etc/ssl/myapp/host.pem"
+  private_key_path: "/etc/ssl/myapp/host-key.pem"
+```
+
+Both keys are optional and independent. The certificate is written as a full chain, leaf first followed by the intermediates, with mode `0644`. The private key is written with mode `0600`.
+
+> [!IMPORTANT]
+> DeployEx runs as the unprivileged `deployex` user, so the destination directory has to be writable by it. Paths such as `/etc/ssl` are root owned and will fail with `:eacces` until permission is granted:
+> ```bash
+> install -d -o deployex -g deployex -m 0750 /etc/ssl/myapp
+> ```
+> A failure to write is logged but does **not** fail the renewal. The certificate has already been issued and imported at that point, and failing would make the manager retry and reissue against the Let's Encrypt weekly limit.
+
+The same export is available on demand, which is useful for placing an already issued certificate without waiting for a renewal:
+
+```elixir
+Foundation.Certificate.export_to_files("myapp", "/etc/ssl/myapp/host.pem", "/etc/ssl/myapp/host-key.pem")
+```
 
 ### Non-Upgradable Configuration Fields
 


### PR DESCRIPTION
`importer` hands a renewed certificate to a cloud service, which covers a load balancer terminating TLS but not a process that has to read the certificate from the filesystem.

NervesHub is the case in point - its device endpoint reads:

```elixir
ssl_certfile = System.get_env("DEVICE_SSL_CERTFILE", "/etc/ssl/#{host}.pem")
ssl_keyfile  = System.get_env("DEVICE_SSL_KEYFILE",  "/etc/ssl/#{host}-key.pem")
```

so a certificate that only reaches Certificate Manager never reaches the devices.

## Both asks

**On demand**, reading the stored certificate from the catalog:

```elixir
Foundation.Certificate.export_to_files("nerveshub", "/etc/ssl/host.pem", "/etc/ssl/host-key.pem")
{:ok, %{certificate_path: "/etc/ssl/host.pem", private_key_path: "/etc/ssl/host-key.pem"}}
```

**Automatically on renewal**, via new config:

```yaml
storage_options:
  certificate_path: "/etc/ssl/myapp/host.pem"
  private_key_path: "/etc/ssl/myapp/host-key.pem"
```

Both keys are optional and independent - give one and only that file is written:

```yaml
storage_options:
  certificate_path: "/etc/ssl/myapp/host.pem"      # written
  # private_key_path omitted                       -> skipped, no error
```

Certificate-only is the useful case, for something that presents the chain without holding the key. Omitting both, or omitting `storage_options` entirely, disables the export.

The certificate is written as a **full chain** - leaf first, then intermediates - at mode `0644`; the private key at `0600`. Parent directories are created.

## Permissions, which is the first thing that will bite

DeployEx runs as the unprivileged **`deployex`** user (`User=deployex` in the systemd unit), so `/etc/ssl` is not writable by it:

```bash
install -d -o deployex -g deployex -m 0750 /etc/ssl/myapp
```

Documented in the yaml guide with an `[!IMPORTANT]` callout, and the error carries the path and reason so `:eacces` is obvious rather than mysterious.

## Two decisions worth reviewing

**Files are written after `Catalog.certificate_update/2`, not before.** My first pass had it in the `with` chain before the catalog update, which would have written the *previous* certificate on every renewal - correct-looking and silently one renewal behind.

**A nil path skips that file.** The first version documented both paths as optional but would have raised `FunctionClauseError` on `Path.dirname(nil)`, so configuring only `certificate_path` would have crashed the write. Fixed, with a test per combination.

**A write failure does not fail the renewal.** It is logged with the reason and the pipeline continues. At that point the certificate has already been issued and imported, so failing would leave the manager retrying and reissuing against the Let's Encrypt limit of **5 identical certificates per week**. Turning a permissions problem into rate-limit exhaustion would be a much worse outcome than a log line - but it does mean a misconfigured path is only visible in the logs, so shout if you would rather it were loud.

## Risk assessment

**Impact:** an application with no `storage_options` behaves exactly as before - the new step returns immediately. With it configured, certificate and key are written on every renewal.

**Blast radius:** `apps/foundation`. `Yaml.Certificate` gains `storage_options`, the certificate manager gains one step at the end of a successful renewal, `Foundation.Certificate` gains a public function. No changes to `deployer`, `sentinel`, `host` or `deployex_web`.

**Regression risk:** low. The renewal path is otherwise unchanged, and `storage_options` defaults to `nil` for every existing configuration.

**Rollback:** plain commit revert. Files already written stay on disk, simply no longer refreshed.

## Checks

Full umbrella suite green (foundation 235 + 25 doctests, host 21, deployer 172, sentinel 84, deployex_web 177 + 6 doctests), `mix credo --strict` clean, compiles with `--warnings-as-errors`, docs regenerated.

Five new tests cover the chain ordering, the leaf-only case, each path being optional, `:not_found` when nothing has been issued, and the unwritable-destination path. That last one uses a real unwritable path rather than mocking `File` - an earlier attempt at `with_mock File` killed the test runner, since the whole suite depends on it.

**Not verified:** no run against a live NervesHub instance or a real renewal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)