### PR TITLE
fix(deployer): stop reporting a DeployEx hot upgrade as successful before it has run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug fixes
  * [`PULL-272`](https://github.com/thiagoesteves/deployex/pull/272) Refuse a DeployEx hot upgrade built for a different OTP
  * [`PULL-273`](https://github.com/thiagoesteves/deployex/pull/273) Remove the unpacked release left behind by a failed hot upgrade
+ * [`PULL-274`](https://github.com/thiagoesteves/deployex/pull/274) Stop reporting a DeployEx hot upgrade as successful before it has run
 
 ### Enhancements
  * None

--- a/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
@@ -110,9 +110,9 @@ defmodule Deployer.HotUpgrade.Deployex do
   ### ==========================================================================
 
   # NOTE: an asynchronous execution is a cast, so :ok means the request was accepted and
-  #       says nothing about the upgrade. Reporting success here claimed a failed upgrade
-  #       had installed, three seconds before the release was even unpacked. The outcome
-  #       arrives later, on the hot upgrade events topic.
+  #       says nothing about the upgrade itself, which has not run yet. Only the
+  #       synchronous path can report an installation. The asynchronous outcome arrives
+  #       later, on the hot upgrade events topic.
   defp log_requested(false, current_version, to_version) do
     Logger.info(
       "Hot upgrade in #{@deployex_name} started, #{current_version} -> #{to_version}, " <>

--- a/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
@@ -89,11 +89,17 @@ defmodule Deployer.HotUpgrade.Deployex do
              Map.from_struct(check)
            ),
          :ok <- HotUpgradeApp.execute(upgrade_data) do
-      Logger.warning("Hot upgrade in #{@deployex_name} installed with success")
+      log_requested(sync_execution, current_version, to_version)
       :ok
     else
       {:error, reason} = error ->
-        Logger.error("Hot upgrade failed: #{inspect(reason)}")
+        # Nothing here restarts DeployEx. Whatever the stage, it carries on serving with
+        # the code it already had, and a failure before install_release leaves no trace,
+        # the unpacked release is removed
+        Logger.error(
+          "Hot upgrade in #{@deployex_name} failed, #{current_version} -> #{to_version}, " <>
+            "reason: #{inspect(reason)}. #{@deployex_name} is still running #{current_version}."
+        )
 
         error
     end
@@ -102,6 +108,23 @@ defmodule Deployer.HotUpgrade.Deployex do
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # NOTE: an asynchronous execution is a cast, so :ok means the request was accepted and
+  #       says nothing about the upgrade. Reporting success here claimed a failed upgrade
+  #       had installed, three seconds before the release was even unpacked. The outcome
+  #       arrives later, on the hot upgrade events topic.
+  defp log_requested(false, current_version, to_version) do
+    Logger.info(
+      "Hot upgrade in #{@deployex_name} started, #{current_version} -> #{to_version}, " <>
+        "the outcome follows"
+    )
+  end
+
+  defp log_requested(true, current_version, to_version) do
+    Logger.warning(
+      "Hot upgrade in #{@deployex_name} installed with success, #{current_version} -> #{to_version}"
+    )
+  end
 
   # A hot upgrade replaces application code inside the running VM, it cannot replace the VM
   # underneath it. A release built for another OTP brings a different Erlang and Elixir, and

--- a/apps/deployer/test/hot_upgrade/deployex_test.exs
+++ b/apps/deployer/test/hot_upgrade/deployex_test.exs
@@ -90,9 +90,29 @@ defmodule Deployer.HotUpgrade.DeployexTest do
     with_mock HotUpgradeApp, [:passthrough],
       check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end,
       execute: fn _check -> :ok end do
+      # the default is synchronous, so :ok really is the upgrade having finished
       assert capture_log(fn ->
                assert :ok = Deployex.execute("/tmp/deployex-1.0.0.tar.gz", [])
              end) =~ "Hot upgrade in deployex installed with success"
+    end
+  end
+
+  test "execute/1 asynchronous does not claim the upgrade succeeded" do
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options -> {:ok, []} end)
+
+    with_mock HotUpgradeApp, [:passthrough],
+      check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end,
+      # a cast returns :ok as soon as the request is accepted, the upgrade has not run
+      execute: fn _check -> :ok end do
+      log =
+        capture_log(fn ->
+          assert :ok = Deployex.execute("/tmp/deployex-1.0.0.tar.gz", sync_execution: false)
+        end)
+
+      assert log =~ "started"
+      assert log =~ "the outcome follows"
+      refute log =~ "installed with success"
     end
   end
 
@@ -106,7 +126,25 @@ defmodule Deployer.HotUpgrade.DeployexTest do
       assert capture_log(fn ->
                assert {:error, :no_match_versions} =
                         Deployex.execute("/tmp/deployex-1.0.0.tar.gz", [])
-             end) =~ "Hot upgrade failed: :no_match_versions"
+             end) =~ "reason: :no_match_versions"
+    end
+  end
+
+  test "execute/1 error says DeployEx keeps running" do
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options -> {:ok, []} end)
+
+    with_mock HotUpgradeApp, [:passthrough],
+      check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end,
+      execute: fn _check -> {:error, :make_relup} end do
+      log =
+        capture_log(fn ->
+          assert {:error, :make_relup} = Deployex.execute("/tmp/deployex-1.0.0.tar.gz", [])
+        end)
+
+      # nothing restarts DeployEx, whatever stage the upgrade reached
+      assert log =~ "is still running"
+      assert log =~ "failed"
     end
   end
 end

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -80,6 +80,45 @@ Use the DeployEx web interface to download a release from GitHub:
 5. Click **Apply**
 6. Monitor the progress modal until the hot-upgrade completes successfully
 
