### PR TITLE
fix(deployer): name the versions in deployment notifications and report a deployment only when one has finished

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,7 +335,8 @@ git diff $PREV..HEAD -- mix.lock | grep -E "^[+-] +\{:"
 
 **5. Values that cannot cross a code swap.** A function value is tied to the module version that created it, and `install_release` replaces every umbrella application because they all carry the release version.
 Anything that outlives the upgrade must be data, not a closure: GenServer state, ETS, `:persistent_term`, timers, and messages already queued.
-`Deployer.HotUpgrade.Execute` declares `after_async_make_permanent` as `mfa()` for exactly this reason.
+`Deployer.HotUpgrade.Execute` declares `after_async_make_permanent` as `Deployer.HotUpgrade.Execute.callback()`, a `{module(), atom(), list()}` tuple applied rather than called, for exactly this reason.
+It is not `mfa()`, whose third element is an arity rather than an argument list.
 
 ```bash
 git diff $PREV..HEAD -- apps/*/lib | grep -nE "^\+.*(fn |&[A-Z])"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
  * None
 
 ### Bug fixes
- * None
+ * [`PULL-288`](https://github.com/thiagoesteves/deployex/pull/288) Report a deployment as complete only when one has finished, not on a hot upgrade or an application restart
 
 ### Enhancements
  * [`PULL-288`](https://github.com/thiagoesteves/deployex/pull/288) Report the versions a hot upgrade moved between in the completion notification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG (0.9.X)
 
+## 0.9.13 ()
+
+### Backwards incompatible changes from 0.9.12
+ * None
+
+### Bug fixes
+ * None
+
+### Enhancements
+ * [`PULL-288`](https://github.com/thiagoesteves/deployex/pull/288) Report the versions a hot upgrade moved between in the completion notification
+
 ## 0.9.12 🚀 (2026-08-12)
 
 ### Backwards incompatible changes from 0.9.11

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -312,12 +312,12 @@ defmodule Deployer.Engine.Worker do
         #       reports running right after an engine worker restart
         if current_deployment.timer_ref, do: Process.cancel_timer(current_deployment.timer_ref)
 
-        Foundation.Notifications.notify("deployment_complete", %{
-          node: node(),
-          sname: sname,
-          status: :ok,
-          message: "Full deployment applied successfully!"
-        })
+        # Only a full deployment sets deployment_to_terminate, and it is cleared as soon as
+        # the report it was waiting for arrives, so it is what says this report completes a
+        # deployment. Everything else that reports running, a crash restart, a restart asked
+        # for from the UI, or a hot upgrade that has already reported itself with the
+        # versions it moved between, is not a deployment and is not announced as one
+        if deployment_to_terminate, do: notify_deployment_complete(sname)
 
         new_instance =
           if state.current == state.replicas, do: 1, else: state.current + 1
@@ -334,9 +334,15 @@ defmodule Deployer.Engine.Worker do
 
         Logger.info(" # Moving to the next instance: #{new_instance}")
 
+        # The timer was cancelled above, so the reference goes with it, otherwise the
+        # deployment keeps one that reads as a rollback window still open
+        deployments =
+          Map.put(state.deployments, state.current, %{current_deployment | timer_ref: nil})
+
         %{
           state
           | current: new_instance,
+            deployments: deployments,
             deployment_to_terminate: nil,
             available_ports: available_ports
         }
@@ -673,6 +679,20 @@ defmodule Deployer.Engine.Worker do
       end)
 
     handle_hot_upgrade_result(result, state, sname, new_sname, release)
+  end
+
+  # The deployment wrote the version to the catalog before the sname reported running, so
+  # the notification reads it from there instead of threading it through the call
+  defp notify_deployment_complete(sname) do
+    version = Status.current_version(sname)
+
+    Foundation.Notifications.notify("deployment_complete", %{
+      node: node(),
+      sname: sname,
+      status: :ok,
+      message: "Full deployment applied successfully, version #{version}",
+      version: to_string(version)
+    })
   end
 
   # The release said it could hot upgrade, through its appup or jellyfish file, otherwise

--- a/apps/deployer/lib/deployer/hot_upgrade/application.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/application.ex
@@ -133,12 +133,12 @@ defmodule Deployer.HotUpgrade.Application do
   def handle_info({:make_permanent, params}, state) do
     case permfy(%{params | make_permanent_async: false}) do
       :ok ->
-        notify_complete_ok(params.sname)
+        notify_complete_ok(params)
 
         apply_after_async_make_permanent(params.after_async_make_permanent)
 
       reason ->
-        notify_error(params.sname, reason)
+        notify_error(params, reason)
     end
 
     {:noreply, state}
@@ -235,7 +235,7 @@ defmodule Deployer.HotUpgrade.Application do
          :ok <- install_release(data),
          :ok <- notify_make_permanent(data.make_permanent_async, data.sname, data.to_version),
          :ok <- permfy(data),
-         :ok <- notify_complete_ok(data.make_permanent_async, data.sname) do
+         :ok <- notify_complete_ok(data.make_permanent_async, data) do
       Logger.info(
         "Release upgrade executed with success at node: #{node} from: #{from_version} to: #{to_version}"
       )
@@ -252,7 +252,7 @@ defmodule Deployer.HotUpgrade.Application do
     # remove_unpacked_release/1 only acts while the release is still unpacked, so an error
     # after it was installed leaves it alone
     remove_unpacked_release(data)
-    notify_error(data.sname, error)
+    notify_error(data, error)
   end
 
   def do_check(%Check{from_version: from_version, to_version: to_version} = data)
@@ -762,42 +762,42 @@ defmodule Deployer.HotUpgrade.Application do
     )
   end
 
-  @spec notify_complete_ok(skip :: boolean(), sname :: String.t()) :: :ok
-  defp notify_complete_ok(skip \\ false, sname)
+  @spec notify_complete_ok(skip :: boolean(), data :: Execute.t()) :: :ok
+  defp notify_complete_ok(skip \\ false, data)
 
-  defp notify_complete_ok(true, _sname), do: :ok
+  defp notify_complete_ok(true, _data), do: :ok
 
-  defp notify_complete_ok(_skip, sname) do
+  defp notify_complete_ok(_skip, %Execute{} = data) do
+    notify_outcome(data, :ok, "Hot upgrade applied successfully, #{versions(data)}")
+  end
+
+  @spec notify_error(data :: Execute.t(), result :: any()) :: :ok
+  defp notify_error(%Execute{} = data, result) do
+    notify_outcome(data, :error, "Hot upgrade #{versions(data)} failed: #{inspect(result)}")
+  end
+
+  # The versions are on the message rather than only on the payload, so every notification
+  # adapter reports them without having to know about this event
+  defp notify_outcome(%Execute{sname: sname} = data, status, message) do
     Phoenix.PubSub.broadcast(
       Deployer.PubSub,
       @events_topic,
-      {:hot_upgrade_complete, Node.self(), sname, :ok, "Hot upgrade applied successfully!"}
+      {:hot_upgrade_complete, Node.self(), sname, status, message}
     )
 
     Foundation.Notifications.notify("deployment_complete", %{
       node: node(),
       sname: sname,
-      status: :ok,
-      message: "Hot upgrade applied successfully!"
+      status: status,
+      message: message,
+      from_version: to_string(data.from_version),
+      to_version: to_string(data.to_version)
     })
   end
 
-  @spec notify_error(sname :: String.t(), result :: any()) :: :ok
-  defp notify_error(sname, result) do
-    message = "Upgrade failed: #{inspect(result)}"
-
-    Phoenix.PubSub.broadcast(
-      Deployer.PubSub,
-      @events_topic,
-      {:hot_upgrade_complete, Node.self(), sname, :error, message}
-    )
-
-    Foundation.Notifications.notify("deployment_complete", %{
-      node: node(),
-      sname: sname,
-      status: :error,
-      message: message
-    })
+  # Charlists by the time the upgrade runs, do_execute/1 converts them
+  defp versions(%Execute{from_version: from_version, to_version: to_version}) do
+    "#{from_version} -> #{to_version}"
   end
 
   @spec stash_runtime_config(node(), runtime_config()) :: :ok | {:error, any()}

--- a/apps/deployer/lib/deployer/hot_upgrade/execute.ex
+++ b/apps/deployer/lib/deployer/hot_upgrade/execute.ex
@@ -2,6 +2,13 @@ defmodule Deployer.HotUpgrade.Execute do
   @moduledoc """
   Structure to handle the upgrade execute data
   """
+  @typedoc """
+  A callback to apply, carrying the arguments to apply it with.
+
+  Not `mfa()`, whose third element is an arity rather than an argument list.
+  """
+  @type callback :: {module(), atom(), list()}
+
   @type t :: %__MODULE__{
           node: atom(),
           sname: String.t() | nil,
@@ -13,7 +20,7 @@ defmodule Deployer.HotUpgrade.Execute do
           to_version: binary() | charlist() | nil,
           make_permanent_async: boolean(),
           sync_execution: boolean(),
-          after_async_make_permanent: mfa() | nil
+          after_async_make_permanent: callback() | nil
         }
 
   @derive Jason.Encoder

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -1058,6 +1058,124 @@ defmodule Deployer.EngineTest do
     end
   end
 
+  describe "Deployment complete notification" do
+    @tag :capture_log
+    test "a full deployment reports the version it deployed" do
+      name = "myelixir"
+      sname = Catalog.create_sname(name)
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> stub(:current_version, fn ^sname -> "1.1.0" end)
+
+      Deployer.MonitorMock
+      |> stub(:stop_service, fn _name, _sname -> :ok end)
+
+      subscribe_to_deployment_complete()
+
+      pid = start_worker(name)
+      running_deployment(pid, sname, deploying?: true)
+
+      GenServer.cast(pid, {:application_running, sname})
+
+      # the message is what every adapter renders, the payload key is there for the ones
+      # that forward structured data
+      assert_receive {"deployment_complete", payload}, 1_000
+      assert payload.status == :ok
+      assert payload.message == "Full deployment applied successfully, version 1.1.0"
+      assert payload.version == "1.1.0"
+    end
+
+    @tag :capture_log
+    test "a report that does not complete a deployment is not announced as one" do
+      name = "myelixir"
+      sname = Catalog.create_sname(name)
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> stub(:current_version, fn ^sname -> "1.1.0" end)
+
+      subscribe_to_deployment_complete()
+
+      pid = start_worker(name)
+      running_deployment(pid, sname, deploying?: false)
+
+      GenServer.cast(pid, {:application_running, sname})
+
+      # a crash restart, a restart asked for from the UI and a hot upgrade all report an
+      # application running without a deployment waiting for it, and the hot upgrade has
+      # already sent its own notification with the versions it moved between
+      refute_receive {"deployment_complete", _payload}, 300
+    end
+
+    @tag :capture_log
+    test "the same deployment is not reported twice" do
+      name = "myelixir"
+      sname = Catalog.create_sname(name)
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> stub(:current_version, fn ^sname -> "1.1.0" end)
+
+      Deployer.MonitorMock
+      |> stub(:stop_service, fn _name, _sname -> :ok end)
+
+      subscribe_to_deployment_complete()
+
+      pid = start_worker(name)
+      running_deployment(pid, sname, deploying?: true)
+
+      GenServer.cast(pid, {:application_running, sname})
+      assert_receive {"deployment_complete", _payload}, 1_000
+
+      # the application reporting running again, e.g. after a crash restart, finds the
+      # deployment already completed
+      GenServer.cast(pid, {:application_running, sname})
+      refute_receive {"deployment_complete", _payload}, 300
+
+      assert %Deployer.Engine.Deployment{timer_ref: nil} = :sys.get_state(pid).deployments[1]
+    end
+
+    defp subscribe_to_deployment_complete do
+      Phoenix.PubSub.subscribe(
+        Foundation.PubSub,
+        Foundation.Notifications.topic("deployment_complete")
+      )
+    end
+
+    defp start_worker(name) do
+      assert {:ok, pid} =
+               Engine.Worker.start_link(%Engine.Worker{
+                 deploy_rollback_timeout_ms: 60_000,
+                 deploy_schedule_interval_ms: 60_000,
+                 name: name,
+                 language: "elixir"
+               })
+
+      pid
+    end
+
+    # deployment_to_terminate is what the worker sets when it starts a full deployment and
+    # clears when the report it is waiting for arrives, so it is what tells a deployment
+    # apart from an application that is only reporting itself running again
+    defp running_deployment(pid, sname, deploying?: deploying?) do
+      :sys.replace_state(pid, fn state ->
+        deployment = %{
+          state.deployments[state.current]
+          | sname: sname,
+            state: :active,
+            timer_ref: Process.send_after(pid, :ignored, 60_000)
+        }
+
+        %{
+          state
+          | deployments: Map.put(state.deployments, state.current, deployment),
+            deployment_to_terminate: if(deploying?, do: %Deployer.Engine.Deployment{})
+        }
+      end)
+    end
+  end
+
   describe "Ghosted version list" do
     @tag :capture_log
     test "The worker takes the new list from the broadcast" do

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1421,6 +1421,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     assert payload.to_version == "0.9.13"
   end
 
+  @tag :capture_log
   test "a failing after make permanent callback does not take the server down" do
     node = Node.self()
     pid = Process.whereis(UpgradeApp)

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1386,6 +1386,41 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
   end
 
   @tag :capture_log
+  test "the completion notification carries the versions it upgraded between" do
+    node = Node.self()
+    pid = Process.whereis(UpgradeApp)
+
+    Foundation.RpcMock
+    |> stub(:call, fn ^node, :release_handler, :make_permanent, _params, @expected_timeout ->
+      :ok
+    end)
+
+    Phoenix.PubSub.subscribe(
+      Foundation.PubSub,
+      Foundation.Notifications.topic("deployment_complete")
+    )
+
+    send(
+      pid,
+      {:make_permanent,
+       %Execute{
+         node: node,
+         sname: "deployex",
+         from_version: ~c"0.9.12",
+         to_version: ~c"0.9.13",
+         make_permanent_async: true
+       }}
+    )
+
+    # the message is what every adapter renders, the payload keys are there for the ones
+    # that forward structured data
+    assert_receive {"deployment_complete", payload}, 1_000
+    assert payload.status == :ok
+    assert payload.message == "Hot upgrade applied successfully, 0.9.12 -> 0.9.13"
+    assert payload.from_version == "0.9.12"
+    assert payload.to_version == "0.9.13"
+  end
+
   test "a failing after make permanent callback does not take the server down" do
     node = Node.self()
     pid = Process.whereis(UpgradeApp)
@@ -1514,7 +1549,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                      1_000
 
       assert_receive {:hot_upgrade_complete, ^node, ^sname, :ok,
-                      "Hot upgrade applied successfully!"},
+                      "Hot upgrade applied successfully, 0.1.0 -> 0.2.0"},
                      1_000
 
       assert_receive {:handle_ref_event, ^ref}, 1_000
@@ -1610,7 +1645,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                      1_000
 
       assert_receive {:hot_upgrade_complete, ^node, ^sname, :ok,
-                      "Hot upgrade applied successfully!"},
+                      "Hot upgrade applied successfully, 0.1.0 -> 0.2.0"},
                      1_000
     end
   end
@@ -1704,7 +1739,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                      1_000
 
       assert_receive {:hot_upgrade_complete, ^node, ^sname, :ok,
-                      "Hot upgrade applied successfully!"},
+                      "Hot upgrade applied successfully, 0.1.0 -> 0.2.0"},
                      1_000
     end
   end
@@ -1802,7 +1837,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                               1_000
 
                assert_receive {:hot_upgrade_complete, ^node, ^sname, :error,
-                               "Upgrade failed: {:error, {:error, :no_match_versions}}"},
+                               "Hot upgrade 0.1.0 -> 0.2.0 failed: {:error, {:error, :no_match_versions}}"},
                               1_000
              end) =~
                "Error while trying to set a permanent version for 0.2.0, reason: {:error, :no_match_versions}"
@@ -1906,7 +1941,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
                               1_000
 
                assert_receive {:hot_upgrade_complete, ^node, ^sname, :error,
-                               "Upgrade failed: {:error, {:error, :no_match_versions}}"},
+                               "Hot upgrade 0.1.0 -> 0.2.0 failed: {:error, {:error, :no_match_versions}}"},
                               1_000
              end) =~
                "Error while trying to set a permanent version for 0.2.0, reason: {:error, :no_match_versions}"

--- a/apps/foundation/lib/foundation/notifications.ex
+++ b/apps/foundation/lib/foundation/notifications.ex
@@ -19,7 +19,7 @@ defmodule Foundation.Notifications do
   |----------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------|
   | `"crash_restart"`                 | Monitored app crashed and is being restarted               | `node`, `sname`, `name`, `language`, `crash_restart_count`                 |
   | `"deployment_started"`            | New deployment was initiated for an sname                  | `node`, `sname`, `version`                                                  |
-  | `"deployment_complete"`           | Hot-upgrade finished (success or failure)                  | `node`, `sname`, `status` (`:ok`/`:error`), `message`                      |
+  | `"deployment_complete"`           | Full deployment or hot upgrade finished (success or failure)| `node`, `sname`, `status` (`:ok`/`:error`), `message`, plus `version` for a full deployment and `from_version`/`to_version` for a hot upgrade |
   | `"watchdog_threshold_exceeded"`   | Watchdog exceeded a resource threshold and restarted an app| `node`, `type`, `current_percentage`, `restart_threshold_percent`          |
   | `"watchdog_threshold_warning"`    | Resource crossed the warning threshold (or returned below) | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
   | `"certificate_renewed"`           | TLS certificate was successfully renewed                   | `app_name`, `domains`                                                       |

--- a/apps/foundation/lib/foundation/notifications/adapter.ex
+++ b/apps/foundation/lib/foundation/notifications/adapter.ex
@@ -41,7 +41,7 @@ defmodule Foundation.Notifications.Adapter do
   |--------------------------------|-----------------------------------------------------------------------------------------------|
   | `"crash_restart"`              | `node`, `sname`, `name`, `language`, `crash_restart_count`                                   |
   | `"deployment_started"`         | `node`, `sname`, `version`                                                                    |
-  | `"deployment_complete"`        | `node`, `sname`, `status` (`:ok`/`:error`), `message`                                        |
+  | `"deployment_complete"`        | `node`, `sname`, `status` (`:ok`/`:error`), `message`, plus `version` for a full deployment and `from_version`/`to_version` for a hot upgrade |
   | `"deployment_shutdown"`        | `node`, `sname`                                                                               |
   | `"watchdog_threshold_exceeded"`| `node`, `type`, `current_percentage`, `restart_threshold_percent`                             |
   | `"watchdog_threshold_warning"` | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |

--- a/apps/foundation/lib/foundation/notifications/slack.ex
+++ b/apps/foundation/lib/foundation/notifications/slack.ex
@@ -45,7 +45,7 @@ defmodule Foundation.Notifications.Slack do
       Crash count: *3*
 
       ✅ *deployment_complete* — `myapp-1` on `myapp@prod-1`
-      Status: *ok* — Hot upgrade applied successfully!
+      Status: *ok* — Hot upgrade applied successfully, 1.0.0 -> 1.1.0
 
   ## Supported events
 

--- a/apps/foundation/lib/foundation/notifications/webhook.ex
+++ b/apps/foundation/lib/foundation/notifications/webhook.ex
@@ -53,7 +53,7 @@ defmodule Foundation.Notifications.Webhook do
   |---------------------------------|--------------------------------------------------------------------------------------------------------|
   | `crash_restart`                 | `node`, `sname`, `name`, `language`, `crash_restart_count`                                            |
   | `deployment_started`            | `node`, `sname`, `version`                                                                             |
-  | `deployment_complete`           | `node`, `sname`, `status` (`:ok`/`:error`), `message`                                                 |
+  | `deployment_complete`           | `node`, `sname`, `status` (`:ok`/`:error`), `message`, plus `version` for a full deployment and `from_version`/`to_version` for a hot upgrade |
   | `deployment_shutdown`           | `node`, `sname`                                                                                        |
   | `watchdog_threshold_exceeded`   | `node`, `type`, `current_percentage`, `restart_threshold_percent`                                      |
   | `watchdog_threshold_warning`    | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |

--- a/apps/foundation/lib/foundation/system/finch_stream.ex
+++ b/apps/foundation/lib/foundation/system/finch_stream.ex
@@ -68,6 +68,13 @@ defmodule Foundation.System.FinchStream do
 
   require Logger
 
+  @typedoc """
+  A callback to apply, carrying the arguments to apply it with, which the stream appends to.
+
+  Not `mfa()`, whose third element is an arity rather than an argument list.
+  """
+  @type callback :: {module(), atom(), list()}
+
   @type t :: %__MODULE__{
           url: String.t() | nil,
           file_path: String.t() | nil,
@@ -76,8 +83,8 @@ defmodule Foundation.System.FinchStream do
           size: non_neg_integer() | nil,
           processed: non_neg_integer() | nil,
           file_pid: pid() | nil,
-          handle_progress: mfa() | nil,
-          handle_continue: mfa() | nil,
+          handle_progress: callback() | nil,
+          handle_continue: callback() | nil,
           error: String.t() | nil
         }
 

--- a/mix/shared.exs
+++ b/mix/shared.exs
@@ -1,5 +1,5 @@
 defmodule Mix.Shared do
-  def version, do: "0.9.12"
+  def version, do: "0.9.13-rc1"
 
   def elixir, do: "~> 1.16"
 


### PR DESCRIPTION
## Problem

Deployment notifications did not say which version they were about, and the engine worker announced a full deployment for anything that reported itself running.

```
✅ deployment_complete — deployex on deployex@prod-1
Status: ok — Hot upgrade applied successfully!

