### PR TITLE
feat(web): add a ghosted version list with clear all and clear one actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
  * [`PULL-276`](https://github.com/thiagoesteves/deployex/pull/276) Ghost the version instead of forcing a full deployment when a hot upgrade never installed the release
 
 ### Enhancements
- * None
+ * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions
 
 ## 0.9.10 🚀 (2026-08-10)
 

--- a/apps/deployer/lib/deployer/engine.ex
+++ b/apps/deployer/lib/deployer/engine.ex
@@ -53,39 +53,4 @@ defmodule Deployer.Engine do
   """
   @spec restart_deployments(name :: String.t()) :: :ok
   def restart_deployments(name), do: Engine.Worker.restart_deployments(name)
-
-  @doc """
-  Retrieve the ghosted version list for the application
-  """
-  @spec ghosted_version_list(name :: String.t()) :: list()
-  def ghosted_version_list(name), do: Status.ghosted_version_list(name)
-
-  @doc """
-  Remove one version from the ghosted version list, allowing it to be deployed again
-  """
-  @spec remove_ghosted_version(name :: String.t(), version :: String.t()) :: {:ok, list()}
-  def remove_ghosted_version(name, version) do
-    call_worker(name, {:remove_ghosted_version, version}, fn ->
-      Status.remove_ghosted_version(name, version)
-    end)
-  end
-
-  @doc """
-  Remove every version from the ghosted version list
-  """
-  @spec clear_ghosted_versions(name :: String.t()) :: {:ok, list()}
-  def clear_ghosted_versions(name) do
-    call_worker(name, :clear_ghosted_versions, fn -> Status.clear_ghosted_versions(name) end)
-  end
-
-  # The worker keeps its own copy of the ghosted list and consults it on every deployment
-  # check, so the change has to go through it while it is running, otherwise it would keep
-  # skipping a version that is no longer ghosted. With no worker there is no copy to keep in
-  # step and the stored list is the only thing to update
-  defp call_worker(name, message, without_worker) do
-    case Process.whereis(String.to_existing_atom(name)) do
-      nil -> without_worker.()
-      pid -> GenServer.call(pid, message)
-    end
-  end
 end

--- a/apps/deployer/lib/deployer/engine.ex
+++ b/apps/deployer/lib/deployer/engine.ex
@@ -53,4 +53,39 @@ defmodule Deployer.Engine do
   """
   @spec restart_deployments(name :: String.t()) :: :ok
   def restart_deployments(name), do: Engine.Worker.restart_deployments(name)
+
+  @doc """
+  Retrieve the ghosted version list for the application
+  """
+  @spec ghosted_version_list(name :: String.t()) :: list()
+  def ghosted_version_list(name), do: Status.ghosted_version_list(name)
+
+  @doc """
+  Remove one version from the ghosted version list, allowing it to be deployed again
+  """
+  @spec remove_ghosted_version(name :: String.t(), version :: String.t()) :: {:ok, list()}
+  def remove_ghosted_version(name, version) do
+    call_worker(name, {:remove_ghosted_version, version}, fn ->
+      Status.remove_ghosted_version(name, version)
+    end)
+  end
+
+  @doc """
+  Remove every version from the ghosted version list
+  """
+  @spec clear_ghosted_versions(name :: String.t()) :: {:ok, list()}
+  def clear_ghosted_versions(name) do
+    call_worker(name, :clear_ghosted_versions, fn -> Status.clear_ghosted_versions(name) end)
+  end
+
+  # The worker keeps its own copy of the ghosted list and consults it on every deployment
+  # check, so the change has to go through it while it is running, otherwise it would keep
+  # skipping a version that is no longer ghosted. With no worker there is no copy to keep in
+  # step and the stored list is the only thing to update
+  defp call_worker(name, message, without_worker) do
+    case Process.whereis(String.to_existing_atom(name)) do
+      nil -> without_worker.()
+      pid -> GenServer.call(pid, message)
+    end
+  end
 end

--- a/apps/deployer/lib/deployer/engine.ex
+++ b/apps/deployer/lib/deployer/engine.ex
@@ -4,7 +4,6 @@ defmodule Deployer.Engine do
   require Logger
 
   alias Deployer.Engine
-  alias Deployer.Status
   alias Foundation.Catalog
   alias Foundation.Yaml.Application, as: YamlApplication
 
@@ -19,14 +18,9 @@ defmodule Deployer.Engine do
     application |> Map.from_struct() |> init_worker()
   end
 
-  def init_worker(%{name: name} = application) do
-    ghosted_version_list = Status.ghosted_version_list(name)
-
-    service =
-      struct(
-        %Engine.Worker{ghosted_version_list: ghosted_version_list},
-        application
-      )
+  def init_worker(%{} = application) do
+    # The ghosted list is read by the worker itself, after it has subscribed
+    service = struct(%Engine.Worker{}, application)
 
     Engine.Supervisor.start_deployment(service)
 

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -72,9 +72,11 @@ defmodule Deployer.Engine.Worker do
       ) do
     Logger.info("Initializing Engine Server for #{name}")
 
-    # The list is loaded once when the worker starts and kept in step from here on, anything
-    # changing it announces the new list rather than reaching into this process
+    # Subscribe before reading, in this order. A change made in between then arrives as a
+    # message instead of being lost in the gap. Reading here is also what makes a restarted
+    # worker current, the supervisor hands back the list captured when it was first started
     Status.subscribe_ghosted_versions(name)
+    ghosted_version_list = Status.ghosted_version_list(name)
 
     schedule_new_deployment(deploy_schedule_interval_ms)
 
@@ -118,6 +120,7 @@ defmodule Deployer.Engine.Worker do
      %{
        state
        | deployments: deployments,
+         ghosted_version_list: ghosted_version_list,
          available_ports: build_ports_by_index(replica_ports, replicas)
      }}
   end

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -187,6 +187,26 @@ defmodule Deployer.Engine.Worker do
     {:noreply, state}
   end
 
+  # The worker keeps its own copy of the ghosted list and consults it on every deployment
+  # check, so the removal has to go through it. Removing straight from the catalog would
+  # leave the running worker still skipping the version until it was restarted
+  @impl true
+  def handle_call({:remove_ghosted_version, version}, _from, %__MODULE__{name: name} = state) do
+    Logger.info("Removing ghosted version #{version} for #{name}, it can be deployed again")
+
+    {:ok, ghosted_version_list} = Status.remove_ghosted_version(name, version)
+
+    {:reply, {:ok, ghosted_version_list}, %{state | ghosted_version_list: ghosted_version_list}}
+  end
+
+  def handle_call(:clear_ghosted_versions, _from, %__MODULE__{name: name} = state) do
+    Logger.info("Clearing the ghosted version list for #{name}, they can be deployed again")
+
+    {:ok, ghosted_version_list} = Status.clear_ghosted_versions(name)
+
+    {:reply, {:ok, ghosted_version_list}, %{state | ghosted_version_list: ghosted_version_list}}
+  end
+
   @impl true
   def handle_cast(:restart_deployments, %__MODULE__{} = state) do
     {:noreply, do_restart_deployments(state)}

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -72,6 +72,10 @@ defmodule Deployer.Engine.Worker do
       ) do
     Logger.info("Initializing Engine Server for #{name}")
 
+    # The list is loaded once when the worker starts and kept in step from here on, anything
+    # changing it announces the new list rather than reaching into this process
+    Status.subscribe_ghosted_versions(name)
+
     schedule_new_deployment(deploy_schedule_interval_ms)
 
     check_installled_apps = fn
@@ -141,6 +145,20 @@ defmodule Deployer.Engine.Worker do
     {:noreply, new_state}
   end
 
