### PR TITLE
fix(foundation): carry the certificate storage_options into the certificate manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  * [`PULL-280`](https://github.com/thiagoesteves/deployex/pull/280) Record the version after a DeployEx self upgrade through an MFA, not a captured function
  * [`PULL-283`](https://github.com/thiagoesteves/deployex/pull/283) Apply the FinchStream download callbacks through an MFA instead of a captured function
  * [`PULL-284`](https://github.com/thiagoesteves/deployex/pull/284) Show why a release downloaded from GitHub was refused in the download panel
+ * [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286) Carry the certificate storage_options into the certificate manager so renewals are written to disk
 
 ### Enhancements
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions

--- a/apps/foundation/lib/foundation/certificates/manager/supervisor.ex
+++ b/apps/foundation/lib/foundation/certificates/manager/supervisor.ex
@@ -67,10 +67,13 @@ defmodule Foundation.Certificates.Manager.Supervisor do
       acme_provider: cert.acme_provider,
       acme_options: to_map(cert.acme_options),
       importer: cert.importer,
-      importer_options: to_map(cert.importer_options)
+      importer_options: to_map(cert.importer_options),
+      storage_options: to_map(cert.storage_options)
     }
   end
 
+  # Every options field is optional, and a missing one has to stay missing rather than raise
+  defp to_map(nil), do: nil
   defp to_map(value) when is_struct(value), do: Map.from_struct(value)
   defp to_map(value) when is_map(value), do: value
 end

--- a/apps/foundation/test/certificates/manager/manager_test.exs
+++ b/apps/foundation/test/certificates/manager/manager_test.exs
@@ -240,6 +240,61 @@ defmodule Foundation.Certificates.ManagerTest do
     end
   end
 
+  describe "storage_options" do
+    @tag :capture_log
+    test "writes the renewed certificate to the configured paths" do
+      dir = Path.join(System.tmp_dir!(), "cert-storage-#{System.unique_integer([:positive])}")
+      cert_path = Path.join(dir, "device-ssl-cert.crt")
+      key_path = Path.join(dir, "device-ssl-key.crt")
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      no_cert = %Certificate{certificate_pem: nil}
+
+      stored = %Certificate{
+        certificate_pem: "cert_pem",
+        chain_certificate_pem: "chain_pem",
+        private_key_pem: "key_pem"
+      }
+
+      with_mocks([
+        {Catalog, [],
+         [
+           certificate: fn _app -> stored end,
+           certificate_update: fn _app, c -> {:ok, c} end
+         ]},
+        {Catalog.Certificate, [],
+         [
+           new: fn _state -> no_cert end,
+           # due for renewal, so the storage step runs
+           valid?: fn _cert, _days -> false end,
+           metadata_from_cert_pem: fn _pem ->
+             {:ok,
+              %{
+                issuer: "TestCA",
+                valid_from: ~U[2024-01-01 00:00:00Z],
+                valid_until: ~U[2025-01-01 00:00:00Z]
+              }}
+           end,
+           split_certificate_chain: fn _pem -> {"cert_pem", "chain_pem"} end
+         ]},
+        {Network, [],
+         [
+           lookup: fn _domain_charlist, _class, _type, _options ->
+             ["_acme.example.com.", "token123"]
+           end
+         ]}
+      ]) do
+        config =
+          base_config(storage_options: %{certificate_path: cert_path, private_key_path: key_path})
+
+        assert {:ok, :renewed, _cert} = Manager.request_and_import_certificate(config)
+      end
+
+      assert File.read!(cert_path) =~ "cert_pem"
+      assert File.read!(key_path) == "key_pem"
+    end
+  end
+
   describe "wait_for_dns_propagation (via request_and_import_certificate)" do
     @tag :capture_log
     test "times out when DNS never propagates and returns {:error, :dns_propagation_timeout}" do

--- a/apps/foundation/test/certificates/manager/supervisor_test.exs
+++ b/apps/foundation/test/certificates/manager/supervisor_test.exs
@@ -24,7 +24,11 @@ defmodule Foundation.Certificates.Manager.SupervisorTest do
         acme_provider: SomeACMEProvider,
         acme_options: %{email: "ops@example.com"},
         importer: SomeImporter,
-        importer_options: %{}
+        importer_options: %{},
+        storage_options: %{
+          certificate_path: "/etc/ssl/device-ssl-cert.crt",
+          private_key_path: "/etc/ssl/device-ssl-key.crt"
+        }
       },
       overrides
     )