+### Choosing the right release file
+
+Each release publishes one artifact per OTP line, `deployex-ubuntu-24.04-otp-27.tar.gz` and `deployex-ubuntu-24.04-otp-28.tar.gz`.
+The file has to match the `otp_version` the installation runs, which is the one in its `deployex.yaml`.
+Picking the wrong one is the easiest way to hit the first entry in the list above, updating Erlang OTP, without meaning to.
+
+A hot upgrade replaces application code inside the running VM, it cannot replace the VM or the language runtime underneath it.
+A release built for another OTP brings a different Erlang and Elixir, and `systools:make_relup/4` needs an `.appup` for every application whose version changes, which neither ships.
+
+From `0.9.11` the wrong file is refused while the release is validated, before anything is unpacked, naming the OTP the installation runs:
+
+```bash
+[error] Hot upgrade refused, this release was built for a different OTP. deployex runs
+OTP 27 with erts 15.2.7.11 and the release brings erts 16.4.0.4. A hot upgrade cannot
+replace the runtime under a running system. Use the artifact matching the otp_version
+this installation runs, or apply it as a full deployment.
+```
+
+Earlier versions accepted the file and failed later, after unpacking, with a missing `elixir.appup` that said nothing about the file being wrong.
+
+### When a hot upgrade fails
+
+DeployEx does not fall back to a full deployment for itself, unlike a monitored application.
+It keeps running the version it already had, at every stage, and logs why the upgrade stopped:
+
+```bash
+[error] Hot upgrade in deployex failed, 0.9.10 -> 0.9.11, reason: :make_relup.
+deployex is still running 0.9.10.
+```
+
+From `0.9.11` the reason `systools` reports is included rather than printed separately to stdout, and the release unpacked by the failed attempt is removed.
+Without that removal the next attempt at the same version fails with `{:existing_release, version}` before it starts, and has to be cleared by hand.
+
+> [!NOTE]
+> The UI applies the upgrade asynchronously, so the log records that it started and the outcome follows on a later line.
+> The progress modal shows the result as it happens.
+> The installer script applies it synchronously, so there `Hot upgrade in deployex installed with success` is written once the upgrade has actually finished.
+
+
 ## Hot-Upgrading Monitored Applications
 
 Example GitHub CI workflow for hot-upgrading applications:

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -89,7 +89,7 @@ Picking the wrong one is the easiest way to hit the first entry in the list abov
 A hot upgrade replaces application code inside the running VM, it cannot replace the VM or the language runtime underneath it.
 A release built for another OTP brings a different Erlang and Elixir, and `systools:make_relup/4` needs an `.appup` for every application whose version changes, which neither ships.
 
-From `0.9.11` the wrong file is refused while the release is validated, before anything is unpacked, naming the OTP the installation runs:
+The wrong file is refused while the release is validated, before anything is unpacked, naming the OTP the installation runs:
 
 ```bash
 [error] Hot upgrade refused, this release was built for a different OTP. deployex runs
@@ -98,20 +98,17 @@ replace the runtime under a running system. Use the artifact matching the otp_ve
 this installation runs, or apply it as a full deployment.
 ```
 
-Earlier versions accepted the file and failed later, after unpacking, with a missing `elixir.appup` that said nothing about the file being wrong.
-
 ### When a hot upgrade fails
 
 DeployEx does not fall back to a full deployment for itself, unlike a monitored application.
 It keeps running the version it already had, at every stage, and logs why the upgrade stopped:
 
 ```bash
-[error] Hot upgrade in deployex failed, 0.9.10 -> 0.9.11, reason: :make_relup.
-deployex is still running 0.9.10.
+[error] Hot upgrade in deployex failed, 0.9.0 -> 0.9.1, reason: :make_relup.
+deployex is still running 0.9.0.
 ```
 