+  # Only a change on this node matters, the ghosted list is stored by the DeployEx instance
+  # that owns the application
+  def handle_info(
+        {:ghosted_versions_updated, source_node, _name, ghosted_version_list},
+        %__MODULE__{} = state
+      )
+      when source_node == node() do
+    {:noreply, %{state | ghosted_version_list: ghosted_version_list}}
+  end
+
+  def handle_info({:ghosted_versions_updated, _source_node, _name, _list}, state) do
+    {:noreply, state}
+  end
+
   def handle_info(
         {:timeout_rollback, instance, sname},
         %{name: name, deployments: deployments, deployment_to_terminate: deployment_to_terminate} =
@@ -185,26 +203,6 @@ defmodule Deployer.Engine.Worker do
       end
 
     {:noreply, state}
-  end
-
-  # The worker keeps its own copy of the ghosted list and consults it on every deployment
-  # check, so the removal has to go through it. Removing straight from the catalog would
-  # leave the running worker still skipping the version until it was restarted
-  @impl true
-  def handle_call({:remove_ghosted_version, version}, _from, %__MODULE__{name: name} = state) do
-    Logger.info("Removing ghosted version #{version} for #{name}, it can be deployed again")
-
-    {:ok, ghosted_version_list} = Status.remove_ghosted_version(name, version)
-
-    {:reply, {:ok, ghosted_version_list}, %{state | ghosted_version_list: ghosted_version_list}}
-  end
-
-  def handle_call(:clear_ghosted_versions, _from, %__MODULE__{name: name} = state) do
-    Logger.info("Clearing the ghosted version list for #{name}, they can be deployed again")
-
-    {:ok, ghosted_version_list} = Status.clear_ghosted_versions(name)
-
-    {:reply, {:ok, ghosted_version_list}, %{state | ghosted_version_list: ghosted_version_list}}
   end
 
   @impl true

--- a/apps/deployer/lib/deployer/status.ex
+++ b/apps/deployer/lib/deployer/status.ex
@@ -139,6 +139,13 @@ defmodule Deployer.Status do
   def clear_ghosted_versions(name), do: default().clear_ghosted_versions(name)
 
   @doc """
+  Subscribe to the ghosted version list changes for the application
+  """
+  @impl true
+  @spec subscribe_ghosted_versions(name :: String.t()) :: :ok
+  def subscribe_ghosted_versions(name), do: default().subscribe_ghosted_versions(name)
+
+  @doc """
   Retrieve the history version list by name
   """
   @impl true

--- a/apps/deployer/lib/deployer/status.ex
+++ b/apps/deployer/lib/deployer/status.ex
@@ -124,6 +124,21 @@ defmodule Deployer.Status do
   def ghosted_version_list(name), do: default().ghosted_version_list(name)
 
   @doc """
+  Remove one version from the ghosted version list, returning the remaining list
+  """
+  @impl true
+  @spec remove_ghosted_version(name :: String.t(), version :: String.t()) :: {:ok, list()}
+  def remove_ghosted_version(name, version),
+    do: default().remove_ghosted_version(name, version)
+
+  @doc """
+  Remove every version from the ghosted version list
+  """
+  @impl true
+  @spec clear_ghosted_versions(name :: String.t()) :: {:ok, list()}
+  def clear_ghosted_versions(name), do: default().clear_ghosted_versions(name)
+
+  @doc """
   Retrieve the history version list by name
   """
   @impl true

--- a/apps/deployer/lib/deployer/status/adapter.ex
+++ b/apps/deployer/lib/deployer/status/adapter.ex
@@ -16,6 +16,7 @@ defmodule Deployer.Status.Adapter do
   @callback ghosted_version_list(String.t()) :: list()
   @callback remove_ghosted_version(String.t(), String.t()) :: {:ok, list()}
   @callback clear_ghosted_versions(String.t()) :: {:ok, list()}
+  @callback subscribe_ghosted_versions(String.t()) :: :ok
   @callback history_version_list(String.t(), Keyword.t()) :: list()
   @callback update(String.t()) :: :ok
   @callback set_mode(String.t(), :automatic | :manual, String.t()) :: {:ok, map()}

--- a/apps/deployer/lib/deployer/status/adapter.ex
+++ b/apps/deployer/lib/deployer/status/adapter.ex
@@ -14,6 +14,8 @@ defmodule Deployer.Status.Adapter do
   @callback set_current_version_map(String.t(), Release.Version.t(), Keyword.t()) :: :ok
   @callback add_ghosted_version(Catalog.Version.t()) :: {:ok, list()}
   @callback ghosted_version_list(String.t()) :: list()
+  @callback remove_ghosted_version(String.t(), String.t()) :: {:ok, list()}
+  @callback clear_ghosted_versions(String.t()) :: {:ok, list()}
   @callback history_version_list(String.t(), Keyword.t()) :: list()
   @callback update(String.t()) :: :ok
   @callback set_mode(String.t(), :automatic | :manual, String.t()) :: {:ok, map()}

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -209,6 +209,12 @@ defmodule Deployer.Status.Application do
   def ghosted_version_list(name), do: Catalog.ghosted_versions(name)
 
   @impl true
+  def remove_ghosted_version(name, version), do: Catalog.remove_ghosted_version(name, version)
+
+  @impl true
+  def clear_ghosted_versions(name), do: Catalog.clear_ghosted_versions(name)
+
+  @impl true
   def history_version_list(name, options), do: Catalog.versions(name, options)
 
   @impl true

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -18,6 +18,7 @@ defmodule Deployer.Status.Application do
 
   @update_apps_interval :timer.seconds(1)
   @apps_data_updated_topic "deployex::monitoring_app_updated"
+  @ghosted_versions_topic "deployex::ghosted_versions"
 
   @manual_version_max_list 10
 
@@ -203,16 +204,26 @@ defmodule Deployer.Status.Application do
   end
 
   @impl true
-  def add_ghosted_version(version), do: Catalog.add_ghosted_version(version)
+  def add_ghosted_version(%{name: name} = version) do
+    version |> Catalog.add_ghosted_version() |> broadcast_ghosted_versions(name)
+  end
 
   @impl true
   def ghosted_version_list(name), do: Catalog.ghosted_versions(name)
 
   @impl true
-  def remove_ghosted_version(name, version), do: Catalog.remove_ghosted_version(name, version)
+  def remove_ghosted_version(name, version) do
+    name |> Catalog.remove_ghosted_version(version) |> broadcast_ghosted_versions(name)
+  end
 
   @impl true
-  def clear_ghosted_versions(name), do: Catalog.clear_ghosted_versions(name)
+  def clear_ghosted_versions(name) do
+    name |> Catalog.clear_ghosted_versions() |> broadcast_ghosted_versions(name)
+  end
+
+  @impl true
+  def subscribe_ghosted_versions(name),
+    do: Phoenix.PubSub.subscribe(Deployer.PubSub, ghosted_versions_topic(name))
 
   @impl true
   def history_version_list(name, options), do: Catalog.versions(name, options)
@@ -251,6 +262,22 @@ defmodule Deployer.Status.Application do
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # Anything holding a copy of the ghosted list has to hear about a change, the engine worker
+  # consults its own copy on every deployment check. The node is carried in the message so a
+  # subscriber can tell whose list changed, the storage is local to each DeployEx instance
+  defp broadcast_ghosted_versions({:ok, ghosted_version_list} = result, name) do
+    Phoenix.PubSub.broadcast(
+      Deployer.PubSub,
+      ghosted_versions_topic(name),
+      {:ghosted_versions_updated, Node.self(), name, ghosted_version_list}
+    )
+
+    result
+  end
+
+  defp ghosted_versions_topic(name), do: "#{@ghosted_versions_topic}::#{name}"
+
   defp do_set_mode(name, :automatic = mode, _version) do
     config = Catalog.config(name)
     Catalog.config_update(name, %{config | mode: mode})

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -1050,6 +1050,60 @@ defmodule Deployer.EngineTest do
     end
   end
 
+  describe "Ghosted version list" do
+    @tag :capture_log
+    test "Remove one ghosted version updates the worker state" do
+      name = "myelixir"
+      ghosted = %Foundation.Catalog.Version{version: "2.0.0", name: name}
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> expect(:remove_ghosted_version, 1, fn ^name, "2.0.0" -> {:ok, []} end)
+
+      assert {:ok, pid} =
+               Engine.Worker.start_link(%Engine.Worker{
+                 deploy_rollback_timeout_ms: 60_000,
+                 deploy_schedule_interval_ms: 60_000,
+                 name: name,
+                 language: "elixir",
+                 ghosted_version_list: [ghosted]
+               })
+
+      assert {:ok, []} = Engine.remove_ghosted_version(name, "2.0.0")
+
+      # the worker consults its own copy on every deployment check, so it has to be the one
+      # that changed, not only the stored list
+      assert %{ghosted_version_list: []} = :sys.get_state(pid)
+    end
+
+    @tag :capture_log
+    test "Clear all ghosted versions updates the worker state" do
+      name = "myelixir"
+
+      ghosted = [
+        %Foundation.Catalog.Version{version: "2.0.0", name: name},
+        %Foundation.Catalog.Version{version: "3.0.0", name: name}
+      ]
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> expect(:clear_ghosted_versions, 1, fn ^name -> {:ok, []} end)
+
+      assert {:ok, pid} =
+               Engine.Worker.start_link(%Engine.Worker{
+                 deploy_rollback_timeout_ms: 60_000,
+                 deploy_schedule_interval_ms: 60_000,
+                 name: name,
+                 language: "elixir",
+                 ghosted_version_list: ghosted
+               })
+
+      assert {:ok, []} = Engine.clear_ghosted_versions(name)
+
+      assert %{ghosted_version_list: []} = :sys.get_state(pid)
+    end
+  end
+
   describe "Deployment rollback" do
     @tag :capture_log
     test "Rollback a version after timeout" do

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -14,11 +14,13 @@ defmodule Deployer.EngineTest do
   alias Foundation.Fixture.Catalog, as: FixtureCatalog
 
   setup do
-    # Every worker subscribes on start up, the tests that care about the notification
-    # override this with their own expectation
+    # Every worker subscribes and then reads the list on start up, the tests that care about
+    # the ghosted list override these with their own expectations
     stub(Deployer.StatusMock, :subscribe_ghosted_versions, fn name ->
       Phoenix.PubSub.subscribe(Deployer.PubSub, "deployex::ghosted_versions::#{name}")
     end)
+
+    stub(Deployer.StatusMock, :ghosted_version_list, fn _name -> [] end)
 
     FixtureCatalog.cleanup()
   end
@@ -334,6 +336,7 @@ defmodule Deployer.EngineTest do
       |> expect(:update, 1, fn _sname -> :ok end)
       |> expect(:set_current_version_map, 1, fn _sname, _release, _attrs -> :ok end)
       |> stub(:current_version, fn _sname -> "1.0.0" end)
+      |> stub(:ghosted_version_list, fn ^name -> [%{version: ghosted_version}] end)
 
       Deployer.MonitorMock
       |> expect(:start_service, 1, fn _service ->
@@ -368,8 +371,7 @@ defmodule Deployer.EngineTest do
                    deploy_rollback_timeout_ms: 1_000,
                    deploy_schedule_interval_ms: 100,
                    name: name,
-                   language: language,
-                   ghosted_version_list: [%{version: ghosted_version}]
+                   language: language
                  })
 
         assert_receive {:handle_ref_event, ^ref}, 1_000
