### PR TITLE
chore: prepare release 0.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG (0.9.X)
 
-## 0.9.11 ()
+## 0.9.11 🚀 (2026-08-12)
 
 ### Backwards incompatible changes from 0.9.10
  * None

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| [**0.9.11**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.11) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.10**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.10) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.9**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.9) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.8**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.8) | **27.3.4.15**                                              | **28.5.0.4**                                               |

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.10"
+version: "0.9.11"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.10"
+version: "0.9.11"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.10"                                        # DeployEx version
+version: "0.9.11"                                        # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.11-rc1"
+  def version, do: "0.9.11"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
## What this does

Prepares `0.9.11` for release, dated **2026-08-12**.

| Step | Change |
|---|---|
| `mix/shared.exs` | `0.9.11-rc1` → `0.9.11` |
| `README.md` | new `0.9.11` row in the compatibility table |
| `devops/installer/deployex-aws.yaml` | `version: "0.9.11"` |
| `devops/installer/deployex-gcp.yaml` | `version: "0.9.11"` |
| `guides/docs/yaml/README.md` | `version: "0.9.11"` in the example |
| `CHANGELOG.md` | `## 0.9.11 🚀 (2026-08-12)` |
| `mix docs` | regenerated, run last |

The OTP columns come from the pinned toolchains, `devops/releases/otp-27/.tool-versions` and `otp-28/.tool-versions`, giving **27.3.4.15** and **28.5.0.4**. Both are unchanged from `0.9.10`, so a hot upgrade from `0.9.10` stays on the same OTP.

## What is in the release

Almost all of it is about hot upgrades failing safely.

- A release built for a different OTP is refused while it is validated, before anything is unpacked (#272)
- A failed attempt no longer leaves the release registered, so the same version can be applied again, and the reason `systools` reports is logged rather than printed to stdout (#273)
- A DeployEx self upgrade is no longer reported as successful before it has run (#274)
- A file that is not a DeployEx release is refused instead of crashing the upload (#275)
- A hot upgrade that fails before installing anything ghosts the version instead of forcing a full deployment, since the node was never touched (#276)
- Ghosted versions can be listed and removed from the Applications page (#277)
- The cleanup added by #273 no longer deletes the running release libraries (#278)

#276 is the one to read before upgrading. A release whose `.appup` or `jellyfish.json` says it supports a hot upgrade, and which then fails before installing, is no longer deployed by restart. The application stays on its current version and the failed version is ghosted. Publishing a fixed version deploys normally, and releases that need a full deployment never enter that path.

## Risk assessment

**Impact:** publishes `0.9.11`. Operators get the changes above, none of which require any action from them.

**Blast radius:** version, changelog, compatibility table, the two installer configurations, the YAML guide example, and the generated documentation. No application code changes.

**Regression risk:** low, there is no behaviour change in this commit. Full suite green, `mix format --check-formatted` and `mix credo --strict` clean.

**Rollback:** plain commit revert. If the tag has already been pushed it has to be deleted too, since the tag is what triggers the release build.

## After merging

Pushing the `0.9.11` tag from `main` triggers `.github/workflows/releases.yaml` to build and publish the artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
