### PR TITLE
fix(deployer): refuse a DeployEx hot upgrade built for a different OTP

### DIFF
--- a/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
@@ -38,11 +38,15 @@ defmodule Deployer.HotUpgrade.Deployex do
 
     with {:ok, _} <-
            Commander.run("tar -xf  #{download_path} -C #{new_path}", [:sync, :stdout, :stderr]),
+         :ok <- check_otp_version(new_path),
          {:ok, %Check{deploy: :hot_upgrade} = check} <- HotUpgradeApp.check(check) do
       {:ok, check}
     else
       {:ok, %Check{deploy: :full_deployment}} ->
         {:error, :full_deployment}
+
+      {:error, {:otp_mismatch, _versions} = reason} ->
+        {:error, reason}
 
       reason ->
         Logger.warning(
@@ -98,6 +102,50 @@ defmodule Deployer.HotUpgrade.Deployex do
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # A hot upgrade replaces application code inside the running VM, it cannot replace the VM
+  # underneath it. A release built for another OTP brings a different Erlang and Elixir, and
+  # systools:make_relup needs an appup for every application whose version changes, which
+  # neither ships. The upgrade fails after the release is unpacked, complaining about a
+  # missing appup and saying nothing about the wrong artifact having been chosen.
+  #
+  # The release bundles its own erts directory, so its OTP is known before anything is
+  # installed. The erts version identifies the OTP release, OTP 27 ships erts 15 and OTP 28
+  # ships erts 16, so comparing it against the running one is the same check.
+  defp check_otp_version(new_path) do
+    running_erts = to_string(:erlang.system_info(:version))
+
+    case Path.wildcard("#{new_path}/erts-*") do
+      [directory] ->
+        package_erts = directory |> Path.basename() |> String.replace_prefix("erts-", "")
+        compare_otp_version(running_erts, package_erts)
+
+      _ ->
+        # No bundled erts to compare, leave it to the checks that follow
+        :ok
+    end
+  end
+
+  defp compare_otp_version(erts, erts), do: :ok
+
+  defp compare_otp_version(running_erts, package_erts) do
+    versions = %{
+      running_otp: to_string(:erlang.system_info(:otp_release)),
+      running_erts: running_erts,
+      package_erts: package_erts
+    }
+
+    Logger.error("""
+    Hot upgrade refused, this release was built for a different OTP. #{@deployex_name} runs \
+    OTP #{versions.running_otp} with erts #{running_erts} and the release brings erts \
+    #{package_erts}. A hot upgrade cannot replace the runtime under a running system. Use \
+    the artifact matching the otp_version this installation runs, or apply it as a full \
+    deployment.\
+    """)
+
+    {:error, {:otp_mismatch, versions}}
+  end
+
   defp parse_version(download_path) do
     [_, to_version] =
       download_path

--- a/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
@@ -126,7 +126,8 @@ defmodule Deployer.HotUpgrade.Deployex do
     end
   end
 
-  defp compare_otp_version(erts, erts), do: :ok
+  defp compare_otp_version(running_erts, package_erts) when running_erts == package_erts,
+    do: :ok
 
   defp compare_otp_version(running_erts, package_erts) do
     versions = %{

--- a/apps/deployer/test/hot_upgrade/deployex_test.exs
+++ b/apps/deployer/test/hot_upgrade/deployex_test.exs
@@ -22,6 +22,46 @@ defmodule Deployer.HotUpgrade.DeployexTest do
     end
   end
 
+  test "check/1 refuses a release built for a different OTP" do
+    new_path = "/tmp/hotupgrade/deployex"
+    on_exit(fn -> File.rm_rf(new_path) end)
+
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options ->
+      # stands in for the extraction. The release carries its own erts, which identifies
+      # the OTP it was built for
+      File.mkdir_p!("#{new_path}/erts-0.0.1")
+      {:ok, []}
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:otp_mismatch, versions}} = Deployex.check("/tmp/deployex-1.0.0.tar.gz")
+
+        assert versions.package_erts == "0.0.1"
+        assert versions.running_erts == to_string(:erlang.system_info(:version))
+        assert versions.running_otp == to_string(:erlang.system_info(:otp_release))
+      end)
+
+    assert log =~ "built for a different OTP"
+  end
+
+  test "check/1 accepts a release built for the same OTP" do
+    new_path = "/tmp/hotupgrade/deployex"
+    on_exit(fn -> File.rm_rf(new_path) end)
+
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options ->
+      File.mkdir_p!("#{new_path}/erts-#{:erlang.system_info(:version)}")
+      {:ok, []}
+    end)
+
+    with_mock HotUpgradeApp, [:passthrough],
+      check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end do
+      assert {:ok, %Check{}} = Deployex.check("/tmp/deployex-1.0.0.tar.gz")
+    end
+  end
+
   test "check/1 fail to untar" do
     Host.CommanderMock
     |> expect(:run, fn _command, _options -> {:error, ["invalid"]} end)