@@ -1064,15 +1066,18 @@ defmodule Deployer.EngineTest do
 
       Deployer.StatusMock
       |> expect(:list_installed_apps, fn _name -> [] end)
+      |> expect(:ghosted_version_list, 1, fn ^name -> [ghosted] end)
 
       assert {:ok, pid} =
                Engine.Worker.start_link(%Engine.Worker{
                  deploy_rollback_timeout_ms: 60_000,
                  deploy_schedule_interval_ms: 60_000,
                  name: name,
-                 language: "elixir",
-                 ghosted_version_list: [ghosted]
+                 language: "elixir"
                })
+
+      # read on start up, not handed in by whoever started the worker
+      assert :sys.get_state(pid).ghosted_version_list == [ghosted]
 
       Phoenix.PubSub.broadcast(
         Deployer.PubSub,
@@ -1088,21 +1093,62 @@ defmodule Deployer.EngineTest do
     end
 
     @tag :capture_log
-    test "The worker ignores a change made on another node" do
+    test "A change made while the worker starts up is not lost" do
       name = "myelixir"
       ghosted = %Foundation.Catalog.Version{version: "2.0.0", name: name}
+      test_pid = self()
 
       Deployer.StatusMock
       |> expect(:list_installed_apps, fn _name -> [] end)
+      # stands in for a change landing between the subscribe and the read. Subscribing first
+      # is what turns it into a message the worker still gets, rather than a lost update
+      |> expect(:subscribe_ghosted_versions, fn ^name ->
+        :ok = Phoenix.PubSub.subscribe(Deployer.PubSub, "deployex::ghosted_versions::#{name}")
+
+        Phoenix.PubSub.broadcast(
+          Deployer.PubSub,
+          "deployex::ghosted_versions::#{name}",
+          {:ghosted_versions_updated, Node.self(), name, [ghosted]}
+        )
+
+        send(test_pid, :subscribed)
+        :ok
+      end)
+      |> expect(:ghosted_version_list, 1, fn ^name -> [] end)
 
       assert {:ok, pid} =
                Engine.Worker.start_link(%Engine.Worker{
                  deploy_rollback_timeout_ms: 60_000,
                  deploy_schedule_interval_ms: 60_000,
                  name: name,
-                 language: "elixir",
-                 ghosted_version_list: [ghosted]
+                 language: "elixir"
                })
+
+      assert_receive :subscribed
+
+      # the read returned the list from before the change, the message carries the change
+      assert :sys.get_state(pid).ghosted_version_list == [ghosted]
+    end
+
+    @tag :capture_log
+    test "The worker ignores a change made on another node" do
+      name = "myelixir"
+      ghosted = %Foundation.Catalog.Version{version: "2.0.0", name: name}
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> expect(:ghosted_version_list, 1, fn ^name -> [ghosted] end)
+
+      assert {:ok, pid} =
+               Engine.Worker.start_link(%Engine.Worker{
+                 deploy_rollback_timeout_ms: 60_000,
+                 deploy_schedule_interval_ms: 60_000,
+                 name: name,
+                 language: "elixir"
+               })
+
+      # read on start up, not handed in by whoever started the worker
+      assert :sys.get_state(pid).ghosted_version_list == [ghosted]
 
       Phoenix.PubSub.broadcast(
         Deployer.PubSub,

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -14,6 +14,12 @@ defmodule Deployer.EngineTest do
   alias Foundation.Fixture.Catalog, as: FixtureCatalog
 
   setup do
+    # Every worker subscribes on start up, the tests that care about the notification
+    # override this with their own expectation
+    stub(Deployer.StatusMock, :subscribe_ghosted_versions, fn name ->
+      Phoenix.PubSub.subscribe(Deployer.PubSub, "deployex::ghosted_versions::#{name}")
+    end)
+
     FixtureCatalog.cleanup()
   end
 
@@ -1052,13 +1058,12 @@ defmodule Deployer.EngineTest do
 
   describe "Ghosted version list" do
     @tag :capture_log
-    test "Remove one ghosted version updates the worker state" do
+    test "The worker takes the new list from the broadcast" do
       name = "myelixir"
       ghosted = %Foundation.Catalog.Version{version: "2.0.0", name: name}
 
       Deployer.StatusMock
       |> expect(:list_installed_apps, fn _name -> [] end)
-      |> expect(:remove_ghosted_version, 1, fn ^name, "2.0.0" -> {:ok, []} end)
 
       assert {:ok, pid} =
                Engine.Worker.start_link(%Engine.Worker{
@@ -1069,25 +1074,26 @@ defmodule Deployer.EngineTest do
                  ghosted_version_list: [ghosted]
                })
 
-      assert {:ok, []} = Engine.remove_ghosted_version(name, "2.0.0")
+      Phoenix.PubSub.broadcast(
+        Deployer.PubSub,
+        "deployex::ghosted_versions::#{name}",
+        {:ghosted_versions_updated, Node.self(), name, []}
+      )
 
-      # the worker consults its own copy on every deployment check, so it has to be the one
-      # that changed, not only the stored list
-      assert %{ghosted_version_list: []} = :sys.get_state(pid)
+      # the worker consults its own copy on every deployment check, so that is what has to
+      # end up changed
+      # :sys.get_state queues behind the broadcast the worker was just sent, so by the time
+      # it replies the message has been handled
+      assert :sys.get_state(pid).ghosted_version_list == []
     end
 
     @tag :capture_log
-    test "Clear all ghosted versions updates the worker state" do
+    test "The worker ignores a change made on another node" do
       name = "myelixir"
-
-      ghosted = [
-        %Foundation.Catalog.Version{version: "2.0.0", name: name},
-        %Foundation.Catalog.Version{version: "3.0.0", name: name}
-      ]
+      ghosted = %Foundation.Catalog.Version{version: "2.0.0", name: name}
 
       Deployer.StatusMock
       |> expect(:list_installed_apps, fn _name -> [] end)
-      |> expect(:clear_ghosted_versions, 1, fn ^name -> {:ok, []} end)
 
       assert {:ok, pid} =
                Engine.Worker.start_link(%Engine.Worker{
@@ -1095,12 +1101,18 @@ defmodule Deployer.EngineTest do
                  deploy_schedule_interval_ms: 60_000,
                  name: name,
                  language: "elixir",
-                 ghosted_version_list: ghosted
+                 ghosted_version_list: [ghosted]
                })
 
-      assert {:ok, []} = Engine.clear_ghosted_versions(name)
+      Phoenix.PubSub.broadcast(
+        Deployer.PubSub,
+        "deployex::ghosted_versions::#{name}",
+        {:ghosted_versions_updated, :other@node, name, []}
+      )
 
-      assert %{ghosted_version_list: []} = :sys.get_state(pid)
+      # the ghosted list is stored by the instance that owns the application, another node
+      # changing its own says nothing about this one
+      assert :sys.get_state(pid).ghosted_version_list == [ghosted]
     end
   end
 

--- a/apps/deployer/test/status/application_test.exs
+++ b/apps/deployer/test/status/application_test.exs
@@ -125,6 +125,55 @@ defmodule Deployer.Status.ApplicationTest do
     assert length(StatusApp.ghosted_version_list(name_1)) == 2
   end
 
+  test "remove_ghosted_version/2 and clear_ghosted_versions/1", %{
+    name_1: name_1,
+    sname_1: sname_1
+  } do
+    version_map = StatusApp.current_version_map(sname_1)
+
+    assert {:ok, _} = StatusApp.add_ghosted_version(version_map)
+    assert {:ok, _} = StatusApp.add_ghosted_version(%{version_map | version: "1.1.1"})
+    assert length(StatusApp.ghosted_version_list(name_1)) == 2
+
+    assert {:ok, remaining} = StatusApp.remove_ghosted_version(name_1, "1.1.1")
+    assert length(remaining) == 1
+
+    assert {:ok, []} = StatusApp.clear_ghosted_versions(name_1)
+    assert Enum.empty?(StatusApp.ghosted_version_list(name_1))
+  end
+
+  test "every ghosted version change is announced to the subscribers", %{
+    name_1: name_1,
+    sname_1: sname_1
+  } do
+    assert :ok = StatusApp.subscribe_ghosted_versions(name_1)
+
+    version_map = StatusApp.current_version_map(sname_1)
+    node = Node.self()
+
+    assert {:ok, _} = StatusApp.add_ghosted_version(version_map)
+    assert_receive {:ghosted_versions_updated, ^node, ^name_1, [_ghosted]}
+
+    assert {:ok, _} = StatusApp.remove_ghosted_version(name_1, version_map.version)
+    assert_receive {:ghosted_versions_updated, ^node, ^name_1, []}
+
+    assert {:ok, _} = StatusApp.clear_ghosted_versions(name_1)
+    assert_receive {:ghosted_versions_updated, ^node, ^name_1, []}
+  end
+
+  test "a subscriber only hears about the application it subscribed to", %{
+    name_1: name_1,
+    name_2: name_2,
+    sname_1: sname_1
+  } do
+    assert :ok = StatusApp.subscribe_ghosted_versions(name_2)
+
+    version_map = StatusApp.current_version_map(sname_1)
+    assert {:ok, _} = StatusApp.add_ghosted_version(version_map)
+
+    refute_receive {:ghosted_versions_updated, _node, ^name_1, _list}
+  end
+
   test "history_version_list", %{name_1: name_1, name_2: name_2, name_3: name_3} do
     version_list_1 = StatusApp.history_version_list(name_1, [])
     version_list_2 = StatusApp.history_version_list(name_2, [])

--- a/apps/deployex_web/lib/deployex_web/live/applications/ghosted.ex
+++ b/apps/deployex_web/lib/deployex_web/live/applications/ghosted.ex
@@ -1,0 +1,133 @@
+defmodule DeployexWeb.ApplicationsLive.Ghosted do
+  use DeployexWeb, :live_component
+
+  require Logger
+
+  alias Deployer.Engine
+
+  attr :name, :string, required: true
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        {"#{@title}"}
+        <:subtitle>
+          A ghosted version is skipped by every deployment. Removing it here lets the engine
+          offer it again on the next check.
+        </:subtitle>
+      </.header>
+
+      <%= if @ghosted_list == [] do %>
+        <div class="mt-4 rounded-lg border border-base-300 bg-base-200 px-4 py-6 text-center">
+          <span class="text-sm text-base-content/60 italic">No ghosted versions</span>
+        </div>
+      <% else %>
+        <div class="mt-4 flex items-center justify-between">
+          <span class="text-sm text-base-content/70">
+            {length(@ghosted_list)} ghosted {if length(@ghosted_list) == 1,
+              do: "version",
+              else: "versions"}
+          </span>
+          <button
+            id="ghosted-clear-all"
+            class="btn btn-sm btn-error"
+            phx-click="ghosted-clear-all"
+            phx-target={@myself}
+            data-confirm={"Remove all ghosted versions for #{@name}? They will be offered again on the next deployment check."}
+          >
+            Clear All
+          </button>
+        </div>
+
+        <div class="relative mt-2 overflow-x-auto overflow-y-auto shadow-md sm:rounded-lg max-h-96">
+          <table class="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
+            <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-400 dark:text-gray-200 sticky top-0 z-10">
+              <tr>
+                <th scope="col" class="px-6 py-1">
+                  Version
+                </th>
+                <th scope="col" class="px-6 py-1">
+                  Sname
+                </th>
+                <th scope="col" class="px-6 py-1">
+                  Deploy Type
+                </th>
+                <th scope="col" class="px-6 py-1">
+                  Date
+                </th>
+                <th scope="col" class="px-6 py-1">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= for version <- @ghosted_list do %>
+                <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+                  <th
+                    scope="row"
+                    class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+                  >
+                    {version.version}
+                  </th>
+                  <td class="px-6 py-2">
+                    {version.sname}
+                  </td>
+                  <td class="px-3 py-2">
+                    {version.deployment}
+                  </td>
+                  <td class="px-6 py-2">
+                    {format_date(version.inserted_at)}
+                  </td>
+                  <td class="px-6 py-2">
+                    <button
+                      id={"ghosted-remove-#{version_id(version.version)}"}
+                      class="btn btn-xs btn-outline btn-error"
+                      phx-click="ghosted-remove"
+                      phx-value-version={version.version}
+                      phx-target={@myself}
+                      data-confirm={"Remove version #{version.version} from the ghosted list?"}
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{name: name} = assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:ghosted_list, Engine.ghosted_version_list(name))
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("ghosted-remove", %{"version" => version}, %{assigns: %{name: name}} = socket) do
+    {:ok, ghosted_list} = Engine.remove_ghosted_version(name, version)
+
+    {:noreply, assign(socket, :ghosted_list, ghosted_list)}
+  end
+
+  def handle_event("ghosted-clear-all", _params, %{assigns: %{name: name}} = socket) do
+    {:ok, ghosted_list} = Engine.clear_ghosted_versions(name)
+
+    {:noreply, assign(socket, :ghosted_list, ghosted_list)}
+  end
+
+  # The version becomes part of a DOM id, and a dot there would be read as a class selector
+  defp version_id(version), do: String.replace(version, ".", "-")
+
+  defp format_date(nil), do: "-/-"
+  defp format_date(inserted_at), do: NaiveDateTime.to_string(inserted_at)
+end

--- a/apps/deployex_web/lib/deployex_web/live/applications/ghosted.ex
+++ b/apps/deployex_web/lib/deployex_web/live/applications/ghosted.ex
@@ -3,7 +3,7 @@ defmodule DeployexWeb.ApplicationsLive.Ghosted do
 
   require Logger
 
-  alias Deployer.Engine
+  alias Deployer.Status
 
   attr :name, :string, required: true
 
@@ -107,20 +107,20 @@ defmodule DeployexWeb.ApplicationsLive.Ghosted do
     socket =
       socket
       |> assign(assigns)
-      |> assign(:ghosted_list, Engine.ghosted_version_list(name))
+      |> assign(:ghosted_list, Status.ghosted_version_list(name))
 
     {:ok, socket}
   end
 
   @impl true
   def handle_event("ghosted-remove", %{"version" => version}, %{assigns: %{name: name}} = socket) do
-    {:ok, ghosted_list} = Engine.remove_ghosted_version(name, version)
+    {:ok, ghosted_list} = Status.remove_ghosted_version(name, version)
 
     {:noreply, assign(socket, :ghosted_list, ghosted_list)}
   end
 
   def handle_event("ghosted-clear-all", _params, %{assigns: %{name: name}} = socket) do
-    {:ok, ghosted_list} = Engine.clear_ghosted_versions(name)
+    {:ok, ghosted_list} = Status.clear_ghosted_versions(name)
 
     {:noreply, assign(socket, :ghosted_list, ghosted_list)}
   end

--- a/apps/deployex_web/lib/deployex_web/live/applications/ghosted.ex
+++ b/apps/deployex_web/lib/deployex_web/live/applications/ghosted.ex
@@ -1,8 +1,6 @@
 defmodule DeployexWeb.ApplicationsLive.Ghosted do
   use DeployexWeb, :live_component
 
-  require Logger
-
   alias Deployer.Status
 
   attr :name, :string, required: true
@@ -33,9 +31,7 @@ defmodule DeployexWeb.ApplicationsLive.Ghosted do
           <button
             id="ghosted-clear-all"
             class="btn btn-sm btn-error"
-            phx-click="ghosted-clear-all"
-            phx-target={@myself}
-            data-confirm={"Remove all ghosted versions for #{@name}? They will be offered again on the next deployment check."}
+            phx-click="ghosted-clear-request"
           >
             Clear All
           </button>
@@ -84,10 +80,8 @@ defmodule DeployexWeb.ApplicationsLive.Ghosted do
                     <button
                       id={"ghosted-remove-#{version_id(version.version)}"}
                       class="btn btn-xs btn-outline btn-error"
-                      phx-click="ghosted-remove"
+                      phx-click="ghosted-remove-request"
                       phx-value-version={version.version}
-                      phx-target={@myself}
-                      data-confirm={"Remove version #{version.version} from the ghosted list?"}
                     >
                       Remove
                     </button>
@@ -110,19 +104,6 @@ defmodule DeployexWeb.ApplicationsLive.Ghosted do
       |> assign(:ghosted_list, Status.ghosted_version_list(name))
 
     {:ok, socket}
-  end
-
-  @impl true
-  def handle_event("ghosted-remove", %{"version" => version}, %{assigns: %{name: name}} = socket) do
-    {:ok, ghosted_list} = Status.remove_ghosted_version(name, version)
-
-    {:noreply, assign(socket, :ghosted_list, ghosted_list)}
-  end
-
-  def handle_event("ghosted-clear-all", _params, %{assigns: %{name: name}} = socket) do
-    {:ok, ghosted_list} = Status.clear_ghosted_versions(name)
-
-    {:noreply, assign(socket, :ghosted_list, ghosted_list)}
   end
 
   # The version becomes part of a DOM id, and a dot there would be read as a class selector

--- a/apps/deployex_web/lib/deployex_web/live/applications/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/applications/index.ex
@@ -5,6 +5,7 @@ defmodule DeployexWeb.ApplicationsLive do
   alias Deployer.Engine
   alias Deployer.Monitor
   alias Deployer.Status
+  alias DeployexWeb.ApplicationsLive.Ghosted
   alias DeployexWeb.ApplicationsLive.Logs
   alias DeployexWeb.ApplicationsLive.Terminal
   alias DeployexWeb.ApplicationsLive.Versions
@@ -78,6 +79,21 @@ defmodule DeployexWeb.ApplicationsLive do
         sname={@selected_sname}
         title={@page_title}
         action={@live_action}
+        patch={~p"/applications"}
+      />
+    </.modal>
+
+    <.modal
+      :if={@live_action in [:ghosted]}
+      id="app-ghosted-modal"
+      show
+      on_cancel={JS.patch(~p"/applications")}
+    >
+      <.live_component
+        module={Ghosted}
+        id={"ghosted-#{@selected_name}"}
+        name={@selected_name}
+        title={@page_title}
         patch={~p"/applications"}
       />
     </.modal>
@@ -427,6 +443,13 @@ defmodule DeployexWeb.ApplicationsLive do
     |> assign(:selected_sname, nil)
   end
 
+  defp apply_action(socket, :ghosted, %{"name" => name}) do
+    socket
+    |> assign(:page_title, "#{name} ghosted versions")
+    |> assign(:selected_name, name)
+    |> assign(:selected_sname, nil)
+  end
+
   defp apply_action(socket, :restart, %{"name" => name, "sname" => sname}) do
     socket
     |> assign(:page_title, "Restart application")
@@ -573,6 +596,10 @@ defmodule DeployexWeb.ApplicationsLive do
 
   def handle_event("app-versions-click", %{"name" => name}, socket) do
     {:noreply, push_patch(socket, to: ~p"/applications/#{name}/versions")}
+  end
+
+  def handle_event("app-ghosted-click", %{"name" => name}, socket) do
+    {:noreply, push_patch(socket, to: ~p"/applications/#{name}/ghosted")}
   end
 
   def handle_event("restart", %{"id" => "deployex"}, socket) do

--- a/apps/deployex_web/lib/deployex_web/live/applications/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/applications/index.ex
@@ -274,6 +274,58 @@ defmodule DeployexWeb.ApplicationsLive do
       </Confirm.content>
     <% end %>
 
+    <%= if @ghosted_confirmation do %>
+      <Confirm.content id="app-ghosted-confirm-modal">
+        <:header :if={@ghosted_confirmation.version}>Remove Ghosted Version</:header>
+        <:header :if={is_nil(@ghosted_confirmation.version)}>Clear Ghosted Versions</:header>
+
+        <div class="space-y-6">
+          <div class="bg-base-200 border border-base-300 rounded-lg p-4">
+            <p class="text-sm text-base-content/60">Application</p>
+            <p class="font-semibold text-base-content">{@ghosted_confirmation.name}</p>
+          </div>
+
+          <p :if={@ghosted_confirmation.version} class="text-base-content/90 leading-relaxed">
+            Remove version
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-mono font-semibold bg-warning/20 text-warning-content">
+              {@ghosted_confirmation.version}
+            </span>
+            from the ghosted list?
+          </p>
+
+          <p :if={is_nil(@ghosted_confirmation.version)} class="text-base-content/90 leading-relaxed">
+            Remove all <span class="font-semibold">{@ghosted_confirmation.count}</span>
+            ghosted versions?
+          </p>
+
+          <div class="text-base-content/60 leading-relaxed">
+            A ghosted version is skipped by every deployment. The engine offers it again on its
+            next check, which deploys it if it is still the version to deploy.
+          </div>
+        </div>
+
+        <:footer>
+          <Confirm.cancel_button id="ghosted">Cancel</Confirm.cancel_button>
+          <Confirm.danger_button
+            :if={is_nil(@ghosted_confirmation.version)}
+            event="ghosted-confirm"
+            id="ghosted"
+            value={@ghosted_confirmation.name}
+          >
+            Yes, Clear All
+          </Confirm.danger_button>
+          <Confirm.confirm_button
+            :if={@ghosted_confirmation.version}
+            event="ghosted-confirm"
+            id="ghosted"
+            value={@ghosted_confirmation.version}
+          >
+            Remove Version
+          </Confirm.confirm_button>
+        </:footer>
+      </Confirm.content>
+    <% end %>
+
     <%= if @mode_confirmation do %>
       <Confirm.content id="app-set-mode-modal-deployex">
         <:header>Change Application Mode</:header>
@@ -367,6 +419,7 @@ defmodule DeployexWeb.ApplicationsLive do
       |> assign(:terminal_message, nil)
       |> assign(:terminal_process, nil)
       |> assign(:mode_confirmation, nil)
+      |> assign(:ghosted_confirmation, nil)
       |> assign(:yaml_config, yaml_config)
       |> assign(:pk_cert_details, default_pk_cert_details())
       |> assign(:current_path, "/applications")
@@ -389,6 +442,7 @@ defmodule DeployexWeb.ApplicationsLive do
      |> assign(:terminal_message, nil)
      |> assign(:terminal_process, nil)
      |> assign(:mode_confirmation, nil)
+     |> assign(:ghosted_confirmation, nil)
      |> assign(:yaml_config, default_yaml_config())
      |> assign(:pk_cert_details, default_pk_cert_details())
      |> assign(:current_path, "/applications")}
