### PR TITLE
fix(deployer): clean up after a failed hot upgrade and log why it failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
  * [`PULL-272`](https://github.com/thiagoesteves/deployex/pull/272) Refuse a DeployEx hot upgrade built for a different OTP
+ * [`PULL-273`](https://github.com/thiagoesteves/deployex/pull/273) Remove the unpacked release left behind by a failed hot upgrade
 
 ### Enhancements
  * None

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -442,6 +442,10 @@ defmodule Deployer.HotUpgrade.Application do
         [root ++ ~c"/releases/#{name}-" ++ from_version],
         [root ++ ~c"/releases/#{name}-" ++ from_version],
         [
+          # NOTE: silent stops systools printing the reason to stdout, where it lands
+          #       unprefixed and detached from the failure, and returns it instead. The
+          #       relup file is still written, only noexec skips that
+          :silent,
           {:path, [root ++ ~c"/lib/*/ebin"]},
           {:outdir, [root ++ ~c"/releases/" ++ to_version]}
         ]
@@ -449,8 +453,20 @@ defmodule Deployer.HotUpgrade.Application do
       @rpc_timeout
     )
     |> case do
-      :ok ->
+      {:ok, _relup, _module, []} ->
         :ok
+
+      {:ok, _relup, module, warnings} ->
+        Logger.warning("systools:make_relup warnings: #{format_systools(node, module, warnings)}")
+        :ok
+
+      {:error, module, error} ->
+        Logger.error(
+          "systools:make_relup failed for #{name} #{from_version} -> #{to_version}, " <>
+            "reason: #{format_systools(node, module, error)}"
+        )
+
+        {:error, :make_relup}
 
       reason ->
         Logger.error("systools:make_relup failed, reason: #{inspect(reason)}")
@@ -824,6 +840,20 @@ defmodule Deployer.HotUpgrade.Application do
           {:halt, {:error, {:config_provider_failed, mod, reason}}}
       end
     end)
+  end
+
+  # systools reports through format_error/1 on the module it returns, which turns a term
+  # such as {file_problem, {File, {open, enoent}}} into the sentence it would have printed
+  defp format_systools(node, module, term) do
+    case Rpc.call(node, module, :format_error, [term], @rpc_timeout) do
+      formatted when is_list(formatted) or is_binary(formatted) ->
+        formatted |> IO.chardata_to_string() |> String.trim()
+
+      _ ->
+        inspect(term)
+    end
+  rescue
+    _ -> inspect(term)
   end
 
   defp check_jellyfish_files(files, from_version, to_version) do

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -208,6 +208,7 @@ defmodule Deployer.HotUpgrade.Application do
       :ok
     else
       error ->
+        remove_unpacked_release(data)
         notify_error(data.sname, error)
         error
     end
@@ -532,6 +533,42 @@ defmodule Deployer.HotUpgrade.Application do
 
         {:error, reason}
     end
+  end
+
+  @doc """
+  Remove a release that was unpacked but never installed.
+
+  `release_handler:unpack_release/1` registers the release before the upgrade continues,
+  so a failure anywhere after it leaves the version behind with status `unpacked`. The
+  next attempt at the same version then fails with `{:existing_release, version}` before
+  it starts, and the files sitting in the release directory are the ones from the attempt
+  that failed, which may not be the ones the next attempt intends to install.
+
+  Only a release still marked `unpacked` is removed. Once it is `current` or `permanent`
+  the code is in use, and `release_handler` refuses to remove a permanent release anyway.
+  """
+  @spec remove_unpacked_release(Execute.t()) :: :ok
+  def remove_unpacked_release(%Execute{node: node, to_version: to_version}) do
+    version = to_charlist(to_version)
+
+    case List.keyfind(which_releases(node), version, 1) do
+      {:unpacked, ^version} ->
+        case Rpc.call(node, :release_handler, :remove_release, [version], @rpc_timeout) do
+          :ok ->
+            Logger.info("Removed the unpacked release #{to_version} left by the failed upgrade")
+
+          reason ->
+            Logger.error(
+              "Error while removing the unpacked release #{to_version}, reason: #{inspect(reason)}"
+            )
+        end
+
+      _ ->
+        # Either never unpacked, or already installed and in use
+        :ok
+    end
+
+    :ok
   end
 
   @spec which_releases(node()) :: list()

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -510,7 +510,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       root
     end)
     |> expect(:call, fn ^node, :systools, :make_relup, _params, @expected_timeout ->
-      :ok
+      {:ok, :relup, :systools_relup, []}
     end)
 
     assert :ok =
