### PR TITLE
fix(deployer): ghost the version instead of forcing a full deployment when a hot upgrade never installed the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  * [`PULL-273`](https://github.com/thiagoesteves/deployex/pull/273) Remove the unpacked release left behind by a failed hot upgrade
  * [`PULL-274`](https://github.com/thiagoesteves/deployex/pull/274) Stop reporting a DeployEx hot upgrade as successful before it has run
  * [`PULL-275`](https://github.com/thiagoesteves/deployex/pull/275) Refuse a file that is not a DeployEx release instead of crashing the upload
+ * [`PULL-276`](https://github.com/thiagoesteves/deployex/pull/276) Ghost the version instead of forcing a full deployment when a hot upgrade never installed the release
 
 ### Enhancements
  * None

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -656,8 +656,8 @@ defmodule Deployer.Engine.Worker do
 
   # The release said it could hot upgrade, through its appup or jellyfish file, otherwise
   # this deployment would never have reached here. It then failed without the node having
-  # been touched, so there is nothing to recover from with a restart. Ghost the version so
-  # the engine stops offering it and the application keeps serving what it already runs
+  # been touched, so there is nothing to recover and no reason to restart it. Ghost the
+  # version so the engine stops offering it and the application keeps serving what it runs
   defp handle_hot_upgrade_result(
          {:error, {:not_installed, reason}},
          %{name: name} = state,

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -617,39 +617,78 @@ defmodule Deployer.Engine.Worker do
     # For hot code reloading, the previous deployment code is not changed
     sname = state.deployments[instance].sname
 
-    :global.trans({{__MODULE__, :deploy_lock}, self()}, fn ->
-      Logger.info("Hot upgrade instance: #{instance} sname: #{sname}")
+    result =
+      :global.trans({{__MODULE__, :deploy_lock}, self()}, fn ->
+        Logger.info("Hot upgrade instance: #{instance} sname: #{sname}")
 
-      from_version = Status.current_version(sname)
+        from_version = Status.current_version(sname)
 
-      %{node: node} = Catalog.node_info(sname)
+        %{node: node} = Catalog.node_info(sname)
 
-      upgrade_data = %Deployer.HotUpgrade.Execute{
-        node: node,
-        sname: sname,
+        upgrade_data = %Deployer.HotUpgrade.Execute{
+          node: node,
+          sname: sname,
+          name: name,
+          language: language,
+          current_path: Catalog.current_path(sname),
+          new_path: Catalog.new_path(sname),
+          from_version: from_version,
+          to_version: release.version
+        }
+
+        case HotUpgrade.execute(upgrade_data) do
+          :ok ->
+            Status.set_current_version_map(sname, release, deployment: :hot_upgrade)
+
+            # Cleanup Any folder left for the new sname
+            Catalog.cleanup(new_sname)
+
+            notify_application_running(sname)
+            :ok
+
+          error ->
+            error
+        end
+      end)
+
+    handle_hot_upgrade_result(result, state, sname, new_sname, release)
+  end
+
+  # The release said it could hot upgrade, through its appup or jellyfish file, otherwise
+  # this deployment would never have reached here. It then failed without the node having
+  # been touched, so there is nothing to recover from with a restart. Ghost the version so
+  # the engine stops offering it and the application keeps serving what it already runs
+  defp handle_hot_upgrade_result(
+         {:error, {:not_installed, reason}},
+         %{name: name} = state,
+         sname,
+         new_sname,
+         release
+       ) do
+    Logger.error(
+      "Hot upgrade failed before the release was installed at sname: #{sname}, " <>
+        "reason: #{inspect(reason)}. #{name} is still running " <>
+        "#{Status.current_version(sname)}, ghosting version #{release.version}."
+    )
+
+    # Nothing was installed, so the folders prepared for the new sname are unused
+    Catalog.cleanup(new_sname)
+
+    {:ok, ghosted_version_list} =
+      Status.add_ghosted_version(%Catalog.Version{
+        version: release.version,
+        hash: release.hash,
+        pre_commands: release.pre_commands,
         name: name,
-        language: language,
-        current_path: Catalog.current_path(sname),
-        new_path: Catalog.new_path(sname),
-        from_version: from_version,
-        to_version: release.version
-      }
+        sname: sname,
+        deployment: :hot_upgrade,
+        inserted_at: NaiveDateTime.utc_now()
+      })
 
-      case HotUpgrade.execute(upgrade_data) do
-        :ok ->
-          Status.set_current_version_map(sname, release, deployment: :hot_upgrade)
+    %{state | ghosted_version_list: ghosted_version_list}
+  end
 
-          # Cleanup Any folder left for the new sname
-          Catalog.cleanup(new_sname)
-
-          notify_application_running(sname)
-          :ok
-
-        _reason ->
-          :ok
-      end
-    end)
-
+  defp handle_hot_upgrade_result(_result, state, sname, new_sname, release) do
     if Status.current_version(sname) != release.version do
       Logger.error("Hot Upgrade failed, running for full deployment")
 

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -188,9 +188,9 @@ defmodule Deployer.HotUpgrade.Application do
          :ok <- prepare_release(data) do
       install(data, node)
     else
-      error ->
+      {:error, reason} = error ->
         report_failure(data, error)
-        not_installed(error)
+        {:error, {:not_installed, reason}}
     end
   end
 
@@ -237,9 +237,6 @@ defmodule Deployer.HotUpgrade.Application do
     remove_unpacked_release(data)
     notify_error(data.sname, error)
   end
-
-  defp not_installed({:error, reason}), do: {:error, {:not_installed, reason}}
-  defp not_installed(error), do: {:error, {:not_installed, error}}
 
   def do_check(%Check{from_version: from_version, to_version: to_version} = data)
       when is_binary(from_version) or is_binary(to_version) do

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -181,38 +181,65 @@ defmodule Deployer.HotUpgrade.Application do
     })
   end
 
-  def do_execute(%Execute{from_version: from_version, to_version: to_version} = data) do
+  def do_execute(%Execute{} = data) do
     notify_progress(data.sname, "Starting upgrade for #{data.sname}...")
 
     with {:ok, node} <- connect(data.node),
-         :ok <- notify_progress(data.sname, "Unpacking release"),
+         :ok <- prepare_release(data) do
+      install(data, node)
+    else
+      error ->
+        report_failure(data, error)
+        not_installed(error)
+    end
+  end
+
+  # Everything here only writes files and builds the relup, the running node is never
+  # touched. Failing at any of these steps leaves it running exactly the code it had, which
+  # is what the caller is told through {:error, {:not_installed, reason}}
+  defp prepare_release(%Execute{sname: sname} = data) do
+    with :ok <- notify_progress(sname, "Unpacking release"),
          :ok <- unpack_release(data),
-         :ok <- notify_progress(data.sname, "Creating relup file"),
+         :ok <- notify_progress(sname, "Creating relup file"),
          :ok <- make_relup(data),
-         :ok <- notify_progress(data.sname, "Checking release can be installed"),
+         :ok <- notify_progress(sname, "Checking release can be installed"),
          :ok <- check_install_release(data),
-         :ok <- notify_progress(data.sname, "Resolving the runtime configuration"),
+         :ok <- notify_progress(sname, "Resolving the runtime configuration"),
          {:ok, runtime_config} <- resolve_runtime_config(data),
-         :ok <- notify_progress(data.sname, "Adding the runtime configuration to the relup"),
-         :ok <- install_runtime_config_hook(data, runtime_config),
-         :ok <- notify_progress(data.sname, "Installing release"),
+         :ok <- notify_progress(sname, "Adding the runtime configuration to the relup") do
+      install_runtime_config_hook(data, runtime_config)
+    end
+  end
+
+  # From install_release on the node is running the new code, so a failure has already
+  # changed it and the previous version can no longer be assumed to be in place
+  defp install(%Execute{from_version: from_version, to_version: to_version} = data, node) do
+    with :ok <- notify_progress(data.sname, "Installing release"),
          :ok <- install_release(data),
          :ok <- notify_make_permanent(data.make_permanent_async, data.sname, data.to_version),
          :ok <- permfy(data),
          :ok <- notify_complete_ok(data.make_permanent_async, data.sname) do
-      message =
+      Logger.info(
         "Release upgrade executed with success at node: #{node} from: #{from_version} to: #{to_version}"
-
-      Logger.info(message)
+      )
 
       :ok
     else
       error ->
-        remove_unpacked_release(data)
-        notify_error(data.sname, error)
+        report_failure(data, error)
         error
     end
   end
+
+  defp report_failure(data, error) do
+    # remove_unpacked_release/1 only acts while the release is still unpacked, so an error
+    # after it was installed leaves it alone
+    remove_unpacked_release(data)
+    notify_error(data.sname, error)
+  end
+
+  defp not_installed({:error, reason}), do: {:error, {:not_installed, reason}}
+  defp not_installed(error), do: {:error, {:not_installed, error}}
 
   def do_check(%Check{from_version: from_version, to_version: to_version} = data)
       when is_binary(from_version) or is_binary(to_version) do

--- a/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/deployex.ex
@@ -48,6 +48,11 @@ defmodule Deployer.HotUpgrade.Deployex do
       {:ok, check}
     else
       {:ok, %Check{deploy: :full_deployment}} ->
+        Logger.warning(
+          "Hot upgrade not supported for this release, #{current_version} -> #{to_version}, " <>
+            "it requires a full deployment"
+        )
+
         {:error, :full_deployment}
 
       {:error, {:otp_mismatch, _versions} = reason} ->
@@ -87,37 +92,56 @@ defmodule Deployer.HotUpgrade.Deployex do
       })
     end
 
-    with {:ok, check} <- check(download_path),
-         %Execute{} = upgrade_data <-
-           struct(
-             %Execute{
-               node: Node.self(),
-               make_permanent_async: make_permanent_async,
-               sync_execution: sync_execution,
-               after_async_make_permanent: after_async_make_permanent
-             },
-             Map.from_struct(check)
-           ),
-         :ok <- HotUpgradeApp.execute(upgrade_data) do
-      log_requested(sync_execution, current_version, to_version)
-      :ok
-    else
-      {:error, reason} = error ->
-        # Nothing here restarts DeployEx. Whatever the stage, it carries on serving with
-        # the code it already had, and a failure before install_release leaves no trace,
-        # the unpacked release is removed
-        Logger.error(
-          "Hot upgrade in #{@deployex_name} failed, #{current_version} -> #{to_version}, " <>
-            "reason: #{inspect(reason)}. #{@deployex_name} is still running #{current_version}."
+    # A failure from check/1 is refused before the upgrade is attempted and reports itself,
+    # only the upgrade's own outcome is logged here
+    with {:ok, check} <- check(download_path) do
+      upgrade_data =
+        struct(
+          %Execute{
+            node: Node.self(),
+            make_permanent_async: make_permanent_async,
+            sync_execution: sync_execution,
+            after_async_make_permanent: after_async_make_permanent
+          },
+          Map.from_struct(check)
         )
 
-        error
+      case HotUpgradeApp.execute(upgrade_data) do
+        :ok ->
+          log_requested(sync_execution, current_version, to_version)
+          :ok
+
+        error ->
+          log_failure(error, current_version, to_version)
+          error
+      end
     end
   end
 
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # Nothing here restarts DeployEx, it carries on serving either way, but which code it is
+  # serving depends on how far the upgrade got. Before install_release nothing was touched
+  # and the unpacked release is removed, so the previous version is still the one running
+  defp log_failure({:error, {:not_installed, reason}}, current_version, to_version) do
+    Logger.error(
+      "Hot upgrade in #{@deployex_name} failed, #{current_version} -> #{to_version}, " <>
+        "reason: #{inspect(reason)}. Nothing was installed, #{@deployex_name} is still " <>
+        "running #{current_version}."
+    )
+  end
+
+  # Past install_release the new code is already loaded, so claiming the previous version is
+  # still running would be wrong
+  defp log_failure({:error, reason}, current_version, to_version) do
+    Logger.error(
+      "Hot upgrade in #{@deployex_name} failed, #{current_version} -> #{to_version}, " <>
+        "reason: #{inspect(reason)}. The release was installed before it failed, " <>
+        "#{@deployex_name} may already be running #{to_version}."
+    )
+  end
 
   # NOTE: an asynchronous execution is a cast, so :ok means the request was accepted and
   #       says nothing about the upgrade itself, which has not run yet. Only the

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -534,6 +534,77 @@ defmodule Deployer.EngineTest do
                end
              end) =~ "Hot Upgrade failed, running for full deployment"
     end
+
+    test "Failure on executing the hotupgrade - not installed, ghost the version" do
+      name = "myelixir"
+      language = "elixir"
+      from_version = "1.0.0"
+      to_version = "2.0.0"
+      ref = make_ref()
+      pid = self()
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> stub(:current_version, fn _sname -> from_version end)
+      |> expect(:update, 1, fn _sname -> :ok end)
+      |> expect(:set_current_version_map, 1, fn _sname, _release, _attrs -> :ok end)
+      |> expect(:add_ghosted_version, 1, fn version_map ->
+        # the version that failed has to be the ghosted one, the running version is fine
+        assert version_map.version == to_version
+        assert version_map.name == name
+
+        send(pid, {:handle_ref_event, ref})
+        {:ok, [version_map]}
+      end)
+
+      Deployer.MonitorMock
+      # only the initial deployment, a hot upgrade that never installed anything must not
+      # start a new instance
+      |> expect(:start_service, 1, fn _service -> {:ok, self()} end)
+      |> stub(:stop_service, fn _name, _sname -> :ok end)
+      |> stub(:run_pre_commands, fn _sname, _release, :new -> {:ok, []} end)
+
+      Deployer.ReleaseMock
+      |> stub(:download_version_map, fn _app_name ->
+        %{version: to_version, hash: "local", pre_commands: []}
+      end)
+      |> stub(:download_release, fn _app_name, ^to_version, _download_path -> :ok end)
+
+      Deployer.HotUpgradeMock
+      |> stub(:prepare_new_path, fn _name, _language, _to_version, _new_path -> :ok end)
+      |> expect(:check, 1, fn %Deployer.HotUpgrade.Check{} = check ->
+        {:ok, %{check | deploy: :hot_upgrade}}
+      end)
+      # the release claimed it could hot upgrade and then failed before install_release,
+      # so the node is still running from_version and there is nothing to recover from
+      |> expect(:execute, 1, fn %Deployer.HotUpgrade.Execute{to_version: ^to_version} ->
+        {:error, {:not_installed, :make_relup}}
+      end)
+
+      log =
+        capture_log(fn ->
+          with_mock System, [:passthrough],
+            cmd: fn "tar", ["-x", "-f", _source_path, "-C", _dest_path] -> {"", 0} end do
+            assert {:ok, _pid} =
+                     Engine.Worker.start_link(%Engine.Worker{
+                       deploy_rollback_timeout_ms: 1_000,
+                       deploy_schedule_interval_ms: 100,
+                       name: name,
+                       language: language
+                     })
+
+            assert_receive {:handle_ref_event, ^ref}, 1_000
+
+            # the version is ghosted in the worker state as well, so the next scheduled
+            # deployment skips it instead of trying the same broken release again
+            refute_receive {:handle_ref_event, ^ref}, 300
+          end
+        end)
+
+      assert log =~ "Hot upgrade failed before the release was installed"
+      assert log =~ "ghosting version #{to_version}"
+      refute log =~ "running for full deployment"
+    end
   end
 
   describe "Deployment Status" do

--- a/apps/deployer/test/hot_upgrade/deployex_test.exs
+++ b/apps/deployer/test/hot_upgrade/deployex_test.exs
@@ -157,21 +157,42 @@ defmodule Deployer.HotUpgrade.DeployexTest do
     end
   end
 
-  test "execute/1 error says DeployEx keeps running" do
+  test "execute/1 error before the release is installed says DeployEx keeps running" do
     Host.CommanderMock
     |> expect(:run, fn _command, _options -> {:ok, []} end)
 
     with_mock HotUpgradeApp, [:passthrough],
       check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end,
-      execute: fn _check -> {:error, :make_relup} end do
+      execute: fn _check -> {:error, {:not_installed, :make_relup}} end do
       log =
         capture_log(fn ->
-          assert {:error, :make_relup} = Deployex.execute("/tmp/deployex-1.0.0.tar.gz", [])
+          assert {:error, {:not_installed, :make_relup}} =
+                   Deployex.execute("/tmp/deployex-1.0.0.tar.gz", [])
         end)
 
-      # nothing restarts DeployEx, whatever stage the upgrade reached
-      assert log =~ "is still running"
-      assert log =~ "failed"
+      # nothing was loaded, so the previous version really is the one still running
+      assert log =~ "Nothing was installed"
+      assert log =~ "is still running 0."
+      assert log =~ "reason: :make_relup"
+    end
+  end
+
+  test "execute/1 error after the release is installed does not claim the old version runs" do
+    Host.CommanderMock
+    |> expect(:run, fn _command, _options -> {:ok, []} end)
+
+    with_mock HotUpgradeApp, [:passthrough],
+      check: fn _check -> {:ok, %Check{deploy: :hot_upgrade}} end,
+      execute: fn _check -> {:error, :make_permanent} end do
+      log =
+        capture_log(fn ->
+          assert {:error, :make_permanent} = Deployex.execute("/tmp/deployex-1.0.0.tar.gz", [])
+        end)
+
+      # the new code is already loaded at this point, claiming otherwise would be wrong
+      assert log =~ "was installed before it failed"
+      assert log =~ "may already be running 1.0.0"
+      refute log =~ "is still running"
     end
   end
 end

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1349,7 +1349,8 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     end)
 
     with_mock Node, [:passthrough], connect: fn ^node -> true end do