@@ -461,6 +515,12 @@ defmodule DeployexWeb.ApplicationsLive do
     socket
     |> assign(:page_title, "Restart all #{name} applications")
     |> assign(:selected_name, name)
+  end
+
+  # The list the component is showing came from a read of its own. Nothing in the assigns it
+  # is given changed, so it has to be told to read again, otherwise it keeps the stale list
+  defp refresh_ghosted_list(name) do
+    send_update(Ghosted, id: "ghosted-#{name}", name: name)
   end
 
   @impl true
@@ -602,6 +662,50 @@ defmodule DeployexWeb.ApplicationsLive do
     {:noreply, push_patch(socket, to: ~p"/applications/#{name}/ghosted")}
   end
 
+  def handle_event(
+        "ghosted-remove-request",
+        %{"version" => version},
+        %{assigns: %{selected_name: name}} = socket
+      ) do
+    {:noreply, assign(socket, :ghosted_confirmation, %{name: name, version: version, count: 1})}
+  end
+
+  def handle_event("ghosted-clear-request", _params, %{assigns: %{selected_name: name}} = socket) do
+    count = name |> Status.ghosted_version_list() |> length()
+
+    {:noreply, assign(socket, :ghosted_confirmation, %{name: name, version: nil, count: count})}
+  end
+
+  def handle_event(
+        "ghosted-confirm",
+        _params,
+        %{assigns: %{ghosted_confirmation: %{name: name, version: nil}}} = socket
+      ) do
+    {:ok, _list} = Status.clear_ghosted_versions(name)
+
+    refresh_ghosted_list(name)
+
+    {:noreply,
+     socket
+     |> assign(:ghosted_confirmation, nil)
+     |> put_flash(:info, "All ghosted versions removed for #{name}")}
+  end
+
+  def handle_event(
+        "ghosted-confirm",
+        _params,
+        %{assigns: %{ghosted_confirmation: %{name: name, version: version}}} = socket
+      ) do
+    {:ok, _list} = Status.remove_ghosted_version(name, version)
+
+    refresh_ghosted_list(name)
+
+    {:noreply,
+     socket
+     |> assign(:ghosted_confirmation, nil)
+     |> put_flash(:info, "Version #{version} removed from the ghosted list")}
+  end
+
   def handle_event("restart", %{"id" => "deployex"}, socket) do
     # NOTE: Say goodbye to your monitored applications
     Deployex.force_terminate(@deployex_terminate_delay)