--- a/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
@@ -1044,6 +1044,9 @@ defmodule DeployexWeb.HotUpgradeLive do
       {:error, :full_deployment} ->
         {:postpone, %{hotupgrade | error: "full deployment only"}}
 
+      {:error, {:otp_mismatch, %{running_otp: otp}}} ->
+        {:postpone, %{hotupgrade | error: "wrong OTP, this installation runs OTP #{otp}"}}
+
       {:error, _reason} ->
         {:postpone, %{hotupgrade | error: "invalid release"}}
     end


### PR DESCRIPTION
Replaces #271, which checked Elixir and ERTS separately. This checks OTP once.

## The failure

Applying the OTP-28 artifact to an installation running the OTP-27 build:

```
Unpacked successfully: "0.9.10"
Could not open file /opt/deployex/lib/elixir-1.19.5/ebin/elixir.appup
systools:make_relup failed, reason: :error
```

Nothing there says *the wrong artifact was chosen*. It surfaces two steps later, as a missing file inside `systools`.

## Why it cannot work

A hot upgrade replaces application code inside the running VM. It cannot replace the VM underneath it. A release built for another OTP brings a different Erlang **and** Elixir, and `systools:make_relup/4` demands an `.appup` for every application whose version changes - which neither ships.

## The check

`check/1` already extracts the release before validating it, and the release bundles its own `erts-<vsn>` directory, so its OTP is knowable before anything is installed:

```elixir
running_erts = to_string(:erlang.system_info(:version))

case Path.wildcard("#{new_path}/erts-*") do
  [directory] -> compare_otp_version(running_erts, package_erts)
  _ -> :ok
end
```

The ERTS version identifies the OTP release - OTP 27 ships ERTS 15, OTP 28 ships ERTS 16 - so comparing it against the running one *is* the OTP check. There is no `OTP_VERSION` file in a release; `mix release` copies `erts-<vsn>` and writes `start_erl.data`, so this is the marker available.

```
Hot upgrade refused, this release was built for a different OTP. deployex runs OTP 27
with erts 15.2.7 and the release brings erts 16.1.1. A hot upgrade cannot replace the
runtime under a running system. Use the artifact matching the otp_version this
installation runs, or apply it as a full deployment.
```

The UI shows `wrong OTP, this installation runs OTP 27` instead of `invalid release`.

## Two deliberate limits

**A release with no bundled `erts` falls through** rather than being rejected. Refusing on a failed `Path.wildcard` would turn an unrelated packaging problem into a confusing OTP error, and the checks that follow report a malformed release better.

**DeployEx self-upgrade only.** Monitored applications go through a different check and are untouched - you were unsure whether they need this, so it is not assumed.

## Risk assessment

**Impact:** choosing the artifact for the wrong `otp_version` is rejected when the file is chosen, naming the OTP the installation runs. An artifact for the right OTP behaves exactly as before.

**Blast radius:** the DeployEx self-upgrade check and the branch that displays its error.

**Regression risk:** low. The new step only rejects an upgrade that would have failed at `make_relup` anyway, and a release without a bundled `erts` falls through rather than being blocked.

**Rollback:** plain commit revert.

## Checks

Full umbrella suite green (foundation 236 + 25 doctests, host 21, deployer 174, sentinel 84, deployex_web 177 + 6 doctests), `mix credo --strict` clean, `mix format --check-formatted` clean, compiles with `--warnings-as-errors`.

Two tests: one builds a release carrying a different `erts` and asserts the refusal names both sides, the other builds one carrying the running `erts` and asserts it passes through.

## Not addressed here

The other half of that incident: `Deployex.execute/2` logged `Hot upgrade in deployex installed with success` **three seconds before the unpack started**, because with `sync_execution: false` it logs on the cast returning `:ok` rather than on completion. A failed self-upgrade still reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
