### PR TITLE
fix(deployer): refuse a hot upgrade built on a different toolchain

### DIFF
--- a/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
@@ -38,11 +38,15 @@ defmodule Deployer.HotUpgrade.Deployex do
 
     with {:ok, _} <-
            Commander.run("tar -xf  #{download_path} -C #{new_path}", [:sync, :stdout, :stderr]),
+         :ok <- check_toolchain(new_path),
          {:ok, %Check{deploy: :hot_upgrade} = check} <- HotUpgradeApp.check(check) do
       {:ok, check}
     else
       {:ok, %Check{deploy: :full_deployment}} ->
         {:error, :full_deployment}
+
+      {:error, {:toolchain_mismatch, _details} = reason} ->
+        {:error, reason}
 
       reason ->
         Logger.warning(
@@ -98,6 +102,56 @@ defmodule Deployer.HotUpgrade.Deployex do
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # A hot upgrade replaces application code inside the running VM, it cannot replace the
+  # VM or the language runtime under it. systools:make_relup/4 needs an appup for every
+  # application whose version changes, and neither Elixir nor the OTP applications ship
+  # one, so an artifact built on a different toolchain fails partway through the upgrade
+  # with a missing appup rather than at the point the wrong file was chosen.
+  #
+  # The release directory names carry both versions, so this is answerable before anything
+  # is installed.
+  defp check_toolchain(new_path) do
+    running = %{
+      elixir: System.version(),
+      erts: to_string(:erlang.system_info(:version))
+    }
+
+    release = %{
+      elixir: version_from_dir(new_path, "lib/elixir-*", "elixir-"),
+      erts: version_from_dir(new_path, "erts-*", "erts-")
+    }
+
+    mismatched =
+      Enum.reject([:elixir, :erts], fn key ->
+        # An unreadable release layout is left to the checks that follow rather than
+        # rejected here, they report it far better than a guess would
+        is_nil(release[key]) or release[key] == running[key]
+      end)
+
+    if mismatched == [] do
+      :ok
+    else
+      details = Map.new(mismatched, &{&1, %{running: running[&1], release: release[&1]}})
+
+      Logger.error("""
+      Hot upgrade refused, the release was built on a different toolchain: \
+      #{inspect(details)}. A hot upgrade cannot change the Erlang or Elixir version under \
+      a running system. Use the artifact matching the otp_version this installation runs, \
+      or apply it as a full deployment.\
+      """)
+
+      {:error, {:toolchain_mismatch, details}}
+    end
+  end
+
+  defp version_from_dir(new_path, pattern, prefix) do
+    case Path.wildcard("#{new_path}/#{pattern}") do
+      [dir] -> dir |> Path.basename() |> String.replace_prefix(prefix, "")
+      _ -> nil
+    end
+  end
+
   defp parse_version(download_path) do
     [_, to_version] =
       download_path

--- a/apps/deployer/test/hot_upgrade/deployex_test.exs
+++ b/apps/deployer/test/hot_upgrade/deployex_test.exs
@@ -22,6 +22,50 @@ defmodule Deployer.HotUpgrade.DeployexTest do
     end
   end
 
+  test "check/1 refuses an artifact built on a different toolchain" do
+    new_path = "/tmp/hotupgrade/deployex"
+    on_exit(fn -> File.rm_rf(new_path) end)
+
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options ->
+      # stands in for the extraction. Same ERTS, different Elixir, which is what applying
+      # the wrong otp_version artifact looks like on disk
+      File.mkdir_p!("#{new_path}/lib/elixir-0.0.1")
+      File.mkdir_p!("#{new_path}/erts-#{:erlang.system_info(:version)}")
+      {:ok, []}
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:toolchain_mismatch, details}} =
+                 Deployex.check("/tmp/deployex-1.0.0.tar.gz")
+
+        assert %{elixir: %{release: "0.0.1", running: running}} = details
+        assert running == System.version()
+        # only the version that actually differs is reported
+        refute Map.has_key?(details, :erts)
+      end)
+
+    assert log =~ "built on a different toolchain"
+  end
+
+  test "check/1 accepts an artifact built on the same toolchain" do
+    new_path = "/tmp/hotupgrade/deployex"
+    on_exit(fn -> File.rm_rf(new_path) end)
+
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options ->
+      File.mkdir_p!("#{new_path}/lib/elixir-#{System.version()}")
+      File.mkdir_p!("#{new_path}/erts-#{:erlang.system_info(:version)}")
+      {:ok, []}
+    end)
+
+    with_mock HotUpgradeApp, [:passthrough],
+      check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end do
+      assert {:ok, %Check{}} = Deployex.check("/tmp/deployex-1.0.0.tar.gz")
+    end
+  end
+
   test "check/1 fail to untar" do
     Host.CommanderMock
     |> expect(:run, fn _command, _options -> {:error, ["invalid"]} end)