@@ -666,6 +770,18 @@ defmodule DeployexWeb.ApplicationsLive do
      |> assign(:yaml_config, default_yaml_config())
      |> put_flash(:info, "New config changes applied with success!")
      |> push_patch(to: ~p"/applications")}
+  end
+
+  # Cancelling this confirmation goes back to the list it was opened from, not out of it
+  def handle_event(
+        "confirm-close-modal",
+        _,
+        %{assigns: %{ghosted_confirmation: %{name: name}}} = socket
+      ) do
+    {:noreply,
+     socket
+     |> assign(:ghosted_confirmation, nil)
+     |> push_patch(to: ~p"/applications/#{name}/ghosted")}
   end
 
   def handle_event(

--- a/apps/deployex_web/lib/deployex_web/live/components/application_dashboard.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_dashboard.ex
@@ -220,6 +220,14 @@ defmodule DeployexWeb.Components.ApplicationDashboard do
                     </path>
                   </svg>
                   <span class="text-sm font-medium text-base-content">Last Ghosted</span>
+                  <button
+                    id={"app-ghosted-#{@monitored_app.name}"}
+                    class="ml-auto btn btn-xs btn-ghost text-warning"
+                    phx-click="app-ghosted-click"
+                    phx-value-name={@monitored_app.name}
+                  >
+                    View all
+                  </button>
                 </div>
                 <div class="bg-warning/30 border border-warning/20 rounded-lg px-3 py-2">
                   <span class="text-sm font-mono text-warning-content">

--- a/apps/deployex_web/lib/deployex_web/router.ex
+++ b/apps/deployex_web/lib/deployex_web/router.ex
@@ -62,6 +62,7 @@ defmodule DeployexWeb.Router do
       live "/embedded-observer", ObserverLive, :index
       live "/applications", ApplicationsLive, :index
       live "/applications/:name/versions", ApplicationsLive, :versions
+      live "/applications/:name/ghosted", ApplicationsLive, :ghosted
       live "/applications/:name/restart", ApplicationsLive, :full_restart
       live "/applications/:name/:sname/logs/stdout", ApplicationsLive, :logs_stdout
       live "/applications/:name/:sname/logs/stderr", ApplicationsLive, :logs_stderr

--- a/apps/deployex_web/test/deployex_web/live/applications/ghosted_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/applications/ghosted_test.exs
@@ -75,13 +75,19 @@ defmodule DeployexWeb.Applications.GhostedTest do
     Deployer.StatusMock
     |> expect(:monitoring, monitoring_with_ghosted(name, "2.0.0"))
     |> expect(:subscribe, fn -> :ok end)
+    # the stored list, read back by the component after every change
     |> stub(:ghosted_version_list, fn ^name ->
-      [ghosted("2.0.0", "myelixir-abc123"), ghosted("1.5.0", "myelixir-def456")]
+      Process.get("ghosted", [
+        ghosted("2.0.0", "myelixir-abc123"),
+        ghosted("1.5.0", "myelixir-def456")
+      ])
     end)
     # no engine worker is running for this application, so the stored list is updated
     |> expect(:remove_ghosted_version, 1, fn ^name, "2.0.0" ->
+      remaining = [ghosted("1.5.0", "myelixir-def456")]
+      Process.put("ghosted", remaining)
       send(test_pid, {:removed, "2.0.0"})
-      {:ok, [ghosted("1.5.0", "myelixir-def456")]}
+      {:ok, remaining}
     end)
 
     {:ok, index_live, _html} = live(conn, ~p"/applications")
@@ -90,13 +96,41 @@ defmodule DeployexWeb.Applications.GhostedTest do
 
     html = index_live |> element("#ghosted-remove-2-0-0") |> render_click()
 
+    # nothing happens until the confirmation is accepted
+    assert html =~ "Remove Ghosted Version"
+    assert html =~ "Remove Version"
+    refute_receive {:removed, "2.0.0"}
+
+    index_live |> element("#confirm-button-ghosted") |> render_click()
+
     assert_receive {:removed, "2.0.0"}
 
     # only the removed row goes, the card keeps showing the last ghosted version it was
     # given by the monitoring update
     refute has_element?(index_live, "#ghosted-remove-2-0-0")
     assert has_element?(index_live, "#ghosted-remove-1-5-0")
-    assert html =~ "1 ghosted version"
+  end
+
+  @tag :capture_log
+  test "cancelling the confirmation leaves the list alone", %{conn: conn} do
+    name = "myelixir"
+
+    Deployer.StatusMock
+    |> expect(:monitoring, monitoring_with_ghosted(name, "2.0.0"))
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:ghosted_version_list, fn ^name -> [ghosted("2.0.0", "myelixir-abc123")] end)
+    |> expect(:remove_ghosted_version, 0, fn _name, _version -> {:ok, []} end)
+
+    {:ok, index_live, _html} = live(conn, ~p"/applications")
+
+    index_live |> element("#app-ghosted-#{name}") |> render_click()
+    index_live |> element("#ghosted-remove-2-0-0") |> render_click()
+
+    html = index_live |> element("#cancel-button-ghosted") |> render_click()
+
+    # cancelling goes back to the list it was opened from, not out of it
+    refute html =~ "Remove Ghosted Version"
+    assert has_element?(index_live, "#ghosted-remove-2-0-0")
   end
 
   @tag :capture_log
