### PR TITLE
fix(web): show why a release downloaded from GitHub was refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  * [`PULL-281`](https://github.com/thiagoesteves/deployex/pull/281) Document the good practices for a hot-upgradeable project and how to check a release
  * [`PULL-282`](https://github.com/thiagoesteves/deployex/pull/282) Add the checks for deciding whether the next version supports hot upgrade to AGENTS.md
  * [`PULL-283`](https://github.com/thiagoesteves/deployex/pull/283) Apply the FinchStream download callbacks through an MFA instead of a captured function
+ * [`PULL-284`](https://github.com/thiagoesteves/deployex/pull/284) Show why a release downloaded from GitHub was refused in the download panel
 
 ## 0.9.10 🚀 (2026-08-10)
 

--- a/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/hot_upgrade/index.ex
@@ -292,7 +292,7 @@ defmodule DeployexWeb.HotUpgradeLive do
                   </div>
                 </div>
 
-                <div :if={@github.download_error} class="alert alert-error">
+                <div :if={@github.download_error} id="github-download-error" class="alert alert-error">
                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
                       stroke-linecap="round"
@@ -796,6 +796,15 @@ defmodule DeployexWeb.HotUpgradeLive do
 
   defp default_form_options, do: %{"github_url" => "", "github_token" => ""}
 
+  # The download panel renders download_error, so the reason stays where the operator was
+  # looking. A flash alone is missed easily, and github_new/2 would clear the field that
+  # exists to show it
+  defp github_download_failed(socket, msg) do
+    socket
+    |> assign(:github, %{github_new() | download_error: msg})
+    |> put_flash(:error, msg)
+  end
+
   defp github_new(id \\ nil, status \\ nil) do
     %{
       download_id: id,
@@ -975,19 +984,13 @@ defmodule DeployexWeb.HotUpgradeLive do
         msg = "Error while handling file: #{artifact_name}, reason: #{error}"
         Logger.error(msg)
 
-        {:noreply,
-         socket
-         |> assign(:github, github_new())
-         |> put_flash(:error, msg)}
+        {:noreply, github_download_failed(socket, msg)}
 
       error ->
         msg = "Error while handling file: #{artifact_name}"
         Logger.error(msg <> ", reason: #{inspect(error)}")
 
-        {:noreply,
-         socket
-         |> assign(:github, github_new())
-         |> put_flash(:error, msg)}
+        {:noreply, github_download_failed(socket, msg)}
     end
   end
 

--- a/apps/deployex_web/test/deployex_web/live/hot_upgrade/github_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/hot_upgrade/github_test.exs
@@ -308,6 +308,61 @@ defmodule DeployexWeb.HotUpgrade.GithubTest do
     end
 
     @tag :capture_log
+    test "keeps the reason on the page when the release is refused", %{conn: conn} do
+      test_pid = self()
+      download_id = Common.uuid4()
+
+      Deployer.HotUpgradeMock
+      |> expect(:subscribe_events, fn -> :ok end)
+
+      capture_log(fn ->
+        with_mock Deployer.Github, [:passthrough],
+          download_artifact: fn _url, _token ->
+            send(test_pid, :download_started)
+            {:ok, download_id}
+          end do
+          with_mock Deployer.HotUpgrade, [:passthrough],
+            deployex_check: fn _path -> {:error, {:otp_mismatch, %{running_otp: "28"}}} end do
+            {:ok, live, _html} = live(conn, ~p"/hotupgrade")
+
+            live |> element("a", "GitHub URL") |> render_click()
+
+            url = "https://github.com/user/repo/actions/runs/123/artifacts/456"
+
+            live
+            |> form("#github-download-form", %{"github_url" => url, "github_token" => ""})
+            |> render_change()
+
+            live |> element("#github-download-form") |> render_submit()
+
+            assert_receive :download_started, 1_000
+
+            artifact_name = "deployex-0.9.10.tar.gz"
+            artifact_path = Path.join(System.tmp_dir!(), artifact_name)
+            File.write!(artifact_path, "fake content")
+
+            send(
+              live.pid,
+              {:github_download_artifact, Node.self(),
+               %Artifact{
+                 artifact_path: artifact_path,
+                 artifact_name: artifact_name,
+                 id: download_id
+               }, :ok}
+            )
+
+            # the download panel has a place for this, a flash the operator may not be
+            # looking at is not enough on its own
+            assert has_element?(live, "#github-download-error")
+            assert render(live) =~ "wrong OTP, this installation runs OTP 28"
+
+            File.rm(artifact_path)
+          end
+        end
+      end)
+    end
+
+    @tag :capture_log
     test "handles github download completion with invalid file", %{conn: conn} do
       test_pid = self()
       download_id = Common.uuid4()


### PR DESCRIPTION
## Problem

A release downloaded from GitHub and then refused left the page unchanged:

```
[info] File .../deployex-0.9.10.tar.gz.zip Downloaded with success
[error] Hot upgrade refused, this release was built for a different OTP. deployex runs
OTP 28 with erts 16.4.0.4 and the release brings erts 15.2.7.11.
[error] Error while handling file: deployex-0.9.10.tar.gz, reason: wrong OTP, this
installation runs OTP 28
[debug] HANDLE EVENT "download-from-github" in DeployexWeb.HotUpgradeLive
```

That last line is the operator pressing Download again, because from the page nothing had happened.

## Cause

The download panel already renders the reason:

```heex
<div :if={@github.download_error} class="alert alert-error">
  <span>{@github.download_error}</span>
</div>
```

and **nothing ever set that field**. Both error paths replaced the whole assign with `github_new()`:

```elixir
socket
|> assign(:github, github_new())   # download_error: nil
|> put_flash(:error, msg)
```

so the one element built to carry the reason was cleared rather than filled, leaving only a flash at the edge of the page.

## Change

Both paths go through `github_download_failed/2`, which keeps the flash and sets the field the panel renders. The alert gained an id so it can be asserted on.

The refusal itself is correct and unchanged, that is #272 doing its job. This is only about it being visible.

## Risk assessment

**Impact:** a release refused after downloading from GitHub reports why in the download panel, and keeps reporting it until the next attempt. The flash is unchanged, and the upload path already showed its errors on the release card.

**Blast radius:** the two error clauses of the GitHub download completion handler in `DeployexWeb.HotUpgradeLive` and the alert markup they feed.

**Regression risk:** low. The successful path is untouched, and the failure paths gain an assign that was already being rendered.

**Rollback:** plain commit revert.

## Reproduction

A test downloads a release refused for running a different OTP and asserts the reason is on the page. It fails against the current code with `Expected truthy, got false` on `#github-download-error`.

Full suite green, `mix format --check-formatted` and `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