-      assert {:error, {:config_provider_failed, _mod, _reason}} =
+      # The node was never touched, which is what :not_installed reports to the caller
+      assert {:error, {:not_installed, {:config_provider_failed, _mod, _reason}}} =
                UpgradeApp.execute(%Execute{
                  node: node,
                  sname: sname,

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -100,15 +100,18 @@ this installation runs, or apply it as a full deployment.
 
 ### When a hot upgrade fails
 
-DeployEx does not fall back to a full deployment for itself, unlike a monitored application.
-It keeps running the version it already had, at every stage, and logs why the upgrade stopped:
+DeployEx does not fall back to a full deployment for itself.
+It keeps running and logs why the upgrade stopped:
 
 ```bash
 [error] Hot upgrade in deployex failed, 0.9.0 -> 0.9.1, reason: :make_relup.
-deployex is still running 0.9.0.
+Nothing was installed, deployex is still running 0.9.0.
 ```
 
 The reason `systools` reports is included in that message, and the release unpacked by the attempt is removed, so the same version can be applied again once the cause is fixed.
+
+Everything up to installing the release only writes files and builds the relup, so a failure there leaves the node running exactly the code it had, which is what `Nothing was installed` reports.
+Past that point the new code is already loaded, and the message says so instead.
 
 > [!NOTE]
 > The UI applies the upgrade asynchronously, so the log records that it started and the outcome follows on a later line.
@@ -126,6 +129,29 @@ Example GitHub CI workflow for hot-upgrading applications:
 4. Generate release with hot-upgrade information
 
 See [example workflow](https://github.com/thiagoesteves/calori/blob/main/.github/workflows/hot-upgrade.yaml) for implementation details.
+
+### When a hot upgrade fails
+
+A release only reaches the hot upgrade path when it shipped the `.appup` or `jellyfish.json` files saying it supports one.
+What DeployEx does when that upgrade fails depends on whether the running node was already changed.
+
+If it failed before the release was installed, nothing on the node was touched and there is nothing a restart would recover.
+The version is ghosted and the application carries on serving what it already runs:
+
+```bash
+[error] Hot upgrade failed before the release was installed at sname: myphoenixapp-63wu32,
+reason: :make_relup. myphoenixapp is still running 1.0.0, ghosting version 1.1.0.
+```
+
+A ghosted version is skipped by every following deployment, so the same broken release is not attempted again.
+Publish a new version once the cause is fixed, the application is not stuck waiting for it.
+
+If the release was already installed and a later step failed, the node is running code that was never made permanent.
+There DeployEx does fall back to a full deployment, which restarts the instance on the new version:
+
+```bash
+[error] Hot Upgrade failed, running for full deployment
+```
 
 # Additional Resources
 

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -135,7 +135,7 @@ See [example workflow](https://github.com/thiagoesteves/calori/blob/main/.github
 A release only reaches the hot upgrade path when it shipped the `.appup` or `jellyfish.json` files saying it supports one.
 What DeployEx does when that upgrade fails depends on whether the running node was already changed.
 
-If it failed before the release was installed, nothing on the node was touched and there is nothing a restart would recover.
+If it failed before the release was installed, nothing on the node was touched, so there is nothing to recover and no reason to restart it.
 The version is ghosted and the application carries on serving what it already runs:
 
 ```bash


### PR DESCRIPTION
## Problem

A hot upgrade that failed was always recovered with a full deployment, whatever stage it reached:

```elixir
if Status.current_version(sname) != release.version do
  Logger.error("Hot Upgrade failed, running for full deployment")
  full_deployment(state, new_sname, release)
```

The error was never looked at. When the upgrade failed before `install_release` the running node had not been touched at all, so there was nothing to recover and no reason to restart it. The restart was pure downtime, for a release that had only ever claimed it could hot upgrade.

## The boundary

`install_release` is the point of no return. Everything before it only writes files and builds the relup, everything after has already changed the node. `do_execute/1` now has that shape instead of one flat `with`:

- `prepare_release/1` runs the steps that leave the node alone and reports `{:error, {:not_installed, reason}}`
- `install/2` runs the rest and reports its errors as they are

The steps and their order are unchanged.

## What each failure does now

A release only reaches this path when it shipped the `.appup` or `jellyfish.json` files saying it supports a hot upgrade, so a release that honestly needs a full deployment is never affected.

**Failed before installing**, monitored application: refused rather than recovered. The version is ghosted, the engine stops offering it, and the application keeps serving what it already runs.

```bash
[error] Hot upgrade failed before the release was installed at sname: myphoenixapp-63wu32,
reason: :make_relup. myphoenixapp is still running 1.0.0, ghosting version 1.1.0.
```

**Failed after installing**: still falls back to a full deployment. The node is running code that was never made permanent, so the restart is genuine recovery.

**DeployEx**, which never falls back for itself, now says which of the two happened. The old message claimed the previous version was still running for every failure, which is wrong once `install_release` has succeeded and `permfy` has not.

## The behaviour change worth knowing

A release with a broken appup used to still ship, by restart. It no longer does, the application stays on its current version and the failed version is ghosted. Publishing a fixed version deploys normally, nothing is stuck waiting.

## Risk assessment

**Impact:** as above. Releases needing a full deployment are unaffected, they never enter this path.

**Blast radius:** `Deployer.HotUpgrade.Application` `do_execute/1`, `Deployer.Engine.Worker` `hot_upgrade/3`, and the failure logging in `Deployer.HotUpgrade.Deployex`. Monitoring, rollback, and the full deployment path itself are untouched.

**Regression risk:** medium. The steps and their order are identical and every error still reaches the same callers, but the error term gained a tag and one class of failure now takes a different branch. The risk is an operator who relied on the fallback shipping code after a broken appup, which is what this removes on purpose.

**Rollback:** plain commit revert. Ghosted versions are recorded per application and a reverted build simply stops consulting the ones this added.

## Tests

New engine test asserting a not installed failure ghosts the **new** version, updates the worker state so the next scheduled deployment skips it, and never starts a second instance. The existing post install failure test still falls back to a full deployment. The config provider test that already aborted before installing now asserts the tag it produces, and the DeployEx failure test is split into the two messages.

Full suite green, `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)