@@ -108,9 +142,13 @@ defmodule DeployexWeb.Applications.GhostedTest do
     |> expect(:monitoring, monitoring_with_ghosted(name, "2.0.0"))
     |> expect(:subscribe, fn -> :ok end)
     |> stub(:ghosted_version_list, fn ^name ->
-      [ghosted("2.0.0", "myelixir-abc123"), ghosted("1.5.0", "myelixir-def456")]
+      Process.get("ghosted", [
+        ghosted("2.0.0", "myelixir-abc123"),
+        ghosted("1.5.0", "myelixir-def456")
+      ])
     end)
     |> expect(:clear_ghosted_versions, 1, fn ^name ->
+      Process.put("ghosted", [])
       send(test_pid, :cleared)
       {:ok, []}
     end)
@@ -121,10 +159,18 @@ defmodule DeployexWeb.Applications.GhostedTest do
 
     html = index_live |> element("#ghosted-clear-all") |> render_click()
 
+    assert html =~ "Clear Ghosted Versions"
+    assert html =~ "Yes, Clear All"
+    refute_receive :cleared
+
+    index_live |> element("#danger-button-ghosted") |> render_click()
+
     assert_receive :cleared
 
-    assert html =~ "No ghosted versions"
-    refute html =~ "Clear All"
+    # send_update is handled after the click returns, so the list is read again on the
+    # render that follows
+    assert render(index_live) =~ "No ghosted versions"
+    refute has_element?(index_live, "#ghosted-clear-all")
   end
 
   @tag :capture_log

