### PR TITLE
docs: add the hot upgrade decision checks to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,64 @@ After the PR is merged, pushing the version tag from main triggers `.github/work
 
 ---
 
+## Deciding Whether the Next Version Supports Hot Upgrade
+
+Every release has to state whether operators can hot-upgrade DeployEx into it or must deploy fully.
+Work through the checks below against the diff from the last released tag, and record the answer in `CHANGELOG.md`.
+
+Run them with the previous tag as the base:
+
+```bash
+PREV=0.9.11   # last released tag
+```
+
+**1. Toolchain.** Any change to Erlang or Elixir means the release cannot be hot-upgraded on that OTP line.
+A different Elixir makes `systools:make_relup/4` ask for an `elixir.appup` that no release ships.
+
+```bash
+git diff $PREV..HEAD -- devops/releases/otp-*/.tool-versions
+```
+
+**2. `runtime.exs`.** Added, removed or modified means a full deployment.
+
+```bash
+git diff --name-only $PREV..HEAD -- config/runtime.exs
+```
+
+**3. Config Providers.** Provider modules run on the node in its **current** version, so a change to them is not applied by the upgrade and only takes effect after a full deployment.
+
+```bash
+git diff --name-only $PREV..HEAD -- apps/foundation/lib/config_provider/
+```
+
+**4. Dependencies.** Every dependency whose version changes needs an appup, which `Jellyfish.generate/1` produces, but a dependency being replaceable at runtime is the dependency's property and not something the appup proves.
+Call out anything stateful.
+
+```bash
+git diff $PREV..HEAD -- mix.lock | grep -E "^[+-] +\{:"
+```
+
+**5. Values that cannot cross a code swap.** A function value is tied to the module version that created it, and `install_release` replaces every umbrella application because they all carry the release version.
+Anything that outlives the upgrade must be data, not a closure: GenServer state, ETS, `:persistent_term`, timers, and messages already queued.
+`Deployer.HotUpgrade.Execute` declares `after_async_make_permanent` as `mfa()` for exactly this reason.
+
+```bash
+git diff $PREV..HEAD -- apps/*/lib | grep -nE "^\+.*(fn |&[A-Z])"
+```
+
+**6. GenServer state shape.** If a `defstruct` backing a `GenServer` state changed, the release needs a `code_change/3`, since an appup can suspend and resume a process but only the project knows how to reshape what it was holding.
+
+**7. Supervision tree and applications.** Children added or removed, or a new application in the umbrella, need checking against the generated appup rather than assumed.
+
+### Recording the answer
+
+- Hot upgrade supported, nothing to add.
+- Not supported, add an entry under `### Backwards incompatible changes` naming the check that failed and telling operators to apply the release as a full deployment.
+
+The reasoning behind each check, and how to verify a built package, is in `guides/docs/hot-upgrades/README.md`.
+
+---
+
 ## Guides and Documentation
 
 - `guides/docs/` - deployment guides per cloud/language (AWS-Elixir, GCP-Elixir, Local-Erlang, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Enhancements
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions
  * [`PULL-281`](https://github.com/thiagoesteves/deployex/pull/281) Document the good practices for a hot-upgradeable project and how to check a release
+ * [`PULL-282`](https://github.com/thiagoesteves/deployex/pull/282) Add the checks for deciding whether the next version supports hot upgrade to AGENTS.md
 
 ## 0.9.10 🚀 (2026-08-10)
 


### PR DESCRIPTION
## What this adds

A `Deciding Whether the Next Version Supports Hot Upgrade` section to `AGENTS.md`, after `Release Preparation`.

Every release has to say whether operators can hot-upgrade DeployEx into it. The guide explains the reasoning, but nothing said how to reach the answer while preparing a release.

Seven checks against the diff from the last released tag, each with the command that answers it:

| # | Check | Why it decides |
|---|---|---|
| 1 | Erlang / Elixir in `devops/releases/otp-*/.tool-versions` | a different Elixir makes `systools` ask for an `elixir.appup` no release ships |
| 2 | `config/runtime.exs` | added, removed or modified means a full deployment |
| 3 | `apps/foundation/lib/config_provider/` | providers run in the **current** version, so a change is not applied by the upgrade |
| 4 | `mix.lock` | every changed dependency needs an appup, and replaceability is the dependency's property |
| 5 | Values that cannot cross a code swap | a function value dies with the module version that made it, and every umbrella app is replaced on every self upgrade |
| 6 | `GenServer` state shape | a changed `defstruct` needs `code_change/3` |
| 7 | Supervision tree and applications | children or apps added or removed have to be checked against the generated appup |

Then where the answer goes: an entry under `### Backwards incompatible changes` naming the check that failed, or nothing when the upgrade is supported.

## Verification

Every command was run against this repository rather than written from memory, including the `apps/*/lib` pathspec form.

Running the whole list for `0.9.10..HEAD` reports **supported**, checks 1 to 4 all come back empty. That matches what actually happened: `0.9.10` to `0.9.11` was applied to stage as a hot upgrade and installed successfully.

Check 5 is the one that came out of #280, where an anonymous function stored in the `Execute` struct was invalidated by `install_release` and killed the server after the upgrade had already been made permanent. `Deployer.HotUpgrade.Execute` declares that field as `mfa()` for that reason, and the section says so.

## Note

`CLAUDE.md` is a symlink to `AGENTS.md`, so this covers both.

The changelog entry sits next to #281's, which is still open on its own branch. If that merges first this may need a one line rebase.

## Risk assessment

**Impact:** guidance only, no behaviour change and no runtime code touched.

**Blast radius:** `AGENTS.md` and the changelog entry.

**Regression risk:** none.

**Rollback:** plain commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
