### PR TITLE
chore: prepare release 0.9.11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,10 @@ git diff $PREV..HEAD -- apps/*/lib | grep -nE "^\+.*(fn |&[A-Z])"
 - Hot upgrade supported, nothing to add.
 - Not supported, add an entry under `### Backwards incompatible changes` naming the check that failed and telling operators to apply the release as a full deployment.
 
+One extra case, independent of the seven checks above: if the release fixes a bug in the hot upgrade path itself, that fix does not apply to the upgrade **into** this version, since the upgrade is performed by the version already installed.
+Check whether the bug being fixed would fire during that upgrade, and if it would, say so under `### Backwards incompatible changes` with what it does and that a full deployment avoids it.
+See the `0.9.11` section for an example.
+
 The reasoning behind each check, and how to verify a built package, is in `guides/docs/hot-upgrades/README.md`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@
  * [`PULL-276`](https://github.com/thiagoesteves/deployex/pull/276) Ghost the version instead of forcing a full deployment when a hot upgrade never installed the release
  * [`PULL-278`](https://github.com/thiagoesteves/deployex/pull/278) Stop the failed hot upgrade cleanup from deleting the running release libraries
  * [`PULL-280`](https://github.com/thiagoesteves/deployex/pull/280) Record the version after a DeployEx self upgrade through an MFA, not a captured function
+ * [`PULL-283`](https://github.com/thiagoesteves/deployex/pull/283) Apply the FinchStream download callbacks through an MFA instead of a captured function
+ * [`PULL-284`](https://github.com/thiagoesteves/deployex/pull/284) Show why a release downloaded from GitHub was refused in the download panel
 
 ### Enhancements
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions
  * [`PULL-281`](https://github.com/thiagoesteves/deployex/pull/281) Document the good practices for a hot-upgradeable project and how to check a release
  * [`PULL-282`](https://github.com/thiagoesteves/deployex/pull/282) Add the checks for deciding whether the next version supports hot upgrade to AGENTS.md
- * [`PULL-283`](https://github.com/thiagoesteves/deployex/pull/283) Apply the FinchStream download callbacks through an MFA instead of a captured function
- * [`PULL-284`](https://github.com/thiagoesteves/deployex/pull/284) Show why a release downloaded from GitHub was refused in the download panel
 
 ## 0.9.10 🚀 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,7 @@
 ## 0.9.11 🚀 (2026-08-12)
 
 ### Backwards incompatible changes from 0.9.10
-
-#### Apply this release as a full deployment
-
-Do not hot-upgrade DeployEx from `0.9.10` to `0.9.11`.
-
-A hot upgrade is carried out by the version already installed, so the fixes in this release only take effect for upgrades applied **from** `0.9.11` onwards, not for the upgrade **into** it. Two of them matter for that one upgrade:
-
- 1. The callback that records the installed version is built by the running code before the release is swapped in. Under `0.9.10` it is an anonymous function, which does not survive its module being replaced, so the upgrade completes and is made permanent while the version is never recorded. The UI keeps reporting `0.9.10`, and `Deployer.HotUpgrade.Application` crashes with `BadFunctionError` and is restarted. Restarting DeployEx afterwards records the correct version. Fixed by [`PULL-280`](https://github.com/thiagoesteves/deployex/pull/280).
- 2. If that upgrade fails before the release is installed, `0.9.10` cleans up with `release_handler:remove_release/1`, which also deletes libraries it believes are unused. An Elixir release ships no `RELEASES` file, so every library looks unused, including the ones DeployEx itself needs. DeployEx keeps running and fails to start the next time it is restarted. Fixed by [`PULL-278`](https://github.com/thiagoesteves/deployex/pull/278).
-
-Hot upgrades between `0.9.11` and later versions behave normally, both fixes are then in the code performing the upgrade.
+ * Apply this release as a full deployment, do not hot-upgrade from `0.9.10`. A hot upgrade is performed by the version already installed, so the fixes in [`PULL-278`](https://github.com/thiagoesteves/deployex/pull/278) and [`PULL-280`](https://github.com/thiagoesteves/deployex/pull/280) only take effect from `0.9.11` onwards. Hot upgrades between later versions behave normally.
 
 ### Bug fixes
  * [`PULL-272`](https://github.com/thiagoesteves/deployex/pull/272) Refuse a DeployEx hot upgrade built for a different OTP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@
 ## 0.9.11 🚀 (2026-08-12)
 
 ### Backwards incompatible changes from 0.9.10
- * None
+
+#### Apply this release as a full deployment
+
+Do not hot-upgrade DeployEx from `0.9.10` to `0.9.11`.
+
+A hot upgrade is carried out by the version already installed, so the fixes in this release only take effect for upgrades applied **from** `0.9.11` onwards, not for the upgrade **into** it. Two of them matter for that one upgrade:
+
+ 1. The callback that records the installed version is built by the running code before the release is swapped in. Under `0.9.10` it is an anonymous function, which does not survive its module being replaced, so the upgrade completes and is made permanent while the version is never recorded. The UI keeps reporting `0.9.10`, and `Deployer.HotUpgrade.Application` crashes with `BadFunctionError` and is restarted. Restarting DeployEx afterwards records the correct version. Fixed by [`PULL-280`](https://github.com/thiagoesteves/deployex/pull/280).
+ 2. If that upgrade fails before the release is installed, `0.9.10` cleans up with `release_handler:remove_release/1`, which also deletes libraries it believes are unused. An Elixir release ships no `RELEASES` file, so every library looks unused, including the ones DeployEx itself needs. DeployEx keeps running and fails to start the next time it is restarted. Fixed by [`PULL-278`](https://github.com/thiagoesteves/deployex/pull/278).
+
+Hot upgrades between `0.9.11` and later versions behave normally, both fixes are then in the code performing the upgrade.
 
 ### Bug fixes
  * [`PULL-272`](https://github.com/thiagoesteves/deployex/pull/272) Refuse a DeployEx hot upgrade built for a different OTP

--- a/guides/docs/hot-upgrades/README.md
+++ b/guides/docs/hot-upgrades/README.md
@@ -248,6 +248,19 @@ replace the runtime under a running system. Use the artifact matching the otp_ve
 this installation runs, or apply it as a full deployment.
 ```
 
+### Which version performs the upgrade
+
+A hot upgrade is carried out by the code already running, not by the code in the package.
+DeployEx unpacks the release, builds the relup and installs it using the version currently installed, and only afterwards is the new code in charge.
+
+That has one consequence worth remembering whenever a release fixes something in the hot upgrade path itself: the fix applies to upgrades performed **from** that version, not to the upgrade **into** it.
+Going from a version with the bug to a version with the fix still runs the bug, because the buggy code is what does the work.
+
+So when a release changes how hot upgrades behave, check its changelog before hot-upgrading into it.
+Where that matters the release says so under `Backwards incompatible changes`, and the answer there is to apply it as a full deployment once, after which hot upgrades carry on normally.
+
+The same applies to a monitored application whose own upgrade instructions changed, its `.appup` is executed by the release being replaced.
+
 ### When a hot upgrade fails
 
 DeployEx does not fall back to a full deployment for itself.


### PR DESCRIPTION
## What this does

Finishes the `0.9.11` checklist. Most of it was already in place, so the diff is small.

| Step | State |
|---|---|
| `mix/shared.exs` → `0.9.11` | already done, #279, kept when #280 shipped as part of the same version |
| `README.md` compatibility row | already done, #279 |
| `devops/installer/deployex-{aws,gcp}.yaml` | already done, #279 |
| `guides/docs/yaml/README.md` | already done, #279 |
| `CHANGELOG.md` heading dated | already done, `## 0.9.11 🚀 (2026-08-12)` |
| `mix docs` | **done here**, last as required |

Verified rather than assumed: the OTP columns still match the pinned toolchains, **27.3.4.15** and **28.5.0.4**, unchanged from `0.9.10`, so a hot upgrade from `0.9.10` stays on the same OTP line.

## Changelog correction

#283 and #284 were under `### Enhancements` and are both fixes, `fix(foundation):` and `fix(web):`. They only landed there because each was appended after the entry above it. Moved to `### Bug fixes`, keeping ascending order.

## What is in the release

**Bug fixes:** #272, #273, #274, #275, #276, #278, #280, #283, #284
**Enhancements:** #277, #281, #282

Nearly all of it is hot upgrades failing safely: refusing a release built for a different OTP, refusing a file that is not a release, not reporting a self upgrade as successful before it has run, logging why `systools` refused, unregistering rather than deleting after a failure, and recording the version a self upgrade installed.

## This release must be applied as a full deployment

A hot upgrade is performed by the version **already installed**, not by the code in the package. So the fixes in this release apply to upgrades performed *from* `0.9.11`, not to the upgrade *into* it. Two of them fire during a `0.9.10` to `0.9.11` hot upgrade:

1. The callback recording the installed version is built by `0.9.10` as an anonymous function, which does not survive its module being replaced. The upgrade completes and is made permanent, the version is never recorded, the UI keeps reporting `0.9.10`, and `Deployer.HotUpgrade.Application` crashes with `BadFunctionError`. Observed on stage. Fixed by #280.
2. If that upgrade fails before installing, `0.9.10` cleans up with `release_handler:remove_release/1`, which deletes libraries it believes are unused, and with no `RELEASES` file every library looks unused, including DeployEx's own. Fixed by #278.

Recorded under `### Backwards incompatible changes from 0.9.10` with both cases. Hot upgrades from `0.9.11` onwards behave normally.

The guide gains the general rule in `Which version performs the upgrade`, since this returns every time a release fixes something in the hot upgrade path, and `AGENTS.md` points at it as a case to check beyond the seven mechanical ones.

**#276 is the one to read before upgrading.** A release whose `.appup` or `jellyfish.json` claims hot upgrade support, and which then fails before installing anything, is no longer deployed by restart. The application stays on its current version and the failed version is ghosted, which #277 then lets you inspect and clear from the UI. Publishing a fixed version deploys normally, and releases that need a full deployment never enter that path.

## Before tagging

`0.9.11` **already exists**, pointing at the #279 merge, and its artifacts were published from that commit. Everything from #280 onwards is not in them, including #278, which stops a failed hot upgrade deleting the running release libraries.

So the tag has to be deleted and re-pushed at this commit, and the release rebuilt. Anyone who fetched `0.9.11` before that has different artifacts from anyone who fetches it after, which is worth saying in the release notes.

## Risk assessment

**Impact:** publishes `0.9.11`. Operators get the changes above, none of which require action from them beyond knowing about #276.

**Blast radius:** changelog and the generated documentation. No application code changes.

**Regression risk:** low, there is no behaviour change in this commit. Full suite green, `mix format --check-formatted` and `mix credo --strict` clean, built and verified at `0.9.11`.

**Rollback:** plain commit revert, and delete the tag if it has already been pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)