--- a/apps/deployex_web/test/deployex_web/live/applications/ghosted_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/applications/ghosted_test.exs
@@ -1,0 +1,145 @@
+defmodule DeployexWeb.Applications.GhostedTest do
+  use DeployexWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mox
+
+  alias DeployexWeb.Fixture.Status, as: FixtureStatus
+  alias Foundation.Catalog
+
+  setup [
+    :set_mox_global,
+    :verify_on_exit!,
+    :log_in_default_user
+  ]
+
+  defp ghosted(version, sname) do
+    %Catalog.Version{
+      version: version,
+      sname: sname,
+      name: "myelixir",
+      deployment: :hot_upgrade,
+      inserted_at: ~N[2026-08-11 10:00:00]
+    }
+  end
+
+  defp monitoring_with_ghosted(name, last_ghosted_version) do
+    fn ->
+      config = %{
+        last_ghosted_version: last_ghosted_version,
+        mode: :automatic,
+        manual_version: nil,
+        versions: []
+      }
+
+      {:ok,
+       [
+         FixtureStatus.deployex(),
+         FixtureStatus.application(%{name: name}, config)
+       ]}
+    end
+  end
+
+  @tag :capture_log
+  test "GET /applications lists every ghosted version", %{conn: conn} do
+    name = "myelixir"
+
+    Deployer.StatusMock
+    |> expect(:monitoring, monitoring_with_ghosted(name, "2.0.0"))
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:ghosted_version_list, fn ^name ->
+      [ghosted("2.0.0", "myelixir-abc123"), ghosted("1.5.0", "myelixir-def456")]
+    end)
+
+    {:ok, index_live, html} = live(conn, ~p"/applications")
+
+    # the card only shows the last one
+    assert html =~ "2.0.0"
+    refute html =~ "1.5.0"
+
+    html = index_live |> element("#app-ghosted-#{name}") |> render_click()
+
+    assert html =~ "#{name} ghosted versions"
+    assert html =~ "2 ghosted versions"
+    assert html =~ "2.0.0"
+    assert html =~ "1.5.0"
+    assert html =~ "myelixir-def456"
+    assert html =~ "Clear All"
+  end
+
+  @tag :capture_log
+  test "removes a single ghosted version", %{conn: conn} do
+    name = "myelixir"
+    test_pid = self()
+
+    Deployer.StatusMock
+    |> expect(:monitoring, monitoring_with_ghosted(name, "2.0.0"))
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:ghosted_version_list, fn ^name ->
+      [ghosted("2.0.0", "myelixir-abc123"), ghosted("1.5.0", "myelixir-def456")]
+    end)
+    # no engine worker is running for this application, so the stored list is updated
+    |> expect(:remove_ghosted_version, 1, fn ^name, "2.0.0" ->
+      send(test_pid, {:removed, "2.0.0"})
+      {:ok, [ghosted("1.5.0", "myelixir-def456")]}
+    end)
+
+    {:ok, index_live, _html} = live(conn, ~p"/applications")
+
+    index_live |> element("#app-ghosted-#{name}") |> render_click()
+
+    html = index_live |> element("#ghosted-remove-2-0-0") |> render_click()
+
+    assert_receive {:removed, "2.0.0"}
+
+    # only the removed row goes, the card keeps showing the last ghosted version it was
+    # given by the monitoring update
+    refute has_element?(index_live, "#ghosted-remove-2-0-0")
+    assert has_element?(index_live, "#ghosted-remove-1-5-0")
+    assert html =~ "1 ghosted version"
+  end
+
+  @tag :capture_log
+  test "clears every ghosted version", %{conn: conn} do
+    name = "myelixir"
+    test_pid = self()
+
+    Deployer.StatusMock
+    |> expect(:monitoring, monitoring_with_ghosted(name, "2.0.0"))
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:ghosted_version_list, fn ^name ->
+      [ghosted("2.0.0", "myelixir-abc123"), ghosted("1.5.0", "myelixir-def456")]
+    end)
+    |> expect(:clear_ghosted_versions, 1, fn ^name ->
+      send(test_pid, :cleared)
+      {:ok, []}
+    end)
+
+    {:ok, index_live, _html} = live(conn, ~p"/applications")
+
+    index_live |> element("#app-ghosted-#{name}") |> render_click()
+
+    html = index_live |> element("#ghosted-clear-all") |> render_click()
+
+    assert_receive :cleared
+
+    assert html =~ "No ghosted versions"
+    refute html =~ "Clear All"
+  end
+
+  @tag :capture_log
+  test "shows nothing to clear when no version is ghosted", %{conn: conn} do
+    name = "myelixir"
+
+    Deployer.StatusMock
+    |> expect(:monitoring, monitoring_with_ghosted(name, nil))
+    |> expect(:subscribe, fn -> :ok end)
+    |> stub(:ghosted_version_list, fn ^name -> [] end)
+
+    {:ok, index_live, html} = live(conn, ~p"/applications")
+
+    # with no ghosted version the card has nothing to open
+    assert html =~ "No ghosted versions"
+    refute has_element?(index_live, "#app-ghosted-#{name}")
+  end
+end

--- a/apps/foundation/lib/foundation/catalog.ex
+++ b/apps/foundation/lib/foundation/catalog.ex
@@ -302,6 +302,23 @@ defmodule Foundation.Catalog do
   def add_ghosted_version(version), do: default().add_ghosted_version(version)
 
   @doc """
+  Remove one version from the ghosted version history, returning the remaining list
+
+  A version that is not ghosted is not an error, the list simply comes back unchanged.
+  """
+  @impl true
+  @spec remove_ghosted_version(String.t(), String.t()) :: {:ok, list()}
+  def remove_ghosted_version(name, version),
+    do: default().remove_ghosted_version(name, version)
+
+  @doc """
+  Remove every version from the ghosted version history
+  """
+  @impl true
+  @spec clear_ghosted_versions(String.t()) :: {:ok, list()}
+  def clear_ghosted_versions(name), do: default().clear_ghosted_versions(name)
+
+  @doc """
   Add a user session token (This data is not persistent)
   """
   @impl true

--- a/apps/foundation/lib/foundation/catalog/adapter.ex
+++ b/apps/foundation/lib/foundation/catalog/adapter.ex
@@ -26,6 +26,8 @@ defmodule Foundation.Catalog.Adapter do
   @callback add_version(map()) :: :ok
   @callback ghosted_versions(String.t()) :: list()
   @callback add_ghosted_version(map()) :: {:ok, list()}
+  @callback remove_ghosted_version(String.t(), String.t()) :: {:ok, list()}
+  @callback clear_ghosted_versions(String.t()) :: {:ok, list()}
   @callback add_user_session_token(Accounts.UserToken.t()) :: :ok
   @callback get_user_session_token_by_token(String.t()) :: Accounts.UserToken.t() | nil
   @callback config(String.t()) :: Catalog.Config.t()

--- a/apps/foundation/lib/foundation/catalog/local.ex
+++ b/apps/foundation/lib/foundation/catalog/local.ex
@@ -332,6 +332,37 @@ defmodule Foundation.Catalog.Local do
   end
 
   @impl true
+  def remove_ghosted_version(name, version) do
+    path = ghosted_version_path(name)
+
+    # Entries are stored one file per version, named by the timestamp they were ghosted at,
+    # so the file holding a version is found by reading it back
+    path
+    |> File.ls!()
+    |> Enum.each(fn file ->
+      entry_path = "#{path}/#{file}"
+
+      case read_term(entry_path) do
+        %{version: ^version} -> File.rm(entry_path)
+        _ -> :ok
+      end
+    end)
+
+    {:ok, ghosted_versions(name)}
+  end
+
+  @impl true
+  def clear_ghosted_versions(name) do
+    path = ghosted_version_path(name)
+
+    path
+    |> File.ls!()
+    |> Enum.each(&File.rm("#{path}/#{&1}"))
+
+    {:ok, []}
+  end
+
+  @impl true
   def config(name) do
     name
     |> config_path()