@@ -589,7 +589,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       root
     end)
     |> expect(:call, fn ^node, :systools, :make_relup, _params, @expected_timeout ->
-      :ok
+      {:ok, :relup, :systools_relup, []}
     end)
 
     assert :ok =
@@ -655,6 +655,88 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                         to_version: to_version
                       })
            end) =~ "Error while unpacking the release #{to_version}, reason: :badrpc"
+  end
+
+  @tag :capture_log
+  test "make_relup/1 logs the reason systools reports", %{
+    node: node,
+    sname: sname,
+    app_name: app_name,
+    current_path: current_path,
+    new_path: new_path,
+    from_version: from_version,
+    to_version: to_version
+  } do
+    root = ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
+
+    # the shape systools returns for the missing appup that broke a real upgrade
+    error = {:file_problem, {~c"#{root}/lib/elixir-1.20.3/ebin/elixir.appup", {:open, :enoent}}}
+
+    Foundation.RpcMock
+    |> expect(:call, fn ^node, :code, :root_dir, [], @expected_timeout -> root end)
+    |> expect(:call, fn ^node, :systools, :make_relup, params, @expected_timeout ->
+      # silent is what makes systools return the reason instead of printing it to stdout
+      assert :silent in List.last(params)
+      {:error, :systools_relup, error}
+    end)
+    |> expect(:call, fn ^node, :systools_relup, :format_error, [^error], @expected_timeout ->
+      ~c"Could not open file #{root}/lib/elixir-1.20.3/ebin/elixir.appup"
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, :make_relup} =
+                 UpgradeApp.make_relup(%Execute{
+                   node: node,
+                   sname: sname,
+                   name: app_name,
+                   language: "elixir",
+                   current_path: current_path,
+                   new_path: new_path,
+                   from_version: from_version,
+                   to_version: to_version
+                 })
+      end)
+
+    # the cause is in the log line, not on stdout detached from it
+    assert log =~ "elixir-1.20.3/ebin/elixir.appup"
+    assert log =~ "#{app_name} #{from_version} -> #{to_version}"
+  end
+
+  @tag :capture_log
+  test "make_relup/1 falls back to the raw term when format_error is unusable", %{
+    node: node,
+    sname: sname,
+    app_name: app_name,
+    current_path: current_path,
+    new_path: new_path,
+    from_version: from_version,
+    to_version: to_version
+  } do
+    root = ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
+
+    Foundation.RpcMock
+    |> expect(:call, fn ^node, :code, :root_dir, [], @expected_timeout -> root end)
+    |> expect(:call, fn ^node, :systools, :make_relup, _params, @expected_timeout ->
+      {:error, :systools_relup, :some_reason}
+    end)
+    |> expect(:call, fn ^node, :systools_relup, :format_error, _args, @expected_timeout ->
+      {:badrpc, :nodedown}
+    end)
+
+    assert capture_log(fn ->
+             assert {:error, :make_relup} =
+                      UpgradeApp.make_relup(%Execute{
+                        node: node,
+                        sname: sname,
+                        name: app_name,
+                        language: "elixir",
+                        current_path: current_path,
+                        new_path: new_path,
+                        from_version: from_version,
+                        to_version: to_version
+                      })
+           end) =~ ":some_reason"
   end
 
   @tag :capture_log
@@ -1188,7 +1270,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1251,7 +1333,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1329,7 +1411,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/deployex"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1429,7 +1511,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/deployex"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1523,7 +1605,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/deployex"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1617,7 +1699,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/deployex"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}
@@ -1717,7 +1799,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ~c"/tmp/deployex/varlib/service/deployex"
 
       ^node, :systools, :make_relup, _params, @expected_timeout ->