✅ deployment_complete — myapp-63wu32 on myapp@prod-1
Status: ok — Full deployment applied successfully!
```

Neither names a version, and the second one is sent **after a successful hot upgrade**, so it is duplicated and wrong about what happened.

## 1. Name the versions

```
Hot upgrade applied successfully, 0.9.12 -> 0.9.13
Hot upgrade 0.9.12 -> 0.9.13 failed: {:error, :make_relup}
Full deployment applied successfully, version 1.1.0
```

The versions were already in the `Execute` struct at every call site, so the two hot upgrade notifiers take that struct instead of only the `sname`.

They go on the **message** rather than only on the payload. `Foundation.Notifications.Slack` renders `payload.message` for `deployment_complete`, so putting them there means Slack, webhook and PagerDuty all report them with no adapter change, and the same text reaches the progress modal through the existing broadcast.

The payload carries them as structured data too, for adapters that forward it: `from_version` and `to_version` on a hot upgrade, `version` on a full deployment. The keys are per variant, so the three tables documenting the event now say so, since an adapter reading `payload.from_version` unconditionally would fail on a full deployment. Those tables also described the trigger as a hot upgrade, when a full deployment, a DeployEx shutdown and a DeployexWeb startup emit it as well.

## 2. Report a deployment only when one has finished

`Engine.Worker` announced `Full deployment applied successfully!` from its `:application_running` handler, whatever had put the application there.

A hot upgrade of a monitored application got two notifications, the one the upgrade sent naming its versions and then this one calling it a full deployment. A crash restart got one too, and so did a restart asked for from the UI, both announcing a deployment that never happened. With `replicas: 1` a crash loop produced one successful deployment message per backoff retry, next to the `crash_restart` notification the monitor was already sending for the same crash.

`deployment_to_terminate` is set only by `full_deployment/3` and cleared as soon as the report it was waiting for arrives, so it is what says the report completes a deployment:

```elixir
if deployment_to_terminate, do: notify_deployment_complete(sname)
```

Nothing else sets it, which leaves a hot upgrade to the notification it already sent and a restart to say nothing. No new state and no new arguments threaded through the call. The version comes from the catalog, which the deployment wrote before the application reported running.

The cancelled rollback timer reference is dropped with it. It was left in the deployment after being cancelled, where it reads as a rollback window still open.

## 3. Type the callbacks as an argument list

`mix dialyzer` failed with "The function call apply will not succeed" on the after make permanent callback. `mfa()` is `{module(), atom(), arity()}`, so a value typed that way cannot be handed to `apply/3` as an argument list. Both callbacks now use a local `callback()` type, `{module(), atom(), list()}`, which is what the code has always passed. `Foundation.System.FinchStream` carried the same mistake and is corrected with it, and the hot upgrade checks in `AGENTS.md` now name the type that exists.

## Version

`0.9.13-rc1`, with a `0.9.13` section opened in the changelog.

## Risk assessment

**Impact:** one notification per deployment instead of two for a monitored application hot upgrade, nothing at all for a crash restart or a restart asked for from the UI, and every completion message names its version. No new events, no configuration change, and an installation with notifications disabled is unaffected.

**Blast radius:** the two notifiers in `Deployer.HotUpgrade.Application` with their four call sites, the application running handler in `Deployer.Engine.Worker`, and the moduledoc tables in `Foundation.Notifications`, its `Adapter` and the `Webhook` adapter. The upgrade sequence, the deployment flow and the rollback are untouched, and the type changes are declarations only.

**Regression risk:** low. The notifiers move from taking a string to taking the struct the call sites already held, the worker reads state the deployment had already set, and the payload gains keys no adapter is required to read. An operator who used the old message as a restart signal loses it, which is what the `crash_restart` event is for.

**Rollback:** plain commit revert.

## Tests

- existing broadcast assertions now carry the versions, which is what proves the text reaching Slack changed
- a new hot upgrade test subscribes to the notifications topic and asserts the message plus both payload keys
- three engine tests, one asserting the message and payload of a finished deployment, one asserting a report with no deployment waiting for it sends nothing, one asserting the same deployment is not reported twice

The three engine tests fail against the previous implementation, verified by running them against it. Full suite green, `mix format --check-formatted` and `mix credo --strict` clean, built and verified at `0.9.13-rc1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