@@ -76,9 +80,29 @@ defmodule Foundation.Certificates.Manager.SupervisorTest do
           assert manager.dns_provider == SomeDNSProvider
           assert manager.acme_provider == SomeACMEProvider
           assert manager.importer == SomeImporter
+
+          # without this the renewal writes nothing and says nothing, the store step just
+          # returns on its nil clause
+          assert manager.storage_options == %{
+                   certificate_path: "/etc/ssl/device-ssl-cert.crt",
+                   private_key_path: "/etc/ssl/device-ssl-key.crt"
+                 }
+
           {:ok, self()}
         end do
         Supervisor.start_certificate_manager("my_app", domain_certificate())
+      end
+    end
+
+    test "leaves storage_options nil when the certificate has none" do
+      with_mock DynamicSupervisor, [:passthrough],
+        start_child: fn _sup, spec ->
+          {_mod, _fun, [manager]} = spec.start
+          assert manager.storage_options == nil
+          {:ok, self()}
+        end do
+        cert = domain_certificate(%{storage_options: nil, dns_options: nil, acme_options: nil})
+        Supervisor.start_certificate_manager("my_app", cert)
       end
     end
 


### PR DESCRIPTION
## Problem

A renewed certificate is never written to the paths configured under `storage_options`. On a production host the renewal succeeded end to end:

```
[info] Successfully imported certificate to ACM: arn:aws:acm:... for nerves_hub
[info] Certificate renewed successfully for app: nerves_hub, domains: [...]
```

and the files on disk were untouched, still carrying the timestamp of two days earlier. No error was logged either.

## Cause

`storage_options` is parsed from the YAML into `Foundation.Yaml.Certificate`, and read at the end of a renewal:

```elixir
store_certificate_files(app_name, cert_config.storage_options)
```

But the mapping that builds the manager state from the YAML certificate copied **every field except that one**:

```elixir
importer: cert.importer,
importer_options: to_map(cert.importer_options)
# storage_options never copied
```

So `cert_config.storage_options` was always `nil` and `store_certificate_files/2` returned on its `nil` clause. That is also why nothing was logged: it is not an error path, it is the "nothing configured" path.

The field existed in the manager struct, in the YAML struct, and in the parser. Only the line joining them was missing, so the feature has never worked through the automated path.

## Also fixed

`to_map/1` had no `nil` clause. Every options field is optional, so a missing one raised instead of staying missing. That was latent for `dns_options`, `acme_options` and `importer_options`, and would have fired immediately for `storage_options`, which is `nil` in most installations.

## Risk assessment

**Impact:** a renewal writes the certificate and private key to the configured paths. An installation with no `storage_options` is unaffected. The destination still has to be writable by the `deployex` user, and a failure there is logged without failing the renewal, as before.

**Blast radius:** the mapping in `Foundation.Certificates.Manager.Supervisor`. The renewal, the importers and the YAML parsing are untouched, they were already correct.

**Regression risk:** low. One field is added to a struct that already declared it, and `to_map/1` gains a clause for a value that previously raised.

**Rollback:** plain commit revert.

## Reproduction

Two tests, both failing against the current code:

- the supervisor mapping test asserts the field is carried, `left: nil`
- a second asserts a certificate without `storage_options` maps to `nil` rather than raising, `FunctionClauseError in to_map/1`

Plus an end to end manager test that renews with `storage_options` set and reads the two files back from disk.

The existing mapping test checked a subset of the fields, which is how this went unnoticed.

## Note on the host

The files currently at `/etc/ssl` predate this and will be replaced at the next renewal once this ships. `deployex.sh --install` clears `/var/lib/deployex`, which is why a new certificate was issued in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
