### PR TITLE
chore: prepare release 0.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.9.12 🚀 (2026-08-12)
 
 ### Backwards incompatible changes from 0.9.11
- * Only for applications using `storage_options`. A running certificate manager keeps the state it started with, so after a hot upgrade the fix in [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286) only applies once it is restarted. Remove the `certificates` section of the application from `deployex.yaml`, save, then add it back. Restarting DeployEx has the same effect.
+ * Hot upgrade from `0.9.11` is supported. Applications using `storage_options` need one extra step afterwards, since a running certificate manager keeps the state it started with: comment the `certificates` section out of `deployex.yaml` and apply the change, then uncomment it and apply again. That restarts the manager with the fix from [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286).
 
 ### Bug fixes
  * [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286) Carry the certificate storage_options into the certificate manager so renewals are written to disk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG (0.9.X)
 
+## 0.9.12 🚀 (2026-08-12)
+
+### Backwards incompatible changes from 0.9.11
+ * Only for applications using `storage_options`. A running certificate manager keeps the state it started with, so after a hot upgrade the fix in [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286) only applies once it is restarted. Remove the `certificates` section of the application from `deployex.yaml`, save, then add it back. Restarting DeployEx has the same effect.
+
+### Bug fixes
+ * [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286) Carry the certificate storage_options into the certificate manager so renewals are written to disk
+
+### Enhancements
+ * None
+
 ## 0.9.11 🚀 (2026-08-12)
 
 ### Backwards incompatible changes from 0.9.10
@@ -15,7 +26,6 @@
  * [`PULL-280`](https://github.com/thiagoesteves/deployex/pull/280) Record the version after a DeployEx self upgrade through an MFA, not a captured function
  * [`PULL-283`](https://github.com/thiagoesteves/deployex/pull/283) Apply the FinchStream download callbacks through an MFA instead of a captured function
  * [`PULL-284`](https://github.com/thiagoesteves/deployex/pull/284) Show why a release downloaded from GitHub was refused in the download panel
- * [`PULL-286`](https://github.com/thiagoesteves/deployex/pull/286) Carry the certificate storage_options into the certificate manager so renewals are written to disk
 
 ### Enhancements
  * [`PULL-277`](https://github.com/thiagoesteves/deployex/pull/277) Add a ghosted version list to the UI with clear all and clear one actions

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Since OTP distribution is heavily used between the DeployEx and Monitored Applic
 
 | DeployEx version                                                          | <img src="https://img.shields.io/badge/OTP-27-green.svg"/> | <img src="https://img.shields.io/badge/OTP-28-green.svg"/> |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| [**0.9.12**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.12) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.11**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.11) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.10**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.10) | **27.3.4.15**                                              | **28.5.0.4**                                               |
 | [**0.9.9**](https://github.com/thiagoesteves/deployex/releases/tag/0.9.9) | **27.3.4.15**                                              | **28.5.0.4**                                               |

--- a/devops/installer/deployex-aws.yaml
+++ b/devops/installer/deployex-aws.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "aws"
 secrets_path: "deployex-myapp-prod-secrets"
 aws_region: "sa-east-1"
-version: "0.9.11"
+version: "0.9.12"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/devops/installer/deployex-gcp.yaml
+++ b/devops/installer/deployex-gcp.yaml
@@ -6,7 +6,7 @@ release_bucket: "myapp-prod-distribution"
 secrets_adapter: "gcp"
 secrets_path: "deployex-myapp-prod-secrets"
 google_credentials: "/home/ubuntu/gcp-config.json"
-version: "0.9.11"
+version: "0.9.12"
 otp_version: 28
 otp_tls_certificates: "/usr/local/share/ca-certificates"
 os_target: "ubuntu-24.04"

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -52,7 +52,7 @@ aws_region: "sa-east-1"                                  # AWS region (only for 
 google_credentials: "/home/ubuntu/gcp-config.json"       # Google credentials (only for GCP)
 
 # System Configuration
-version: "0.9.11"                                        # DeployEx version
+version: "0.9.12"                                        # DeployEx version
 otp_version: 28                                          # OTP version (must match monitored apps)
 os_target: "ubuntu-24.04"                                # Target OS server
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.11"
+  def version, do: "0.9.12"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
## What this does

Prepares `0.9.12`, dated **2026-08-12**.

| Step | Change |
|---|---|
| `mix/shared.exs` | `0.9.11` → `0.9.12` |
| `README.md` | new `0.9.12` row |
| `devops/installer/deployex-{aws,gcp}.yaml` | `version: "0.9.12"` |
| `guides/docs/yaml/README.md` | `version: "0.9.12"` |
| `CHANGELOG.md` | new `## 0.9.12 🚀 (2026-08-12)` section, `PULL-286` moved into it |
| `mix docs` | regenerated, run last |

Erlang versions unchanged from `0.9.11`, **27.3.4.15** and **28.5.0.4**, read from the pinned toolchains.

## Contents

One fix, #286, which makes a renewed certificate actually reach the paths configured under `storage_options`. The field was parsed and read but never carried into the certificate manager, so it was always `nil` and the write was skipped silently.

## Hot upgrade from 0.9.11: supported

The seven checks in `AGENTS.md` all come back clean:

| # | Check | Result |
|---|---|---|
| 1 | `.tool-versions` | no change |
| 2 | `config/runtime.exs` | no change |
| 3 | config providers | no change |
| 4 | `mix.lock` | no change |
| 5 | function values added | none |
| 6 | GenServer state shape | unchanged |
| 7 | supervision tree | unchanged |

The only file touched is `Foundation.Certificates.Manager.Supervisor`, and what changed there builds the **initial state** of a certificate manager.

That is the one caveat, and **it applies only to applications using `storage_options`**. A running manager keeps the state it started with, so the fix reaches it when it restarts. One extra step after the upgrade:

1. comment the `certificates` section out of `deployex.yaml` and apply the change
2. uncomment it and apply again

The config watcher stops the manager on the first apply and starts it on the second, so it comes back with the new initial state. Restarting DeployEx does the same thing.

Recorded under `### Backwards incompatible changes from 0.9.11`, leading with the fact that the hot upgrade itself is supported.

## Risk assessment

**Impact:** publishes `0.9.12`. Certificates are written to disk on renewal for installations that configured it, and nothing changes for those that did not.

**Blast radius:** version, changelog, compatibility table, the two installer configurations, the YAML guide example, and the generated documentation. No application code changes.

**Regression risk:** low, there is no behaviour change in this commit. Full suite green, built and verified at `0.9.12`, `mix format --check-formatted` and `mix credo --strict` clean.

**Rollback:** plain commit revert, and delete the tag if it has already been pushed.

## After merging

Pushing the `0.9.12` tag from `main` triggers `.github/workflows/releases.yaml`. Unlike `0.9.11`, this tag does not exist yet, so it is a plain tag and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)