### PR TITLE
fix(deployer): mark a deployment in flight explicitly instead of inferring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
  * [`PULL-288`](https://github.com/thiagoesteves/deployex/pull/288) Report a deployment as complete only when one has finished, not on a hot upgrade or an application restart
+ * [`PULL-289`](https://github.com/thiagoesteves/deployex/pull/289) Mark a deployment in flight explicitly instead of inferring it, so the completion notification is not missed
 
 ### Enhancements
  * [`PULL-288`](https://github.com/thiagoesteves/deployex/pull/288) Report the versions a hot upgrade moved between in the completion notification

--- a/apps/deployer/lib/deployer/engine/deployment.ex
+++ b/apps/deployer/lib/deployer/engine/deployment.ex
@@ -2,11 +2,17 @@ defmodule Deployer.Engine.Deployment do
   @moduledoc """
   Structure to handle the deployment structure
   """
+  @typedoc """
+  `deploying?` says the worker put a version into service and is waiting for the
+  application to report it running, which is what completes a deployment. It is set
+  together with the rollback timer and cleared by the report that closes it.
+  """
   @type t :: %__MODULE__{
           state: :init | :active,
           timer_ref: reference() | nil,
           sname: String.t() | nil,
-          ports: list()
+          ports: list(),
+          deploying?: boolean()
         }
 
   @derive Jason.Encoder
@@ -14,5 +20,6 @@ defmodule Deployer.Engine.Deployment do
   defstruct state: :init,
             timer_ref: nil,
             sname: nil,
-            ports: []
+            ports: [],
+            deploying?: false
 end

--- a/apps/deployer/lib/deployer/engine/worker.ex
+++ b/apps/deployer/lib/deployer/engine/worker.ex
@@ -312,12 +312,12 @@ defmodule Deployer.Engine.Worker do
         #       reports running right after an engine worker restart
         if current_deployment.timer_ref, do: Process.cancel_timer(current_deployment.timer_ref)
 
-        # Only a full deployment sets deployment_to_terminate, and it is cleared as soon as
-        # the report it was waiting for arrives, so it is what says this report completes a
-        # deployment. Everything else that reports running, a crash restart, a restart asked
-        # for from the UI, or a hot upgrade that has already reported itself with the
-        # versions it moved between, is not a deployment and is not announced as one
-        if deployment_to_terminate, do: notify_deployment_complete(sname)
+        # deploying? is set where a version is put into service, by a full deployment and by
+        # the start up path, so it is what says this report completes one. Everything else
+        # that reports running, a crash restart, a restart asked for from the UI, or a hot
+        # upgrade that has already reported itself with the versions it moved between,
+        # finds it false and is not announced as a deployment
+        if current_deployment.deploying?, do: notify_deployment_complete(sname)
 
         new_instance =
           if state.current == state.replicas, do: 1, else: state.current + 1
@@ -334,10 +334,15 @@ defmodule Deployer.Engine.Worker do
 
         Logger.info(" # Moving to the next instance: #{new_instance}")
 
-        # The timer was cancelled above, so the reference goes with it, otherwise the
-        # deployment keeps one that reads as a rollback window still open
+        # This report closed the window: the timer was cancelled above and the flag goes
+        # with it, so a later report for the same deployment, e.g. after a crash restart,
+        # is not taken for another one
         deployments =
-          Map.put(state.deployments, state.current, %{current_deployment | timer_ref: nil})
+          Map.put(state.deployments, state.current, %{
+            current_deployment
+            | timer_ref: nil,
+              deploying?: false
+          })
 
         %{
           state
@@ -355,6 +360,20 @@ defmodule Deployer.Engine.Worker do
       end
 
     {:noreply, state}
+  end
+
+  # A deployment held in state was built by the version running before the hot upgrade, so
+  # it is a map without the deploying? key, and a struct default only applies to a struct
+  # being built. Rebuilding them through struct/2 fills it in, and false is the right value
+  # for anything already in service, the report that would have closed its window is gone
+  @impl true
+  def code_change(_old_vsn, %__MODULE__{} = state, _extra) do
+    deployments =
+      Map.new(state.deployments, fn {instance, deployment} ->
+        {instance, struct(Engine.Deployment, Map.from_struct(deployment))}
+      end)
+
+    {:ok, %{state | deployments: deployments}}
   end
 
   ### ==========================================================================
@@ -562,7 +581,8 @@ defmodule Deployer.Engine.Worker do
         current_deployment
         | timer_ref: timer_ref,
           sname: sname,
-          ports: ports
+          ports: ports,
+          deploying?: true
       })
 
     %{state | deployments: deployments}
@@ -735,7 +755,13 @@ defmodule Deployer.Engine.Worker do
 
       full_deployment(state, new_sname, release)
     else
-      state
+      # The upgrade reported itself with the versions it moved between, and the sname it
+      # ran on keeps running. A window left open on this instance, e.g. by a start up whose
+      # monitor was already running, would otherwise turn the report the upgrade triggers
+      # into a full deployment of this version
+      current_deployment = %{state.deployments[state.current] | deploying?: false}
+
+      %{state | deployments: Map.put(state.deployments, state.current, current_deployment)}
     end
   end
 

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -1074,7 +1074,7 @@ defmodule Deployer.EngineTest do
       subscribe_to_deployment_complete()
 
       pid = start_worker(name)
-      running_deployment(pid, sname, deploying?: true)
+      running_deployment(pid, sname, deploying?: true, terminating?: true)
 
       GenServer.cast(pid, {:application_running, sname})
 
@@ -1087,7 +1087,7 @@ defmodule Deployer.EngineTest do
     end
 
     @tag :capture_log
-    test "a report that does not complete a deployment is not announced as one" do
+    test "a version put into service at start up is reported as well" do
       name = "myelixir"
       sname = Catalog.create_sname(name)
 
@@ -1098,14 +1098,128 @@ defmodule Deployer.EngineTest do
       subscribe_to_deployment_complete()
 
       pid = start_worker(name)
-      running_deployment(pid, sname, deploying?: false)
+
+      # initialize_version/1 puts a version into service without a previous deployment to
+      # terminate, so the flag is set and there is nothing to stop afterwards
+      running_deployment(pid, sname, deploying?: true, terminating?: false)
+
+      GenServer.cast(pid, {:application_running, sname})
+
+      assert_receive {"deployment_complete", payload}, 1_000
+      assert payload.message == "Full deployment applied successfully, version 1.1.0"
+    end
+
+    @tag :capture_log
+    test "a report with nothing waiting for it is not announced as a deployment" do
+      name = "myelixir"
+      sname = Catalog.create_sname(name)
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [] end)
+      |> stub(:current_version, fn ^sname -> "1.1.0" end)
+
+      subscribe_to_deployment_complete()
+
+      pid = start_worker(name)
+      running_deployment(pid, sname, deploying?: false, terminating?: false)
 
       GenServer.cast(pid, {:application_running, sname})
 
       # a crash restart, a restart asked for from the UI and a hot upgrade all report an
-      # application running without a deployment waiting for it, and the hot upgrade has
-      # already sent its own notification with the versions it moved between
+      # application running with nothing waiting for it, and the hot upgrade has already
+      # sent its own notification with the versions it moved between
       refute_receive {"deployment_complete", _payload}, 300
+    end
+
+    @tag :capture_log
+    test "a hot upgrade does not close a window the start up left open" do
+      # Monitors live in a separate supervision tree, so an engine worker restart arms the
+      # rollback window for an application whose monitor is already running and will not
+      # report it running again. The hot upgrade that follows must not take that window
+      name = "myelixir"
+      sname = Catalog.create_sname(name)
+      FixtureFiles.create_bin_files(sname)
+
+      from_version = "1.0.0"
+      to_version = "2.0.0"
+      ref = make_ref()
+      test_pid = self()
+
+      Deployer.StatusMock
+      |> expect(:list_installed_apps, fn _name -> [sname] end)
+      |> expect(:history_version_list, fn _name, _options ->
+        [%Catalog.Version{version: from_version}]
+      end)
+      |> stub(:current_version, fn _sname ->
+        # 0 -> initialize_version, 1 -> check_deployment, 2 -> hot upgrade,
+        # 3 -> the upgrade result, which is what says the upgrade succeeded
+        called = Process.get("current_version", 0)
+        Process.put("current_version", called + 1)
+
+        if called > 2, do: to_version, else: from_version
+      end)
+      |> stub(:update, fn _sname -> :ok end)
+      |> expect(:set_current_version_map, 1, fn _sname, _release, deployment: :hot_upgrade ->
+        send(test_pid, {:handle_ref_event, ref})
+        :ok
+      end)
+
+      Deployer.MonitorMock
+      |> expect(:start_service, 1, fn %{sname: ^sname} -> {:error, {:already_started, self()}} end)
+      |> expect(:run_pre_commands, 1, fn _sname, _release, :new -> {:ok, []} end)
+
+      Deployer.ReleaseMock
+      |> stub(:download_version_map, fn _app_name ->
+        %{version: to_version, hash: "local", pre_commands: []}
+      end)
+      |> expect(:download_release, 1, fn _app_name, ^to_version, _download_path -> :ok end)
+
+      Deployer.HotUpgradeMock
+      |> stub(:prepare_new_path, fn _name, _language, _to_version, _new_path -> :ok end)
+      |> expect(:check, 1, fn check -> {:ok, %{check | deploy: :hot_upgrade}} end)
+      |> expect(:execute, 1, fn %Deployer.HotUpgrade.Execute{to_version: ^to_version} -> :ok end)
+
+      subscribe_to_deployment_complete()
+
+      with_mock System, [:passthrough],
+        cmd: fn "tar", ["-x", "-f", _source_path, "-C", _dest_path] -> {"", 0} end do
+        assert {:ok, pid} =
+                 Engine.Worker.start_link(%Engine.Worker{
+                   deploy_rollback_timeout_ms: 60_000,
+                   deploy_schedule_interval_ms: 100,
+                   name: name,
+                   language: "elixir"
+                 })
+
+        assert_receive {:handle_ref_event, ^ref}, 1_000
+
+        # the upgrade reported itself with the versions it moved between, and the window
+        # the start up left open must not turn the report it triggers into a full
+        # deployment of 2.0.0
+        refute_receive {"deployment_complete", _payload}, 300
+      end
+    end
+
+    test "code_change/3 fills the flag in for a deployment built by the previous version" do
+      # the previous version had no deploying? key at all, a struct default only applies to
+      # a struct being built
+      previous_version_deployment =
+        Map.delete(
+          %Deployer.Engine.Deployment{sname: "myelixir-1234", state: :active, ports: [4000]},
+          :deploying?
+        )
+
+      state = %Engine.Worker{deployments: %{1 => previous_version_deployment}}
+
+      assert {:ok, %Engine.Worker{deployments: %{1 => deployment}}} =
+               Engine.Worker.code_change("0.9.13", state, [])
+
+      assert %Deployer.Engine.Deployment{
+               sname: "myelixir-1234",
+               state: :active,
+               ports: [4000],
+               deploying?: false
+             } = deployment
     end
 
     @tag :capture_log
@@ -1123,7 +1237,7 @@ defmodule Deployer.EngineTest do
       subscribe_to_deployment_complete()
 
       pid = start_worker(name)
-      running_deployment(pid, sname, deploying?: true)
+      running_deployment(pid, sname, deploying?: true, terminating?: true)
 
       GenServer.cast(pid, {:application_running, sname})
       assert_receive {"deployment_complete", _payload}, 1_000
@@ -1133,7 +1247,8 @@ defmodule Deployer.EngineTest do
       GenServer.cast(pid, {:application_running, sname})
       refute_receive {"deployment_complete", _payload}, 300
 
-      assert %Deployer.Engine.Deployment{timer_ref: nil} = :sys.get_state(pid).deployments[1]
+      assert %Deployer.Engine.Deployment{timer_ref: nil, deploying?: false} =
+               :sys.get_state(pid).deployments[1]
     end
 
     defp subscribe_to_deployment_complete do
@@ -1155,22 +1270,22 @@ defmodule Deployer.EngineTest do
       pid
     end
 
-    # deployment_to_terminate is what the worker sets when it starts a full deployment and
-    # clears when the report it is waiting for arrives, so it is what tells a deployment
-    # apart from an application that is only reporting itself running again
-    defp running_deployment(pid, sname, deploying?: deploying?) do
+    # deploying? is set where a version is put into service, and a full deployment is the
+    # case that also leaves a previous deployment waiting to be terminated
+    defp running_deployment(pid, sname, deploying?: deploying?, terminating?: terminating?) do
       :sys.replace_state(pid, fn state ->
         deployment = %{
           state.deployments[state.current]
           | sname: sname,
             state: :active,
-            timer_ref: Process.send_after(pid, :ignored, 60_000)
+            timer_ref: Process.send_after(pid, :ignored, 60_000),
+            deploying?: deploying?
         }
 
         %{
           state
           | deployments: Map.put(state.deployments, state.current, deployment),
-            deployment_to_terminate: if(deploying?, do: %Deployer.Engine.Deployment{})
+            deployment_to_terminate: if(terminating?, do: %Deployer.Engine.Deployment{})
         }
       end)
     end

--- a/apps/deployer/test/engine_test.exs
+++ b/apps/deployer/test/engine_test.exs
@@ -1183,7 +1183,7 @@ defmodule Deployer.EngineTest do
 
       with_mock System, [:passthrough],
         cmd: fn "tar", ["-x", "-f", _source_path, "-C", _dest_path] -> {"", 0} end do
-        assert {:ok, pid} =
+        assert {:ok, _pid} =
                  Engine.Worker.start_link(%Engine.Worker{
                    deploy_rollback_timeout_ms: 60_000,
                    deploy_schedule_interval_ms: 100,

--- a/apps/deployer/test/hot_upgrade/deployex_test.exs
+++ b/apps/deployer/test/hot_upgrade/deployex_test.exs
@@ -99,6 +99,7 @@ defmodule Deployer.HotUpgrade.DeployexTest do
            end) =~ "Hot upgrade not supported for this release"
   end
 
+  @tag :capture_log
   test "check/1 invalid hotupgrade" do
     Host.CommanderMock
     |> expect(:run, fn _command, _options -> {:ok, []} end)

--- a/apps/deployer/test/hot_upgrade/upgrade_test.exs
+++ b/apps/deployer/test/hot_upgrade/upgrade_test.exs
@@ -1458,6 +1458,7 @@ defmodule Deployer.HotUpgrade.ApplicationTest do
     assert pid == Process.whereis(UpgradeApp)
   end
 
+  @tag :capture_log
   test "execute/5 Elixir Deployex success sync operation, make_permanent_async=true", %{
     current_path: current_path,
     new_path: new_path,


### PR DESCRIPTION
## Problem

The completion notification added in #288 is gated on `deployment_to_terminate`, chosen because only `full_deployment/3` sets it. Tested on a real installation, the message did not arrive.

`deployment_to_terminate` correlates with a deployment being in flight, it does not state one. Two cases where it is nil while a version really was put into service:

- `initialize_version/1` starts an application at boot and arms the rollback window without any previous deployment to terminate
- `do_restart_deployments/1`, which runs when a `deployex.yaml` change or a replica port change is applied, rebuilds the deployments and clears the marker mid-flight

## The flag

`Engine.Deployment` carries `deploying?`, set in `set_timeout_to_rollback/3`, the one place a version is put into service, reached by a full deployment and by the start up path, and cleared by the report that closes the window:

```elixir
if current_deployment.deploying?, do: notify_deployment_complete(sname)
```

Being explicit also allows it to be turned **off** where it does not apply, which no inferred marker can do. A start up whose monitor was already running, the engine worker restart case, arms a window that no report will ever close. The hot upgrade that follows would take that window and announce itself as a full deployment of the version it upgraded to. `handle_hot_upgrade_result/5` clears the flag when the upgrade succeeds, so what happened is stated rather than inferred.

## Hot upgrade

`Engine.Deployment` backs the worker's GenServer state, which is check 5 of the list in `AGENTS.md`. A deployment built before the upgrade reaches the new code without the key, since a struct default only applies to a struct being built, and `deployment.deploying?` would raise `KeyError`.

`Deployer.Engine.Worker.code_change/3` rebuilds each one through `struct/2`, filling in `false`, which is right for anything already in service, the report that would have closed its window is gone. The generated appup already updates this module as `{advanced,[]}`, which is the instruction that calls `code_change/3`, verified in `apps/deployer/rel/appups/deployer/0.9.12_to_0.9.13-rc1.appup`. Hot upgrade into this release stays supported.

## Risk assessment

**Impact:** the completion notification arrives for a deployment and for an application put into service at start up, and is silent for a crash restart, a restart asked for from the UI and a hot upgrade.

**Blast radius:** `Deployer.Engine.Deployment` gains a field, and in `Deployer.Engine.Worker` the rollback arming, the application running handler and the hot upgrade result. The deployment flow and the rollback itself are untouched.

**Regression risk:** low. The flag is written where the window is opened and read where it is closed, and `code_change/3` covers the state that crosses a hot upgrade.

**Rollback:** plain commit revert.

## Tests

Six engine tests: a deployment, a version put into service at start up, a report with nothing waiting for it, a deployment reported once only, a hot upgrade that must not take a window the start up left open, and `code_change/3` filling the flag in for a deployment built by the previous version.

The hot upgrade one reproduces the case the flag exists for, an already running monitor at start up followed by an upgrade, and fails on every seed without the clearing. `mix format --check-formatted` and `mix credo --strict` clean, deployer, foundation and deployex_web suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