--- a/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
@@ -1020,6 +1020,16 @@ defmodule DeployexWeb.HotUpgradeLive do
 
   # Helper Functions
 
+  # Names the versions that differ so the operator can see which artifact to fetch instead
+  defp toolchain_error_message(details) do
+    changes =
+      Enum.map_join(details, ", ", fn {name, %{running: running, release: release}} ->
+        "#{name} #{running} -> #{release}"
+      end)
+
+    "wrong artifact for this installation: #{changes}"
+  end
+
   defp handle_release(path, filename, size) do
     uploads_path = "#{:code.priv_dir(:deployex_web)}/static/uploads"
     File.mkdir_p!(uploads_path)
@@ -1043,6 +1053,9 @@ defmodule DeployexWeb.HotUpgradeLive do
 
       {:error, :full_deployment} ->
         {:postpone, %{hotupgrade | error: "full deployment only"}}
+
+      {:error, {:toolchain_mismatch, details}} ->
+        {:postpone, %{hotupgrade | error: toolchain_error_message(details)}}
 
       {:error, _reason} ->
         {:postpone, %{hotupgrade | error: "invalid release"}}


### PR DESCRIPTION
## The failure this prevents

Applying the OTP-28 artifact to an installation running the OTP-27 build:

```
Unpacked successfully: "0.9.10"
Could not open file /opt/deployex/lib/elixir-1.19.5/ebin/elixir.appup
systools:make_relup failed, reason: :error
```

Nothing there says *the wrong file was chosen*. It surfaces two steps after the mistake, as a missing file inside `systools`.

## Why it cannot work

A hot upgrade replaces application code inside the running VM. It cannot replace the VM or the language runtime beneath it. `systools:make_relup/4` demands an `.appup` for every application whose version changes between the two releases, and neither Elixir nor the OTP applications ship one - so any toolchain difference is fatal by construction, not by accident.

For DeployEx that maps directly onto `otp_version`:

```
devops/releases/otp-27/.tool-versions   elixir 1.18.4-otp-27
devops/releases/otp-28/.tool-versions   elixir 1.19.5-otp-28
```

## The check

`check/1` already extracts the release before validating it, so both versions are sitting on disk. It now compares them against the running system:

```elixir
running = %{elixir: System.version(), erts: to_string(:erlang.system_info(:version))}
release = %{elixir: version_from_dir(new_path, "lib/elixir-*", "elixir-"),
            erts:   version_from_dir(new_path, "erts-*", "erts-")}
```

and refuses when either differs, naming both sides:

```
Hot upgrade refused, the release was built on a different toolchain:
%{elixir: %{running: "1.18.4", release: "1.19.5"}}. A hot upgrade cannot change the
Erlang or Elixir version under a running system. Use the artifact matching the
otp_version this installation runs, or apply it as a full deployment.
```

The UI shows `wrong artifact for this installation: elixir 1.18.4 -> 1.19.5` instead of `invalid release`.

Only the versions that actually differ are reported - an ERTS-only change reports ERTS alone.

## Deliberately permissive in one place

A release whose layout cannot be read (no `lib/elixir-*`, no `erts-*`) **falls through** rather than being rejected. The checks that follow report a malformed release far better than a guess here would, and refusing on a failed `Path.wildcard` would turn an unrelated packaging problem into a confusing toolchain error.

## Risk assessment

**Impact:** choosing the wrong artifact is rejected at the point of choosing it, naming the versions. An artifact built on the same toolchain behaves exactly as before.

**Blast radius:** the DeployEx self-upgrade check and the error branch that displays it. The monitored-application path is untouched - it has its own check.

**Regression risk:** low. The new step only rejects an upgrade that would have failed at `make_relup` anyway, and an unreadable layout falls through rather than blocking.

**Rollback:** plain commit revert.

## Checks

Full umbrella suite green (foundation 236 + 25 doctests, host 21, deployer 174, sentinel 84, deployex_web 177 + 6 doctests), `mix credo --strict` clean, `mix format --check-formatted` clean, compiles with `--warnings-as-errors`.

Two new tests: one builds a release layout with a different Elixir and the same ERTS - exactly the shape of the real failure - and asserts only `elixir` is reported; the other builds a matching layout and asserts it passes through.

## Not addressed here

The other half of that incident: `Deployex.execute/2` logged `Hot upgrade in deployex installed with success` **three seconds before the unpack started**, because with `sync_execution: false` it logs on the cast returning `:ok` rather than on the upgrade completing. A failed self-upgrade still reports success. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