-        :ok
+        {:ok, :relup, :systools_relup, []}
 
       ^node, :release_handler, :check_install_release, _params, @expected_timeout ->
         {:ok, :any, :any}

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1181,6 +1181,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
 
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
+
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
 
@@ -1240,6 +1243,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     |> stub(:call, fn
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
+
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
 
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/#{app_name}/1/current"
@@ -1315,6 +1321,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     |> stub(:call, fn
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
+
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
 
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/deployex"
@@ -1413,6 +1422,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
 
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
+
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/deployex"
 
@@ -1504,6 +1516,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
 
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
+
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/deployex"
 
@@ -1594,6 +1609,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     |> stub(:call, fn
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
+
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
 
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/deployex"
@@ -1692,6 +1710,9 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
       ^node, :release_handler, :unpack_release, _params, @expected_timeout ->
         {:ok, to_version}
 
+      ^node, :release_handler, :which_releases, [], @expected_timeout ->
+        []
+
       ^node, :code, :root_dir, [], @expected_timeout ->
         ~c"/tmp/deployex/varlib/service/deployex"
 
@@ -1770,6 +1791,79 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                               1_000
              end) =~
                "Error while trying to set a permanent version for 0.2.0, reason: {:error, :no_match_versions}"
+    end
+  end
+
+  describe "remove_unpacked_release/1" do
+    @tag :capture_log
+    test "removes a release that was unpacked but never installed", %{node: node} do
+      test_pid = self()
+
+      Foundation.RpcMock
+      |> stub(:call, fn
+        ^node, :release_handler, :which_releases, [], @expected_timeout ->
+          [{~c"testapp", ~c"0.2.0", [], :unpacked}, {~c"testapp", ~c"0.1.0", [], :permanent}]
+
+        ^node, :release_handler, :remove_release, [version], @expected_timeout ->
+          send(test_pid, {:removed, version})
+          :ok
+      end)
+
+      assert :ok =
+               UpgradeApp.remove_unpacked_release(%Execute{node: node, to_version: "0.2.0"})
+
+      assert_receive {:removed, ~c"0.2.0"}
+    end
+
+    @tag :capture_log
+    test "leaves an installed release alone", %{node: node} do
+      Foundation.RpcMock
+      |> stub(:call, fn
+        ^node, :release_handler, :which_releases, [], @expected_timeout ->
+          # already in use, removing it would pull the running code away
+          [{~c"testapp", ~c"0.2.0", [], :current}]
+
+        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+          flunk("must not remove a release that is in use")
+      end)
+
+      assert :ok =
+               UpgradeApp.remove_unpacked_release(%Execute{node: node, to_version: "0.2.0"})
+    end
+
+    @tag :capture_log
+    test "does nothing when the release was never unpacked", %{node: node} do
+      Foundation.RpcMock
+      |> stub(:call, fn
+        ^node, :release_handler, :which_releases, [], @expected_timeout ->
+          [{~c"testapp", ~c"0.1.0", [], :permanent}]
+
+        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+          flunk("nothing to remove")
+      end)
+
+      assert :ok =
+               UpgradeApp.remove_unpacked_release(%Execute{node: node, to_version: "0.2.0"})
+    end
+
+    @tag :capture_log
+    test "reports a removal failure without raising", %{node: node} do
+      Foundation.RpcMock
+      |> stub(:call, fn
+        ^node, :release_handler, :which_releases, [], @expected_timeout ->
+          [{~c"testapp", ~c"0.2.0", [], :unpacked}]
+
+        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+          {:error, :enoent}
+      end)
+
+      assert capture_log(fn ->
+               assert :ok =
+                        UpgradeApp.remove_unpacked_release(%Execute{
+                          node: node,
+                          to_version: "0.2.0"
+                        })
+             end) =~ "Error while removing the unpacked release"
     end
   end
 end


### PR DESCRIPTION
Two changes from the same incident: cleaning up after a failed hot upgrade, and making the reason it failed visible.

# 1. Remove the unpacked release left behind by a failure

`release_handler:unpack_release/1` registers the release **and extracts its files** before the upgrade continues, so a failure anywhere after it leaves the version behind with status `unpacked`. The next attempt at the same version then fails before it starts (`release_handler.erl:1542`):

```
{:error, {:existing_release, "0.9.10"}}
```

The only way forward was clearing it by hand.

### Why "treat it as already unpacked" would be wrong

The tempting fix is to accept `{:existing_release, vsn}` and carry on. That would have been **actively dangerous** in the case that found this: the files left behind were from the OTP-28 artifact, so continuing would have installed them under the right version number - exactly what the retry with the correct artifact was trying to avoid.

### The change

`do_execute/1` removes the release on the failure path. `remove_release/1` deletes files, not just the registration (`do_remove_release/4`): the release directory, lib directories no other release still uses (via `diff_dir`), `erts-<vsn>` if nothing else references it, and it rewrites `RELEASES`.

```elixir
case List.keyfind(which_releases(node), version, 1) do
  {:unpacked, ^version} -> remove_release(version)
  _ -> :ok
end
```

**Only a release still marked `unpacked` is removed.** Once it is `current` the code is in use, and `release_handler` refuses a `permanent` one outright. A removal that itself fails is logged, not raised.

This also puts `which_releases/1` to work, which until now was only called from tests.

### Verified on a real node

```
Unpacked successfully: ~c"0.4.2"
Could not open file .../lib/elixir-1.20.3/ebin/elixir.appup
[error] systools:make_relup failed, reason: :error
[info] Removed the unpacked release 0.4.2 left by the failed upgrade
[error] Hot Upgrade failed, running for full deployment
```

# 2. Log the reason systools reports

That same log shows the cause was present but not where you would look for it. The first line is **systools printing to stdout** - no level, no metadata, no connection to the upgrade. DeployEx's own line says `:error` and nothing else, so anything reading only the Logger output has no cause at all.

`make_relup` was called without `silent`. With it, systools returns `{:error, Module, Error}` rather than printing, and `Module:format_error/1` produces the same sentence:

```
[error] systools:make_relup failed for myphoenixapp 0.4.0 -> 0.4.2, reason: Could not
open file .../lib/elixir-1.20.3/ebin/elixir.appup
```

Warnings arrive the same way and are logged instead of printed.

`silent` only changes what is returned - `write_relup_file` still runs, that is `noexec` (`systools_relup.erl:212-229`). A `format_error/1` that cannot be reached falls back to inspecting the raw term, so a formatting problem never hides the failure.

**Note:** two concerns in one PR. Happy to split if you would rather review them apart.

## Risk assessment

**Impact:** a failed hot upgrade can be retried without clearing the previous attempt by hand, and the reason it failed appears in the application log attached to the upgrade it belongs to.

**Blast radius:** the failure branch of `do_execute/1`, `make_relup/1`, and two new helpers. The success path returns `:ok` as before.

**Regression risk:** low. The cleanup only runs when the upgrade has already failed and does nothing unless the release is still `unpacked`. `silent` changes the return shape of `make_relup`, which is handled, and an unexpected shape still falls through to the existing branch.

**Rollback:** plain commit revert.

## Checks

Full umbrella suite green (foundation 236 + 25 doctests, host 21, deployer 180, sentinel 84, deployex_web 177 + 6 doctests), `mix credo --strict` clean, `mix format --check-formatted` clean, compiles with `--warnings-as-errors`.

Six new tests: cleanup when `unpacked`, leaves `current` alone, no-op when never unpacked, logs a removal failure without raising; plus the `{:file_problem, {path, {:open, :enoent}}}` shape from the real failure asserting the appup path and version pair reach the log, and the fallback when `format_error` is unusable. Seven existing `execute/5` stubs gained a `which_releases` clause and nine `make_relup` stubs were updated for the `silent` return shape.

## Not addressed here

`Deployex.execute/2` logs `Hot upgrade in deployex installed with success` before the upgrade completes, because with `sync_execution: false` it logs on the cast returning `:ok`. A failed self-upgrade still reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)