@@ -406,10 +437,12 @@ defmodule Foundation.Catalog.Local do
   defp list(path) do
     path
     |> File.ls!()
-    |> Enum.map(fn file ->
-      ("#{path}/" <> file)
-      |> File.read!()
-      |> Plug.Crypto.non_executable_binary_to_term()
-    end)
+    |> Enum.map(&read_term("#{path}/#{&1}"))
+  end
+
+  defp read_term(path) do
+    path
+    |> File.read!()
+    |> Plug.Crypto.non_executable_binary_to_term()
   end
 end

--- a/apps/foundation/test/catalog/catalog_test.exs
+++ b/apps/foundation/test/catalog/catalog_test.exs
@@ -36,6 +36,45 @@ defmodule Foundation.CatalogTest do
     assert [^version] = Catalog.ghosted_versions(name)
   end
 
+  test "remove_ghosted_version/2", %{name: name} do
+    keep = %Catalog.Version{version: "1.0.0", name: name}
+    remove = %Catalog.Version{version: "2.0.0", name: name}
+
+    assert {:ok, _} = Catalog.add_ghosted_version(keep)
+    assert {:ok, _} = Catalog.add_ghosted_version(remove)
+
+    assert {:ok, [^keep]} = Catalog.remove_ghosted_version(name, "2.0.0")
+    assert [^keep] = Catalog.ghosted_versions(name)
+  end
+
+  test "remove_ghosted_version/2 with a version that is not ghosted", %{name: name} do
+    version = %Catalog.Version{version: "1.0.0", name: name}
+    assert {:ok, _} = Catalog.add_ghosted_version(version)
+
+    # removing something that was never ghosted leaves the list as it is
+    assert {:ok, [^version]} = Catalog.remove_ghosted_version(name, "9.9.9")
+  end
+
+  test "remove_ghosted_version/2 allows the version to be ghosted again", %{name: name} do
+    version = %Catalog.Version{version: "1.0.0", name: name}
+
+    assert {:ok, _} = Catalog.add_ghosted_version(version)
+    assert {:ok, []} = Catalog.remove_ghosted_version(name, "1.0.0")
+    assert {:ok, [^version]} = Catalog.add_ghosted_version(version)
+  end
+
+  test "clear_ghosted_versions/1", %{name: name} do
+    assert {:ok, _} = Catalog.add_ghosted_version(%Catalog.Version{version: "1.0.0", name: name})
+    assert {:ok, _} = Catalog.add_ghosted_version(%Catalog.Version{version: "2.0.0", name: name})
+
+    assert {:ok, []} = Catalog.clear_ghosted_versions(name)
+    assert [] == Catalog.ghosted_versions(name)
+  end
+
+  test "clear_ghosted_versions/1 with an empty list", %{name: name} do
+    assert {:ok, []} = Catalog.clear_ghosted_versions(name)
+  end
+
   test "add_user_session_token/1" do
     user_session = %UserToken{token: "123456789"}
     assert :ok = Catalog.add_user_session_token(user_session)

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -146,6 +146,10 @@ reason: :make_relup. myphoenixapp is still running 1.0.0, ghosting version 1.1.0
 A ghosted version is skipped by every following deployment, so the same broken release is not attempted again.
 Publish a new version once the cause is fixed, the application is not stuck waiting for it.
 
+The application card on the Applications page shows the last ghosted version, and `View all` opens the full list.
+From there a single version or all of them can be removed, which makes the engine offer them again on its next check.
+That is the way to retry a version that was ghosted for a reason that no longer applies.
+
 If the release was already installed and a later step failed, the node is running code that was never made permanent.
 There DeployEx does fall back to a full deployment, which restarts the instance on the new version:
 


### PR DESCRIPTION
## Problem

The application card showed the last ghosted version and nothing else. There was no way to see the rest, and no way to undo one, so a version ghosted for a reason that no longer applies stayed skipped until the storage was edited by hand.

That matters more now that a hot upgrade failing before it installed anything ghosts the version (#276): the fix is often a rebuild of the same version.

## Change

`View all` on the card opens the full list, with a `Remove` per version and a `Clear All` for the application.

```
Version   Sname              Deploy Type   Date                  Action
2.0.0     myelixir-abc123    hot_upgrade   2026-08-11 10:00:00   Remove
1.5.0     myelixir-def456    hot_upgrade   2026-08-10 18:22:41   Remove
```

Both actions confirm through the shared `Confirm` component, the same one behind the restart and mode changes, with the pending action held in a `ghosted_confirmation` assign next to the existing `mode_confirmation`. Clearing everything uses the danger button, removing one uses the confirm button.

Cancelling returns to the list it was opened from. The shared `confirm-close-modal` handler patches back to `/applications`, which would have closed the list too, so there is a clause ahead of it for this case.

The engine offers a removed version again on its next check.

## Keeping the engine worker in step

The engine worker keeps its **own copy** of the ghosted list and consults it on every deployment check, `worker.ex` only loads it at start up. Updating storage alone would leave the running worker skipping a version that is no longer ghosted, until something restarted it.

`Deployer.Status` broadcasts the new list on every change, add, remove and clear alike, and the worker subscribes on start up and takes the list from the message. The UI calls `Deployer.Status` directly, like the neighbouring version history component, and neither side knows about the other.

The topic is per application and the message carries the node that made the change, following the existing monitoring broadcast:

```elixir
"deployex::ghosted_versions::#{name}" → {:ghosted_versions_updated, node, name, list}
```

A worker only acts on changes from its own node. The ghosted list is stored by the DeployEx instance that owns the application, so a change made elsewhere in a distributed setup says nothing about this one.

Because `add_ghosted_version` broadcasts too, the worker's own ghosting converges through the same path, and any future writer of the list works without having to know the worker exists.

The worker **subscribes and then reads**, in that order, and the read seeds its state. A change landing in between then arrives as a message instead of falling in the gap, and messages are handled in order so the last one wins. Reading in `init/1` is also what makes a restarted worker current: the supervisor restarts it from the child spec built when it was first started, so the list handed back is whatever was current then. `Deployer.Engine.init_worker` no longer reads it, the worker owns it.

**Tradeoff:** the list becomes eventually consistent. Between a removal and the worker handling the message, a deployment check would skip the version one more time. The following check picks it up.

## Risk assessment

**Impact:** ghosted versions can be listed and removed from the Applications page. Removing one makes the engine offer that version again on its next check, which deploys it if it is still the version to deploy. Nothing changes for an application whose list is left alone.

**Blast radius:** adds `remove_ghosted_version`, `clear_ghosted_versions` and `subscribe_ghosted_versions` through `Foundation.Catalog` and `Deployer.Status`, a broadcast on the three ghosted functions, a subscription and one `handle_info` pair in `Deployer.Engine.Worker`, a new `Ghosted` live component with its route and modal, and a button on the application dashboard card. The deployment flow and the ghosting itself are untouched.

**Regression risk:** low. Everything added is new and reached only from the new button. The two callbacks added to the `Catalog` and `Status` behaviours are implemented by the local catalog and generated for the mocks.

**Rollback:** plain commit revert. Ghosted entries are plain files per application and a reverted build simply stops offering the actions.

## Tests

Catalog: removing one, removing a version that was never ghosted, clearing all, clearing an empty list, and ghosting a version again after it was removed.

Status: every change is announced with the node and name, and a subscriber only hears about the application it subscribed to.

Engine: the worker reads its own list on start up, takes a new one from a broadcast for its own node, and ignores one from another node, all asserted through `:sys.get_state`. Plus a test that broadcasts from inside the subscribe call, standing in for a change landing between the subscribe and the read, asserting it is not lost. That copy is the part that would silently not work.

LiveView: the full list, a single removal, clear all, cancelling, and the empty state. Neither action runs until it is confirmed, and the list no longer shows what was removed.

One detail worth keeping: version strings become part of the DOM id, and a dot there parses as a class selector, so ids use `2-0-0` while the event still carries `2.0.0`.

The list is read by the component itself, so after a change nothing in the assigns it is given differs and LiveView never asks it to render again. It is told to read once more with `send_update`, otherwise it would go on showing the version that was just removed.

Not included: the list does not refresh on its own while open, only after an action taken in it. A `live_component` has no process of its own, so subscribing would mean the parent LiveView forwarding the message. Worth doing separately if it is wanted.

Full suite green, `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)