### PR TITLE
fix(deployer): stop the failed hot upgrade cleanup from deleting the running release libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  * [`PULL-274`](https://github.com/thiagoesteves/deployex/pull/274) Stop reporting a DeployEx hot upgrade as successful before it has run
  * [`PULL-275`](https://github.com/thiagoesteves/deployex/pull/275) Refuse a file that is not a DeployEx release instead of crashing the upload
  * [`PULL-276`](https://github.com/thiagoesteves/deployex/pull/276) Ghost the version instead of forcing a full deployment when a hot upgrade never installed the release
+ * [`PULL-278`](https://github.com/thiagoesteves/deployex/pull/278) Stop the failed hot upgrade cleanup from deleting the running release libraries
 
 ### Enhancements
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -584,8 +584,18 @@ defmodule Deployer.HotUpgrade.Application do
   it starts, and the files sitting in the release directory are the ones from the attempt
   that failed, which may not be the ones the next attempt intends to install.
 
-  Only a release still marked `unpacked` is removed. Once it is `current` or `permanent`
-  the code is in use, and `release_handler` refuses to remove a permanent release anyway.
+  Only a release still marked `unpacked` is unregistered. Once it is `current` or
+  `permanent` the code is in use, and `release_handler` refuses to touch a permanent
+  release anyway.
+
+  `release_handler:set_removed/1` is used rather than `remove_release/1`. The latter also
+  deletes every library the removed release brought that no *other* release in `RELEASES`
+  declares, and an Elixir release ships no `RELEASES` file, so `release_handler` invents an
+  entry for the running release with an empty library list. Every library would then look
+  unused, including the ones the running release needs, and `lib/` would be emptied under a
+  node that keeps working only until it is restarted. `set_removed/1` unregisters the
+  version and leaves the files alone, which is all that is needed for the version to be
+  applied again.
   """
   @spec remove_unpacked_release(Execute.t()) :: :ok
   def remove_unpacked_release(%Execute{node: node, to_version: to_version}) do
@@ -593,9 +603,12 @@ defmodule Deployer.HotUpgrade.Application do
 
     case List.keyfind(which_releases(node), version, 1) do
       {:unpacked, ^version} ->
-        case Rpc.call(node, :release_handler, :remove_release, [version], @rpc_timeout) do
+        case Rpc.call(node, :release_handler, :set_removed, [version], @rpc_timeout) do
           :ok ->
-            Logger.info("Removed the unpacked release #{to_version} left by the failed upgrade")
+            Logger.info(
+              "Unregistered the unpacked release #{to_version} left by the failed upgrade, " <>
+                "the version can be applied again"
+            )
 
           reason ->
             Logger.error(

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1879,7 +1879,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
 
   describe "remove_unpacked_release/1" do
     @tag :capture_log
-    test "removes a release that was unpacked but never installed", %{node: node} do
+    test "unregisters a release that was unpacked but never installed", %{node: node} do
       test_pid = self()
 
       Foundation.RpcMock
@@ -1887,9 +1887,12 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ^node, :release_handler, :which_releases, [], @expected_timeout ->
           [{~c"testapp", ~c"0.2.0", [], :unpacked}, {~c"testapp", ~c"0.1.0", [], :permanent}]
 
-        ^node, :release_handler, :remove_release, [version], @expected_timeout ->
+        ^node, :release_handler, :set_removed, [version], @expected_timeout ->
           send(test_pid, {:removed, version})
           :ok
+
+        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+          flunk(remove_release_warning())
       end)
 
       assert :ok =
@@ -1906,7 +1909,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
           # already in use, removing it would pull the running code away
           [{~c"testapp", ~c"0.2.0", [], :current}]
 
-        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+        ^node, :release_handler, :set_removed, _args, @expected_timeout ->
           flunk("must not remove a release that is in use")
       end)
 
@@ -1921,7 +1924,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ^node, :release_handler, :which_releases, [], @expected_timeout ->
           [{~c"testapp", ~c"0.1.0", [], :permanent}]
 
-        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+        ^node, :release_handler, :set_removed, _args, @expected_timeout ->
           flunk("nothing to remove")
       end)
 
@@ -1936,7 +1939,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
         ^node, :release_handler, :which_releases, [], @expected_timeout ->
           [{~c"testapp", ~c"0.2.0", [], :unpacked}]
 
-        ^node, :release_handler, :remove_release, _args, @expected_timeout ->
+        ^node, :release_handler, :set_removed, _args, @expected_timeout ->
           {:error, :enoent}
       end)
 
@@ -1948,5 +1951,15 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                         })
              end) =~ "Error while removing the unpacked release"
     end
+  end
+
+  defp remove_release_warning do
+    """
+    release_handler:remove_release must never be called here. It deletes every library the
+    removed release brought that no other release in RELEASES declares, and an Elixir
+    release ships no RELEASES file, so release_handler invents an entry for the running
+    release with an empty library list. Every library looks unused and lib/ is emptied
+    under a node that keeps working only until it is restarted.
+    """
   end
 end

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -108,7 +108,7 @@ It keeps running and logs why the upgrade stopped:
 Nothing was installed, deployex is still running 0.9.0.
 ```
 
-The reason `systools` reports is included in that message, and the release unpacked by the attempt is removed, so the same version can be applied again once the cause is fixed.
+The reason `systools` reports is included in that message, and the release unpacked by the attempt is unregistered, so the same version can be applied again once the cause is fixed.
 
 Everything up to installing the release only writes files and builds the relup, so a failure there leaves the node running exactly the code it had, which is what `Nothing was installed` reports.
 Past that point the new code is already loaded, and the message says so instead.


### PR DESCRIPTION
## Problem

After a failed hot upgrade the application keeps running, but it will not start again. Restarting DeployEx puts it in a crash loop:

```
[info]  # Starting application
[info]  # Running sname: myphoenixapp-ul6s07, monitoring pid = #PID<0.1161.0>, OS process = 58755
[error] Unexpected exit message received for sname: myphoenixapp-ul6s07, application being restarted
```

The cleanup added in #273 called `release_handler:remove_release/1`, which does more than unregister a release:

```erlang
RemoveThese =
    lists:foldl(fun(#release{libs = Libs}, Remove) -> diff_dir(Remove, Libs) end,
                RemoveLibs, NewReleases),
lists:foreach(fun({_Lib, _LVsn, LDir}) -> remove_file(LDir) end, RemoveThese),
```

It deletes every library the removed release brought that no **other** release in `RELEASES` declares.

## Why every library looked unused

An Elixir release ships no `releases/RELEASES` file. Without one, `release_handler:init/1` invents an entry for the running release:

```erlang
_ ->
    {Name, Vsn} = init:script_id(),
    [#release{name = Name, vsn = Vsn, status = permanent}]
```

`libs` defaults to `[]` and `erts_vsn` to `undefined`. `unpack_release` then writes that invented entry to disk next to the real one:

```erlang
[{release,"myphoenixapp","0.4.0",undefined,[],permanent}].
```

So removing the unpacked release compared its libraries against an empty list, found all of them unused, and deleted them from the `lib/` directory the running release shares.

The node carried on, its code was already loaded, and nothing looked wrong until the next restart.

## Evidence

The affected application, next to one on the same host that never had a hot upgrade attempted:

```
myphoenixapp/current   libs: 18   RELEASES: yes
myumbrella/current     libs: 42   RELEASES: no
```

Everything but OTP and Elixir was gone, while `releases/myphoenixapp-0.4.0.rel`, the running release, still lists `bandit`, `castore`, `dns_cluster` and the rest. `RELEASES` only exists on the application that had one, which is what created it.

## Change

`release_handler:set_removed/1` unregisters the version and leaves the files alone:

```erlang
do_set_removed(RelDir, Vsn, Releases, Masters) ->
    NewReleases = lists:keydelete(Vsn, #release.vsn, Releases),
    write_releases(RelDir, NewReleases, Masters),
```

That is all #273 needed. Its goal was for a retry not to fail with `{:existing_release, version}`, never to reclaim disk.

## Risk assessment

**Impact:** a failed hot upgrade no longer damages the installation. Files left by a failed attempt stay on disk and the next attempt at the same version overwrites them.

**Blast radius:** `remove_unpacked_release/1` in `Deployer.HotUpgrade.Application`, one remote call. `remove_release` is now called from nowhere in the project.

**Regression risk:** low. `set_removed` and `remove_release` share the same bookkeeping, refusing a permanent release and erroring the same way. They differ only in the file deletion this never wanted.

**Rollback:** plain commit revert, though reverting restores the data loss.

**Affected versions:** `0.9.11` only, which is unreleased. The cleanup was added in the same version by #273, so no release ever shipped this.

**Recovering a damaged installation:** the libraries are gone from disk, so it has to be deployed again. Removing the affected sname directory lets DeployEx deploy it from scratch.

## Tests

The existing cleanup tests move onto `set_removed`, plus a guard that flunks if `remove_release` is ever called again, carrying the reason why. Reverting the lib file gives `50 tests, 2 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
