### PR TITLE
fix(foundation): apply the FinchStream download callbacks through an MFA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions
  * [`PULL-281`](https://github.com/thiagoesteves/deployex/pull/281) Document the good practices for a hot-upgradeable project and how to check a release
  * [`PULL-282`](https://github.com/thiagoesteves/deployex/pull/282) Add the checks for deciding whether the next version supports hot upgrade to AGENTS.md
+ * [`PULL-283`](https://github.com/thiagoesteves/deployex/pull/283) Apply the FinchStream download callbacks through an MFA instead of a captured function
 
 ## 0.9.10 🚀 (2026-08-10)
 

--- a/apps/deployer/lib/deployer/github/artifact.ex
+++ b/apps/deployer/lib/deployer/github/artifact.ex
@@ -96,6 +96,32 @@ defmodule Deployer.Github.Artifact do
     :ok
   end
 
+  @doc """
+  Report a download progress update, called by `Foundation.System.FinchStream`.
+
+  The initial `:ok` is skipped, the artifact still has to be unzipped before the download
+  counts as complete.
+  """
+  @spec notify_download_progress(map(), String.t(), any()) :: :ok
+  def notify_download_progress(_params, _file_path, :ok), do: :ok
+
+  def notify_download_progress(params, _file_path, result) do
+    Phoenix.PubSub.broadcast(
+      Deployer.PubSub,
+      @github_download_progress,
+      {:github_download_artifact, Node.self(), params, result}
+    )
+  end
+
+  @doc """
+  Report whether a download should carry on, called by `Foundation.System.FinchStream`.
+  """
+  @spec download_running?(String.t(), pid()) :: boolean()
+  def download_running?(id, request_pid) do
+    [{_, status}] = :ets.lookup(@github_artifacts_table, id)
+    Process.alive?(request_pid) and status == :run
+  end
+
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
@@ -184,30 +210,13 @@ defmodule Deployer.Github.Artifact do
 
     :ets.insert(@github_artifacts_table, {id, :run})
 
-    handle_progress = fn
-      _file_path, :ok ->
-        # Skip the initial :ok message.
-        # This module still needs to unzip the download before notifying
-        # that the download is fully completed.
-        :ok
-
-      _file_path, result ->
-        Phoenix.PubSub.broadcast(
-          Deployer.PubSub,
-          @github_download_progress,
-          {:github_download_artifact, Node.self(), new_params, result}
-        )
-    end
-
-    handle_continue = fn ->
-      [{_, status}] = :ets.lookup(@github_artifacts_table, id)
-      Process.alive?(params.request_pid) and status == :run
-    end
-
+    # A download runs for as long as the transfer takes, which is long enough for a hot
+    # upgrade to replace this module. The callbacks are named functions reached through the
+    # module rather than captured values, which would not survive being replaced
     with :ok <-
            FinchStream.download(download_url, file_path, headers,
-             handle_progress: handle_progress,
-             handle_continue: handle_continue
+             handle_progress: {__MODULE__, :notify_download_progress, [new_params]},
+             handle_continue: {__MODULE__, :download_running?, [id, params.request_pid]}
            ) do
       {:ok, new_params}
     end

--- a/apps/deployer/test/github/artifact_test.exs
+++ b/apps/deployer/test/github/artifact_test.exs
@@ -71,8 +71,8 @@ defmodule Deployer.Github.ArtifactTest do
              handle_progress = Keyword.get(opts, :handle_progress)
 
              if handle_progress do
-               handle_progress.(file_path, {:downloading, 50.0})
-               handle_progress.(file_path, {:downloading, 100.0})
+               apply_callback(handle_progress, [file_path, {:downloading, 50.0}])
+               apply_callback(handle_progress, [file_path, {:downloading, 100.0}])
              end
 
              :ok
@@ -122,8 +122,8 @@ defmodule Deployer.Github.ArtifactTest do
 
              if handle_progress do
                # This :ok should be skipped by the handle_progress
-               handle_progress.(file_path, :ok)
-               handle_progress.(file_path, {:downloading, 100.0})
+               apply_callback(handle_progress, [file_path, :ok])
+               apply_callback(handle_progress, [file_path, {:downloading, 100.0}])
              end
 
              :ok
@@ -398,7 +398,7 @@ defmodule Deployer.Github.ArtifactTest do
 
              # Simulate initial progress
              if handle_progress do
-               handle_progress.(file_path, {:downloading, 25.0})
+               apply_callback(handle_progress, [file_path, {:downloading, 25.0}])
              end
 
              {:error, "Download was cancelled"}
@@ -441,7 +441,7 @@ defmodule Deployer.Github.ArtifactTest do
              handle_continue = Keyword.get(opts, :handle_continue)
 
              # Verify keep_downloading returns true
-             assert handle_continue.() == true
+             assert apply_callback(handle_continue, []) == true
 
              :ok
            end
@@ -501,5 +501,10 @@ defmodule Deployer.Github.ArtifactTest do
                       {:error, "Download was cancelled"}},
                      1000
     end
+  end
+
+  # mirrors how Foundation.System.FinchStream applies the callbacks
+  defp apply_callback({module, function, args}, extra_args) do
+    apply(module, function, args ++ extra_args)
   end
 end

--- a/apps/foundation/lib/foundation/system/finch_stream.ex
+++ b/apps/foundation/lib/foundation/system/finch_stream.ex
@@ -13,90 +13,56 @@ defmodule Foundation.System.FinchStream do
 
   ## Callbacks
 
-  You can provide optional callbacks to track progress and control the download.
+  Optional callbacks track progress and control the download.
+  Both are `{module, function, args}` and are applied rather than called.
+
+  A download can run for as long as the transfer takes, which is long enough for a hot
+  upgrade to replace the module that started it. A function value captured by the previous
+  version of that module does not survive being replaced and raises `BadFunctionError` when
+  applied, so the callbacks are named functions reached through their module, which resolves
+  to whatever is loaded at the time.
 
   ### handle_progress
 
-  A function that receives progress updates during the download. It will be called with:
+  Applied with the stored args followed by:
   - `file_path` - The path of the file being downloaded
   - `status` - One of:
     - `{:downloading, progress}` - Progress as a float (0.0 to 100.0)
     - `:ok` - Download completed successfully
     - `{:error, reason}` - Download failed
 
-  Example:
-
-      handle_progress = fn file_path, status ->
-        case status do
-          {:downloading, progress} ->
-            IO.puts("Downloading \#{file_path}: \#{progress}%")
-          
-          :ok ->
-            IO.puts("✓ Completed: \#{file_path}")
-          
-          {:error, reason} ->
-            IO.puts("✗ Failed: \#{file_path} - \#{inspect(reason)}")
-        end
-      end
-
-      FinchStream.download(url, file_path, headers, handle_progress: handle_progress)
-
   ### handle_continue
 
-  A function that determines whether the download should continue. Called before 
-  processing each data chunk. Return `true` to continue, `false` to cancel.
-
-  Example:
-
-      handle_continue = fn ->
-        # Cancel if user requested it
-        !Process.get(:cancel_download, false)
-      end
-
-      FinchStream.download(url, file_path, headers, handle_continue: handle_continue)
+  Applied with the stored args, before processing each data chunk.
+  Return `true` to continue, `false` to cancel.
 
   ## Full Example
 
       defmodule MyApp.Downloader do
         def download_with_tracking(url, file_path) do
-          # Track progress in process dictionary
-          Process.put(:download_progress, 0)
-          
-          handle_progress = fn _file_path, status ->
-            case status do
-              {:downloading, progress} ->
-                Process.put(:download_progress, progress)
-                Phoenix.PubSub.broadcast(
-                  MyApp.PubSub,
-                  "downloads",
-                  {:progress, file_path, progress}
-                )
-              
-              :ok ->
-                Logger.info("Download completed: \#{file_path}")
-              
-              {:error, reason} ->
-                Logger.error("Download failed: \#{file_path} - \#{inspect(reason)}")
-            end
-          end
-          
-          handle_continue = fn ->
-            # Stop if cancelled or if progress hasn't changed in too long
-            !Process.get(:cancel_download, false)
-          end
-          
           Foundation.System.FinchStream.download(
             url,
             file_path,
             [],
-            handle_progress: handle_progress,
-            handle_continue: handle_continue
+            handle_progress: {__MODULE__, :report_progress, [self()]},
+            handle_continue: {__MODULE__, :keep_going?, [self()]}
           )
         end
-        
-        def cancel_download do
-          Process.put(:cancel_download, true)
+
+        def report_progress(owner, file_path, {:downloading, progress}) do
+          Phoenix.PubSub.broadcast(MyApp.PubSub, "downloads", {:progress, file_path, progress})
+          send(owner, {:progress, progress})
         end
+
+        def report_progress(_owner, file_path, :ok) do
+          Logger.info("Download completed: \#{file_path}")
+        end
+
+        def report_progress(_owner, file_path, {:error, reason}) do
+          Logger.error("Download failed: \#{file_path} - \#{inspect(reason)}")
+        end
+
+        def keep_going?(owner), do: Process.alive?(owner)
       end
   """
 
@@ -110,8 +76,8 @@ defmodule Foundation.System.FinchStream do
           size: non_neg_integer() | nil,
           processed: non_neg_integer() | nil,
           file_pid: pid() | nil,
-          handle_progress: mfa(),
-          handle_continue: mfa(),
+          handle_progress: mfa() | nil,
+          handle_continue: mfa() | nil,
           error: String.t() | nil
         }
 
@@ -251,26 +217,32 @@ defmodule Foundation.System.FinchStream do
        )
        when size > 0 do
     progress = Float.round(processed * 100 / size, 1)
-    handle_progress.(file_path, {:downloading, progress})
+    apply_callback(handle_progress, [file_path, {:downloading, progress}])
   end
 
   defp do_handle_progress(
          %__MODULE__{handle_progress: handle_progress, file_path: file_path},
          :ok
        ) do
-    handle_progress.(file_path, :ok)
+    apply_callback(handle_progress, [file_path, :ok])
   end
 
   defp do_handle_progress(
          %__MODULE__{handle_progress: handle_progress, file_path: file_path},
          error
        ) do
-    handle_progress.(file_path, error)
+    apply_callback(handle_progress, [file_path, error])
   end
 
   def do_handle_continue(%__MODULE__{handle_continue: nil}), do: true
 
   def do_handle_continue(%__MODULE__{handle_continue: handle_continue}) do
-    handle_continue.()
+    apply_callback(handle_continue, [])
+  end
+
+  # Applied through the module rather than called as a value, so it resolves against the
+  # code loaded now and not the version that started the download
+  defp apply_callback({module, function, args}, extra_args) do
+    apply(module, function, args ++ extra_args)
   end
 end

--- a/apps/foundation/test/support/finch_stream_callback.ex
+++ b/apps/foundation/test/support/finch_stream_callback.ex
@@ -1,0 +1,21 @@
+defmodule FinchStreamCallback do
+  @moduledoc """
+  Stands in for the `Foundation.System.FinchStream` callbacks.
+
+  Named functions on purpose. The callbacks are applied through their module so they
+  resolve against the code loaded at the time, which is what lets a download survive the
+  module that started it being replaced by a hot upgrade.
+  """
+
+  @spec notify(pid(), String.t(), any()) :: :ok
+  def notify(pid, file_path, status) do
+    send(pid, {:notify, file_path, status})
+    :ok
+  end
+
+  @spec continue(pid(), boolean()) :: boolean()
+  def continue(pid, answer) do
+    send(pid, :keep_downloading_check)
+    answer
+  end
+end

--- a/apps/foundation/test/system/finch_stream_test.exs
+++ b/apps/foundation/test/system/finch_stream_test.exs
@@ -200,9 +200,7 @@ defmodule Foundation.System.FinchStreamTest do
     test "handles error set in accumulator during streaming" do
       test_pid = self()
 
-      handle_progress = fn file_path, status ->
-        send(test_pid, {:notify, file_path, status})
-      end
+      handle_progress = {FinchStreamCallback, :notify, [test_pid]}
 
       with_mock Finch,
         build: fn :get, _url, _headers -> :mocked_request end,
@@ -227,9 +225,7 @@ defmodule Foundation.System.FinchStreamTest do
       test_pid = self()
       file_content = "test content for progress"
 
-      handle_progress = fn file_path, status ->
-        send(test_pid, {:notify, file_path, status})
-      end
+      handle_progress = {FinchStreamCallback, :notify, [test_pid]}
 
       with_mock Finch,
         build: fn :get, _url, _headers -> :mocked_request end,
@@ -252,9 +248,7 @@ defmodule Foundation.System.FinchStreamTest do
     test "calls handle_progress on error" do
       test_pid = self()
 
-      handle_progress = fn file_path, status ->
-        send(test_pid, {:notify, file_path, status})
-      end
+      handle_progress = {FinchStreamCallback, :notify, [test_pid]}
 
       with_mock Finch,
         build: fn :get, _url, _headers -> :mocked_request end,
@@ -273,10 +267,7 @@ defmodule Foundation.System.FinchStreamTest do
     test "respects handle_continue returning false" do
       test_pid = self()
 
-      handle_continue = fn ->
-        send(test_pid, :keep_downloading_check)
-        false
-      end
+      handle_continue = {FinchStreamCallback, :continue, [test_pid, false]}
 
       with_mock Finch,
         build: fn :get, _url, _headers -> :mocked_request end,
@@ -298,10 +289,7 @@ defmodule Foundation.System.FinchStreamTest do
     test "continues downloading when handle_continue returns true" do
       test_pid = self()
 
-      handle_continue = fn ->
-        send(test_pid, :keep_downloading_check)
-        true
-      end
+      handle_continue = {FinchStreamCallback, :continue, [test_pid, true]}
 
       file_content = "download continues"
 
@@ -327,9 +315,7 @@ defmodule Foundation.System.FinchStreamTest do
       test_pid = self()
       chunk_size = 25
 
-      handle_progress = fn file_path, status ->
-        send(test_pid, {:notify, file_path, status})
-      end
+      handle_progress = {FinchStreamCallback, :notify, [test_pid]}
 
       with_mock Finch,
         build: fn :get, _url, _headers -> :mocked_request end,

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -59,8 +59,8 @@ Treat the answer as a place to start looking, not as the verdict, and confirm wh
 Erlang/OTP applications and Elixir itself are the exception and are never in scope.
 They are the runtime the upgrade runs on, not libraries loaded into it, so a release that changes them is a full deployment.
 
-**Never hold an anonymous function across an upgrade.**
-A function value is tied to the version of the module that created it.
+**Do not let an anonymous function outlive the call that created it.**
+A function value is tied to the version of the module that built it.
 Once that module is replaced the value is dead, and calling it raises:
 
 ```bash
@@ -68,8 +68,46 @@ Once that module is replaced the value is dead, and calling it raises:
 likely because it points to an old version of the code
 ```
 
-Store `{module, function, args}` and call it with `apply/3` instead, which resolves against whatever is loaded at the time.
-This applies to anything that outlives the upgrade: GenServer state, ETS tables, `:persistent_term`, timers, and messages already sitting in a mailbox.
+This is about lifetime, not about anonymous functions being risky in themselves.
+Almost all of them are fine, and rewriting them would make the code worse for no gain.
+
+Fine, the value is created and used within the same call, so no upgrade can land between the two:
+
+```elixir
+def totals(entries) do
+  entries
+  |> Enum.filter(fn entry -> entry.status == :running end)
+  |> Enum.map(& &1.size)
+end
+
+def report(entries) do
+  render = fn entry -> "#{entry.name} #{entry.size}" end
+  Enum.map_join(entries, "\n", render)
+end
+```
+
+A problem, the value is stored and called later, and later can be after an upgrade:
+
+```elixir
+# in GenServer state
+{:ok, %{on_complete: fn result -> notify(result) end}}
+
+# in a message the process will handle afterwards
+send(self(), {:finished, fn -> cleanup(path) end})
+
+# handed to something that runs for a while
+Downloader.stream(url, on_progress: fn pct -> broadcast(pct) end)
+```
+
+Store `{module, function, args}` in those places and reach it with `apply/3`, which resolves against whatever is loaded at the time.
+
+Ask one question about a function value: **can this still be called after the current call returns?**
+If it can, it needs to be an MFA.
+The places where the answer is yes are GenServer state, ETS tables, `:persistent_term`, timers, messages already sitting in a mailbox, and callbacks handed to something long-running such as a download or a stream.
+
+Captures have the same lifetime rule.
+`&Module.fun/1` of a public function is as safe as an MFA, since it is resolved through the module.
+`&private_fun/1` and `&(&1 + n)` are closures over the current module version and are not.
 
 **Keep functions out of your configuration.**
 Application environment is written to `sys.config` and read back with `file:consult/1`, so every value has to be a term that can be written down and parsed again.

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -38,6 +38,7 @@ defmodule Mix.Shared do
         # Foundation
         Foundation.Rpc,
         Foundation.RpcMock,
+        FinchStreamCallback,
         Foundation.Macros,
         Foundation.Application,
         Foundation.Catalog.Version,


### PR DESCRIPTION
## Problem

`Foundation.System.FinchStream` declared its callbacks as MFAs and then stored and called closures:

```elixir
handle_progress: mfa(),          # the type
handle_continue: mfa(),
```

```elixir
handle_progress.(file_path, error)   # the code
handle_continue.()
```

The same drift that lost a DeployEx version in #280.

`Deployer.Github.Artifact` builds those closures inside a `handle_cast` and hands them to a download that runs for as long as the transfer takes. A hot upgrade landing while an artifact is downloading replaces both `foundation` and `deployer`, and the captured functions do not survive that, raising `BadFunctionError` in the middle of the stream.

It is a narrow window, the usual flow downloads and *then* upgrades. But it is the same failure mode, and the type already asked for the fix.

## Change

Both callbacks are `{module, function, args}`, applied with the stored arguments followed by the ones the stream provides:

```elixir
handle_progress: {__MODULE__, :notify_download_progress, [new_params]},
handle_continue: {__MODULE__, :download_running?, [id, params.request_pid]}
```

`notify_download_progress/3` and `download_running?/2` behave exactly as the closures did, including skipping the initial `:ok` so progress is only reported once the artifact has been unzipped.

## Documentation

The guide item was **"Never hold an anonymous function across an upgrade"**, which reads as a reason to avoid them. It is now **"Do not let an anonymous function outlive the call that created it"**, written around lifetime.

It says explicitly that almost all anonymous functions are fine and rewriting them would make the code worse, shows a fine example and a problem example side by side, and gives the single question to ask:

> can this still be called after the current call returns?

It also covers captures, which the previous version did not: `&Module.fun/1` of a public function is as safe as an MFA because it resolves through the module, while `&private_fun/1` and `&(&1 + n)` are closures over the current module version and are not.

## Audit

This was the last one. Everything else invoked as a value (`deploy_application.()`, `cp_appup_priv_to_ebin.()`, `parse_sname.()` and the rest) is a local helper called inside the same function body. Nothing puts a function in a message, in ETS, in `:persistent_term`, or in a timer.

The one remaining function value with a long life is `allow_upload(:hotupgrade, progress: &handle_progress/3)`, held in the LiveView socket. That is the framework's own pattern and LiveView rebuilds it on reconnect, so it is left alone.

## Risk assessment

**Impact:** none visible. Downloads report progress and honour cancellation exactly as before, and now survive the module that started them being replaced.

**Blast radius:** `Foundation.System.FinchStream`, its callback type and invocation, and the two callbacks in `Deployer.Github.Artifact`, which become public functions with the same behaviour. `FinchStream` has one caller.

**Regression risk:** low. The callbacks change shape, the type already declared that shape, and the only caller is updated with them.

**Rollback:** plain commit revert.

## Tests

The existing `FinchStream` and artifact tests move onto MFAs through a named callback module, so nothing in the tests captures a function either. Full suite green, coverage above the threshold on all five apps, `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
