### PR TITLE
chore(release): prepare 0.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # CHANGELOG (0.9.X)
 
-## 0.9.10 ()
+## 0.9.10 🚀 (2026-08-10)
 
 ### Backwards incompatible changes from 0.9.9
  * None
 
 ### Bug fixes
  * [`PULL-265`](https://github.com/thiagoesteves/deployex/pull/265) Stop password managers filling credentials into the GitHub artifact form
+ * [`PULL-267`](https://github.com/thiagoesteves/deployex/pull/267) Correct the hot upgrade confirmation, it does not terminate anything
 
 ### Enhancements
- * None
+ * [`PULL-268`](https://github.com/thiagoesteves/deployex/pull/268) Automate TLS certificates and move the deployment guides to Debian 13
+ * [`PULL-269`](https://github.com/thiagoesteves/deployex/pull/269) Write renewed certificates to disk
 
 ## 0.9.9 🚀 (2026-08-07)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| [**0.9.10**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.10) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.9**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.9) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.8**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.8) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.7**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.7) | **27.3.4.14**                                              | **28.5.0.3**                                               |

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.9"
+version: "0.9.10"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.9"
+version: "0.9.10"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.9"                                         # DeployEx version
+version: "0.9.10"                                        # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.9"
+  def version, do: "0.9.10"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
Release preparation for **0.9.10**, following the checklist in `CLAUDE.md`.

| Step | Change |
|---|---|
| `mix/shared.exs` | `0.9.9` → `0.9.10` |
| `README.md` | new compatibility row, OTP columns from `devops/releases/otp-*/.tool-versions` |
| `devops/installer/deployex-aws.yaml` | `version: "0.9.10"` |
| `devops/installer/deployex-gcp.yaml` | `version: "0.9.10"` |
| `guides/docs/yaml/README.md` | `version: "0.9.10"` |
| `CHANGELOG.md` | heading dated `## 0.9.10 🚀 (2026-08-10)` |
| `mix docs` | regenerated last, as requested |

## The changelog was incomplete

It carried only `PULL-265`, but four pull requests have merged since 0.9.9:

```
9ad29a1 (#269) write renewed certificates to disk
44aeb7e (#268) automate TLS certificates and move the guides to Debian 13
c7e070b (#267) correct the hot upgrade confirmation
1407087 (#265) stop password managers filling credentials into the GitHub artifact form
```

All four are now listed, sorted by number within each category:

**Bug fixes** - 265, 267
**Enhancements** - 268, 269

I classified #268 as an Enhancement rather than a Bug fix. It does fix a real defect (two guides requested certificates for the hardcoded example domain), but it is documentation rather than shipped behaviour. Move it if you would rather it read as a fix.

## Not in this release

**#266** (deployment record) is still open and deliberately excluded - you paused that work.

## Verification

The full CI gate set was run **before** `mix docs`, so the published bundle reflects a green tree:

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict` - no issues
- `mix test` - foundation 236 + 25 doctests, host 21, deployer 172, sentinel 84, deployex_web 177 + 6 doctests, 0 failures
- `mix deps.unlock --check-unused`
- `mix deps.audit` - no vulnerabilities

Then `mix docs`, and I unpacked `docs.tar.gz` to confirm it carries `0.9.10` and the new `storage_options` documentation from #269.

`mix dialyzer` was not run - the local PLT is stale and needs a full rebuild; CI covers it.

## After merge

Pushing the `0.9.10` tag from `main` triggers `.github/workflows/releases.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
