### PR TITLE
docs: add hot upgrade good practices and how to check a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Enhancements
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions
+ * [`PULL-281`](https://github.com/thiagoesteves/deployex/pull/281) Document the good practices for a hot-upgradeable project and how to check a release
 
 ## 0.9.10 🚀 (2026-08-10)
 

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -45,10 +45,19 @@ file /var/lib/deployex/service/myphoenixapp/myphoenixapp-4pvclf/current/lib/elix
 Pin the toolchain in `.tool-versions` and keep it identical across the two builds.
 Bumping Erlang or Elixir is a full deployment, not a hot upgrade.
 
-**Change your own code, not your dependencies.**
-Every application whose version changes needs an appup, and each one is real code being swapped inside a live node.
-[Jellyfish][jyf] generates them, but generating an appup is not the same as knowing the dependency survives being replaced under load.
-Group dependency bumps into a release you deploy fully, and keep hot upgrades for your own code.
+**Assess every dependency you upgrade, one at a time.**
+Dependencies can be hot-upgraded, [Jellyfish][jyf] generates their appups the same way it does for your own applications.
+An appup only describes how to load the new code though, it says nothing about whether that library survives being replaced under load, so each one is a decision rather than a default.
+
+What to review is in the warning above.
+Do it per dependency, not per release, and keep the number moving in a single hot upgrade small enough that the review stays realistic.
+
+Reading a dependency diff is worth handing to an LLM.
+Ask it to summarise what changed between the two versions and, specifically, whether anything there affects state held by a running process or the shape of a supervision tree.
+Treat the answer as a place to start looking, not as the verdict, and confirm what it reports against the changelog and the diff itself.
+
+Erlang/OTP applications and Elixir itself are the exception and are never in scope.
+They are the runtime the upgrade runs on, not libraries loaded into it, so a release that changes them is a full deployment.
 
 **Never hold an anonymous function across an upgrade.**
 A function value is tied to the version of the module that created it.
@@ -95,7 +104,8 @@ Nothing listed means the release was built without hot-upgrade information and c
 
 **Check the versions it claims to upgrade from.**
 Extract a `jellyfish.json` and read its `from` and `to`.
-The `from` has to be the version currently running, which the Applications page shows, so a release built against an older version is not applicable no matter how well formed it is.
+For a `"project"` entry the `from` has to be the version currently running, which the Applications page shows, so a release built against an older version is not applicable no matter how well formed it is.
+A `"dependency"` entry carries the library's own versions instead, since dependencies are versioned independently from the project.
 
 **Let DeployEx answer for you.**
 For a monitored application the decision is made at deployment time and written to the log:
@@ -129,9 +139,14 @@ A version left as `unpacked` is one a previous attempt started and did not insta
 
 Hot-upgrades can be applied to:
 - **Monitored Applications** - Your deployed Elixir/Erlang/Gleam applications
+- **Dependencies** - The libraries those applications use, once you have checked the ones you are moving can be replaced in a running node
 - **DeployEx Itself** - The DeployEx system can hot-upgrade without restart
 
+Erlang/OTP applications and Elixir are not in scope.
+They are the runtime rather than libraries loaded into it, and a release that changes either is a full deployment.
+
 DeployEx uses [Jellyfish][jyf] to automatically generate appup files, which can be customized if needed.
+Dependencies are versioned independently from the project, so DeployEx reports them separately, with `type: "dependency"` rather than `type: "project"`.
 
 ## Hot-Upgrading DeployEx
 

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -28,6 +28,103 @@ The last point is the reason for the `config_provider` entry in the list above, 
 
 Keep in mind that most of your releases will not require full deployment. You don't update OTP or libraries frequently, but you can combine hot-upgrades with migrations to avoid downtime, and much more. This topic is very vast, and we encourage you to apply and learn. High availability is a feature that doesn't come for free and require learning process.
 
+## Good practices for a project that can be hot-upgraded
+
+None of this is required to deploy.
+It is what makes the difference between a release that can be hot-upgraded and one that has to restart.
+
+**Build both versions with the same Erlang and Elixir.**
+A hot upgrade replaces application code inside the running VM, it cannot replace the runtime underneath it.
+If the two releases were built with different Elixir versions, `systools` asks for an appup that upgrades Elixir itself, which nobody ships:
+
+```bash
+[error] systools:make_relup failed for myphoenixapp 0.4.0 -> 0.4.2, reason: Could not open
+file /var/lib/deployex/service/myphoenixapp/myphoenixapp-4pvclf/current/lib/elixir-1.20.3/ebin/elixir.appup
+```
+
+Pin the toolchain in `.tool-versions` and keep it identical across the two builds.
+Bumping Erlang or Elixir is a full deployment, not a hot upgrade.
+
+**Change your own code, not your dependencies.**
+Every application whose version changes needs an appup, and each one is real code being swapped inside a live node.
+[Jellyfish][jyf] generates them, but generating an appup is not the same as knowing the dependency survives being replaced under load.
+Group dependency bumps into a release you deploy fully, and keep hot upgrades for your own code.
+
+**Never hold an anonymous function across an upgrade.**
+A function value is tied to the version of the module that created it.
+Once that module is replaced the value is dead, and calling it raises:
+
+```bash
+** (BadFunctionError) function #Function<0.17932506/0 in MyApp.Worker> is invalid,
+likely because it points to an old version of the code
+```
+
+Store `{module, function, args}` and call it with `apply/3` instead, which resolves against whatever is loaded at the time.
+This applies to anything that outlives the upgrade: GenServer state, ETS tables, `:persistent_term`, timers, and messages already sitting in a mailbox.
+
+**Keep functions out of your configuration.**
+Application environment is written to `sys.config` and read back with `file:consult/1`, so every value has to be a term that can be written down and parsed again.
+An anonymous function cannot, and a configuration file that fails to parse is silently replaced with an empty one, which resets the environment of every application in the release.
+Use `&Module.fun/1` captures of exported functions, or plain data your code interprets.
+
+**Give stateful processes a `code_change/3`.**
+An appup can suspend a process, load the new module and resume it, but only your code knows how to reshape the state it was holding.
+If a `GenServer` state changes shape between versions, write the migration.
+If it does not, there is nothing to do.
+
+**Give every build its own version.**
+Upgrades are computed from one version to another, so two builds sharing a version cannot be told apart, and the appup has nothing to describe.
+
+**Exercise the upgrade in CI.**
+Build the current version, build the target, then apply one to the other against a real node before it reaches production.
+This project does it in [`hot_upgrade.yaml`](/.github/workflows/hot_upgrade.yaml), and the [Calori project](https://github.com/thiagoesteves/calori/blob/main/.github/workflows/hot-upgrade.yaml) shows the same idea for a monitored application.
+
+## Checking whether a hot upgrade is possible
+
+**Compare the toolchains first.**
+If the `.tool-versions` used for the two builds differ in Erlang or Elixir, stop here, it is a full deployment.
+
+**Look for the upgrade metadata in the package.**
+An Elixir release carries a `jellyfish.json` per application, an Erlang one carries `.appup` files:
+
+```bash
+tar -tzf myphoenixapp-1.1.0.tar.gz | grep -E "jellyfish.json|[.]appup$"
+```
+
+Nothing listed means the release was built without hot-upgrade information and can only be deployed fully.
+
+**Check the versions it claims to upgrade from.**
+Extract a `jellyfish.json` and read its `from` and `to`.
+The `from` has to be the version currently running, which the Applications page shows, so a release built against an older version is not applicable no matter how well formed it is.
+
+**Let DeployEx answer for you.**
+For a monitored application the decision is made at deployment time and written to the log:
+
+```bash
+[warning] HOT UPGRADE version DETECTED - [%Deployer.HotUpgrade.Jellyfish{name: "myphoenixapp",
+type: "project", from: "1.0.0", to: "1.1.0"}]
+```
+
+```bash
+[warning] HOT UPGRADE version NOT DETECTED, full deployment required, reason: :not_found
+```
+
+`:not_found` means no metadata was found in the package, and `:no_match_versions` means it was found but describes a different starting version.
+
+For DeployEx itself, uploading the file on the Hot-Upgrade page validates it before anything is applied, and the release is only offered for `Apply` once it passes.
+That check refuses a package built for another OTP, and the reasons it can report are described in [Choosing the right release file](#choosing-the-right-release-file).
+
+**Ask the node what it has installed.**
+`:release_handler.which_releases()` lists the releases the node knows about and their status, which tells you what a previous attempt left behind:
+
+```elixir
+iex> :release_handler.which_releases()
+...> |> Enum.map(fn {_name, vsn, _apps, status} -> {vsn, status} end)
+[{~c"1.1.0", :permanent}, {~c"1.0.0", :old}]
+```
+
+A version left as `unpacked` is one a previous attempt started and did not install.
+
 ## Hot-Upgrade Capabilities
 
 Hot-upgrades can be applied to:


### PR DESCRIPTION
## Problem

The hot upgrade guide explained what DeployEx does, and listed what not to hot-upgrade, but never covered what a **project** has to do to be upgradeable in the first place, nor how to tell in advance whether a given release can be applied.

Two sections added before `Hot-Upgrade Capabilities`.

## Good practices for a project that can be hot-upgraded

Each item comes from a failure that produced it, and carries the error it prints.

- **Build both versions with the same Erlang and Elixir.** A different Elixir makes `systools` ask for an `elixir.appup` that nobody ships.
- **Assess every dependency you upgrade, one at a time.** Dependencies can be hot-upgraded, an appup only describes how to load the new code and says nothing about whether the library survives being replaced under load. Points at the existing warning for what to review, suggests handing the diff to an LLM to summarise state and supervision changes, and says to confirm that against the changelog. Erlang/OTP applications and Elixir stay out of scope, they are the runtime rather than libraries loaded into it.
- **Never hold an anonymous function across an upgrade.** A function value is tied to the module version that created it, and calling it after that module is replaced raises `BadFunctionError`. Store `{module, function, args}` and use `apply/3`. Applies to GenServer state, ETS, `:persistent_term`, timers, and messages already in a mailbox.
- **Keep functions out of configuration.** The environment is written to `sys.config` and read back with `file:consult/1`, and a file that fails to parse is silently replaced with an empty one, resetting the environment of every application in the release.
- **Give stateful processes a `code_change/3`** when the state changes shape.
- **Give every build its own version**, since upgrades are computed from one version to another.
- **Exercise the upgrade in CI**, as this project does in `hot_upgrade.yaml`.

## Hot-Upgrade Capabilities

`Dependencies` joins monitored applications and DeployEx itself in the capabilities list, with the exclusion stated next to it: Erlang/OTP applications and Elixir are the runtime, not libraries loaded into it, so a release that changes either is a full deployment.

Dependencies are versioned independently from the project, so DeployEx reports them as `type: "dependency"` rather than `type: "project"`, which is also what the version check compares.

## Checking whether a hot upgrade is possible

The order to work through, with commands:

1. Compare the `.tool-versions` of the two builds, a difference in Erlang or Elixir ends it there
2. Look for the metadata in the package, `tar -tzf ... | grep -E "jellyfish.json|[.]appup$"`
3. Read the `from` and `to` the metadata claims, the `from` has to be what is running
4. Let DeployEx report its own decision, `HOT UPGRADE version DETECTED` or `NOT DETECTED`, and what `:not_found` and `:no_match_versions` mean
5. Ask the node what it already has, `:release_handler.which_releases()`, including a version left `unpacked` by an earlier attempt

## Accuracy

Every log line and reason is taken from the code rather than written from memory. `:not_found` and `:no_match_versions` are the two reasons `check_jellyfish_files/3` can return, and the `which_releases()` example destructures the tuple the same way `Deployer.HotUpgrade.Application` does, so the third element is the application list and not modules.

## Risk assessment

**Impact:** documentation only, no behaviour change.

**Blast radius:** `guides/docs/hot-upgrades/README.md` and the generated documentation.

**Regression risk:** none.

**Rollback:** plain commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)