-From `0.9.11` the reason `systools` reports is included rather than printed separately to stdout, and the release unpacked by the failed attempt is removed.
-Without that removal the next attempt at the same version fails with `{:existing_release, version}` before it starts, and has to be cleared by hand.
+The reason `systools` reports is included in that message, and the release unpacked by the attempt is removed, so the same version can be applied again once the cause is fixed.
 
 > [!NOTE]
 > The UI applies the upgrade asynchronously, so the log records that it started and the outcome follows on a later line.


### PR DESCRIPTION
The DeployEx half of "if nothing happened, say so rather than pretending otherwise".

## The lie

```
15:29:49  Hot upgrade in deployex installed with success
15:29:52  Unpacked successfully: 0.9.10
15:29:53  systools:make_relup failed, reason: :error
```

Success reported **three seconds before the release was unpacked**, on an upgrade that then failed.

The UI applies a self-upgrade with `sync_execution: false` (`index.ex:900`), and an asynchronous execution is a `cast`:

```elixir
def execute(%Execute{sync_execution: false} = params) do
  GenServer.cast(__MODULE__, {:execute, params})     # :ok = request accepted
end
```

That `:ok` was treated as the upgrade having finished. Anything reading the log rather than the UI was told the opposite of what happened - which is why the incident behind #272 and #273 nearly went unnoticed.

## The fix

The asynchronous path now says what is actually known:

```
[info] Hot upgrade in deployex started, 0.9.9 -> 0.9.10, the outcome follows
```

The outcome arrives on the hot upgrade events topic, which is where the UI already reads it from - the UI was never wrong, only the log.

The synchronous path is unchanged. There `:ok` is a `GenServer.call` return, so it really is the upgrade having finished.

## The failure message

```
[error] Hot upgrade in deployex failed, 0.9.9 -> 0.9.10, reason: :make_relup.
deployex is still running 0.9.9.
```

That last sentence is your "nothing happened" point, and it holds at every stage - nothing on this path restarts DeployEx. Since #273, a failure before `install_release` also leaves no unpacked release behind, so the system really is untouched rather than merely still serving.

## Scope

DeployEx only, as agreed. The monitored-application side - not falling back to a full deployment, ghosting the version - is deliberately not here. As discussed, ghosting currently means *this version broke the app* (`worker.ex:163`, after a rollback timeout), and reusing it for *this version could not be hot upgraded* would suppress a full deployment that would have worked. Your own `myphoenixapp` 0.4.0 → 0.4.2 run is the counterexample: the hot upgrade failed, the full deployment succeeded, and under that change the app would have stayed on 0.4.0 with 0.4.2 permanently ghosted.

If you still want it, I would make it opt-in per application and track "could not hot upgrade" separately from the ghost list.

## Documentation

`guides/docs/hot-upgrades/README.md` listed the three ways to apply a DeployEx upgrade but said nothing about **which file** to apply or **what happens when one fails**. Two sections added:

**Choosing the right release file** - the artifact has to match the `otp_version` the installation runs, why a hot upgrade cannot cross OTP, and what the refusal from #272 looks like. The `DO NOT HOT-UPGRADE if` list already warned against updating Erlang OTP; picking the wrong artifact is the easiest way to do that without meaning to, so the two are now connected explicitly.

**When a hot upgrade fails** - DeployEx does not fall back to a full deployment for itself, it keeps running the version it had, and since #273 the release unpacked by a failed attempt is removed so the same version can be retried. Includes a note that the UI applies the upgrade asynchronously, which is why its log says the upgrade *started*, while the installer script is synchronous and reports the finished result.

The existing CLI example keeps `Hot upgrade in deployex installed with success` - that path is synchronous, so it was always accurate.

## Risk assessment

**Impact:** the log says what actually happened. A failed self-upgrade no longer reports success.

**Blast radius:** `Deployer.HotUpgrade.Deployex.execute/2`, log messages only. No change to the upgrade, to what `execute/2` returns, or to the events the UI reads.

**Regression risk:** low, nothing executable changed.

**Rollback:** plain commit revert.

## Checks

Full umbrella suite green (foundation 236 + 25 doctests, host 21, deployer 182, sentinel 84, deployex_web 177 + 6 doctests), `mix credo --strict` clean, `mix format --check-formatted` clean, compiles with `--warnings-as-errors`.

Two new tests: the asynchronous path asserts `started` and `refute`s `installed with success`; the failure path asserts the version pair and "is still running". The existing synchronous success test is kept, with a comment on why `:ok` is trustworthy there.

One note: a full run showed the pre-existing `Foundation.Catalog.setup_all_apps/0` doctest failing on shared `/tmp/var/lib/deployex` state. Three further runs were clean, it reproduces on main, and it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)