### PR TITLE
feat(sentinel): report the critical level whether or not the restart is enabled

### DIFF
--- a/apps/deployex_web/lib/deployex_web/live/terminal/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/terminal/index.ex
@@ -114,7 +114,14 @@ defmodule DeployexWeb.TerminalLive do
      |> push_event("print-host-shell-#{socket.assigns.id}", %{data: message})}
   end
 
+  # NOTE: The terminal server opens the connection in a continue, so the page is rendered before
+  #       the process it writes to is known. A key pressed inside that window is dropped, sending
+  #       it to a process that does not exist yet takes the whole terminal down
   @impl true
+  def handle_event("key", _params, %{assigns: %{terminal_process: nil}} = socket) do
+    {:noreply, socket}
+  end
+
   def handle_event(
         "key",
         %{"key" => key},

--- a/apps/deployex_web/test/deployex_web/live/terminal/index_test.exs
+++ b/apps/deployex_web/test/deployex_web/live/terminal/index_test.exs
@@ -66,6 +66,10 @@ defmodule DeployexWeb.Terminal.IndexTest do
     with_mock Foundation.Common, random_number: fn _from, _to -> 1 end do
       {:ok, index_live, _html} = live(conn, ~p"/terminal")
 
+      # NOTE: The key only reaches the terminal once the LiveView knows the process to write to,
+      #       and that is reported after the connection is open
+      FixtureTerminal.wait_for_connection()
+
       # NOTE: Force handle_event in the live component
       index_live
       |> element("#host-shell-1")

--- a/apps/foundation/lib/foundation/notifications.ex
+++ b/apps/foundation/lib/foundation/notifications.ex
@@ -21,7 +21,7 @@ defmodule Foundation.Notifications do
   | `"deployment_started"`            | New deployment was initiated for an sname                  | `node`, `sname`, `version`                                                  |
   | `"deployment_complete"`           | Full deployment or hot upgrade finished (success or failure)| `node`, `sname`, `status` (`:ok`/`:error`), `message`, plus `version` for a full deployment and `from_version`/`to_version` for a hot upgrade |
   | `"application_ready"`             | Monitored application reported itself running, whatever put it there | `node`, `sname`, `version`                                       |
-  | `"watchdog_threshold_exceeded"`   | Watchdog exceeded a resource threshold and restarted an app| `node`, `type`, `current_percentage`, `restart_threshold_percent`          |
+  | `"watchdog_threshold_exceeded"`   | Resource reached the restart threshold, restarted or not   | `node`, `type`, `current_percentage`, `restart_threshold_percent`, `action` (`:restart`/`:no_restart`) |
   | `"watchdog_threshold_warning"`    | Resource crossed the warning threshold (or returned below) | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
   | `"certificate_renewed"`           | TLS certificate was successfully renewed                   | `app_name`, `domains`                                                       |
   | `"certificate_valid"`             | Periodic check found a still-valid certificate (no renewal)| `app_name`, `domains`                                                       |

--- a/apps/foundation/lib/foundation/notifications/adapter.ex
+++ b/apps/foundation/lib/foundation/notifications/adapter.ex
@@ -44,7 +44,7 @@ defmodule Foundation.Notifications.Adapter do
   | `"deployment_complete"`        | `node`, `sname`, `status` (`:ok`/`:error`), `message`, plus `version` for a full deployment and `from_version`/`to_version` for a hot upgrade |
   | `"application_ready"`          | `node`, `sname`, `version`                                                                    |
   | `"deployment_shutdown"`        | `node`, `sname`                                                                               |
-  | `"watchdog_threshold_exceeded"`| `node`, `type`, `current_percentage`, `restart_threshold_percent`                             |
+  | `"watchdog_threshold_exceeded"`| `node`, `type`, `current_percentage`, `restart_threshold_percent`, `action` (`:restart`/`:no_restart`) |
   | `"watchdog_threshold_warning"` | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
   | `"certificate_renewed"`        | `app_name`, `domains`                                                                         |
   | `"certificate_valid"`          | `app_name`, `domains`                                                                         |

--- a/apps/foundation/lib/foundation/notifications/pagerduty.ex
+++ b/apps/foundation/lib/foundation/notifications/pagerduty.ex
@@ -136,6 +136,10 @@ defmodule Foundation.Notifications.PagerDuty do
   defp format_summary("application_ready", payload),
     do: "application_ready — #{payload.sname} on #{payload.node} (version #{payload.version})"
 
+  defp format_summary("watchdog_threshold_exceeded", %{action: :no_restart} = payload),
+    do:
+      "watchdog_threshold_exceeded — #{payload.type} at #{payload.current_percentage}% on #{payload.node} (restart disabled)"
+
   defp format_summary("watchdog_threshold_exceeded", payload),
     do:
       "watchdog_threshold_exceeded — #{payload.type} at #{payload.current_percentage}% on #{payload.node}"

--- a/apps/foundation/lib/foundation/notifications/slack.ex
+++ b/apps/foundation/lib/foundation/notifications/slack.ex
@@ -57,7 +57,7 @@ defmodule Foundation.Notifications.Slack do
   | `deployment_complete` (error)   | ❌    | Deployment finished with error                        |
   | `application_ready`             | 🟢    | App reported itself running, whatever put it there    |
   | `deployment_shutdown`           | 🛑    | App force-terminated (will restart shortly)           |
-  | `watchdog_threshold_exceeded`   | ⚠️    | Resource threshold crossed; app restarted             |
+  | `watchdog_threshold_exceeded`   | ⚠️    | Restart threshold reached, restarted or not           |
   | `watchdog_threshold_warning`    | 🔶/✅ | Resource crossed warning threshold or normalized      |
   | `certificate_renewed`           | 🔒    | TLS certificate successfully renewed                  |
   | `certificate_failed`            | 🔓    | TLS certificate renewal failed                        |
@@ -150,6 +150,13 @@ defmodule Foundation.Notifications.Slack do
     """
     🟢 *application_ready* — `#{payload.sname}` on `#{payload.node}`
     Version: *#{payload.version}*\
+    """
+  end
+
+  defp format_message("watchdog_threshold_exceeded", %{action: :no_restart} = payload) do
+    """
+    ⚠️ *watchdog_threshold_exceeded* — `#{payload.node}`, restart is disabled
+    Resource: *#{payload.type}* at *#{payload.current_percentage}%* (threshold: #{payload.restart_threshold_percent}%)\
     """
   end
 

--- a/apps/foundation/lib/foundation/notifications/webhook.ex
+++ b/apps/foundation/lib/foundation/notifications/webhook.ex
@@ -56,7 +56,7 @@ defmodule Foundation.Notifications.Webhook do
   | `deployment_complete`           | `node`, `sname`, `status` (`:ok`/`:error`), `message`, plus `version` for a full deployment and `from_version`/`to_version` for a hot upgrade |
   | `application_ready`             | `node`, `sname`, `version`                                                                             |
   | `deployment_shutdown`           | `node`, `sname`                                                                                        |
-  | `watchdog_threshold_exceeded`   | `node`, `type`, `current_percentage`, `restart_threshold_percent`                                      |
+  | `watchdog_threshold_exceeded`   | `node`, `type`, `current_percentage`, `restart_threshold_percent`, `action` (`:restart`/`:no_restart`) |
   | `watchdog_threshold_warning`    | `node`, `type`, `current_percentage`, `warning_threshold_percent`, `action` (`:warning`/`:normalized`) |
   | `certificate_renewed`           | `app_name`, `domains`                                                                                  |
   | `certificate_failed`            | `app_name`, `domains`, `reason`                                                                        |

--- a/apps/foundation/test/catalog/catalog_test.exs
+++ b/apps/foundation/test/catalog/catalog_test.exs
@@ -1,5 +1,8 @@
 defmodule Foundation.CatalogTest do
-  use ExUnit.Case, async: true
+  # NOTE: The setup wipes var_path, a directory the whole suite shares, so this module cannot run
+  #       next to the async ones. Removing it while Foundation.CatalogExDocTest walks the same
+  #       tree makes its mkdir_p fail with :enotdir
+  use ExUnit.Case, async: false
 
   alias Foundation.Accounts.UserToken
   alias Foundation.Catalog

--- a/apps/foundation/test/notifications/pagerduty_test.exs
+++ b/apps/foundation/test/notifications/pagerduty_test.exs
@@ -166,8 +166,21 @@ defmodule Foundation.Notifications.PagerDutyTest do
         {"application_ready", %{node: :n@h, sname: "s", version: "1.0"}, "info"},
         {"deployment_shutdown", %{node: :n@h, sname: "s"}, "warning"},
         {"watchdog_threshold_exceeded",
-         %{node: :n@h, type: :memory, current_percentage: 96, restart_threshold_percent: 95},
-         "critical"},
+         %{
+           node: :n@h,
+           type: :memory,
+           current_percentage: 96,
+           restart_threshold_percent: 95,
+           action: :restart
+         }, "critical"},
+        {"watchdog_threshold_exceeded",
+         %{
+           node: :n@h,
+           type: :atom,
+           current_percentage: 96,
+           restart_threshold_percent: 95,
+           action: :no_restart
+         }, "critical"},
         {"watchdog_threshold_warning",
          %{
            node: :n@h,

--- a/apps/foundation/test/notifications/slack_test.exs
+++ b/apps/foundation/test/notifications/slack_test.exs
@@ -141,7 +141,21 @@ defmodule Foundation.Notifications.SlackTest do
         {"application_ready", %{node: :n@h, sname: "s-1", version: "1.0.0"}},
         {"deployment_shutdown", %{node: :n@h, sname: "s-1"}},
         {"watchdog_threshold_exceeded",
-         %{node: :n@h, type: :memory, current_percentage: 96, restart_threshold_percent: 95}},
+         %{
+           node: :n@h,
+           type: :memory,
+           current_percentage: 96,
+           restart_threshold_percent: 95,
+           action: :restart
+         }},
+        {"watchdog_threshold_exceeded",
+         %{
+           node: :n@h,
+           type: :atom,
+           current_percentage: 96,
+           restart_threshold_percent: 95,
+           action: :no_restart
+         }},
         {"watchdog_threshold_warning",
          %{
            node: :n@h,

--- a/apps/host/test/support/terminal.ex
+++ b/apps/host/test/support/terminal.ex
@@ -5,6 +5,17 @@ defmodule Host.Fixture.Terminal do
 
   alias Host.Terminal
 
+  @doc """
+  Waits until every terminal server has opened its connection and notified its target.
+
+  The connection is opened in a continue, after `Host.Terminal.new/1` has returned, so a test
+  that acts on the terminal right after it is created may reach it before it is connected.
+  """
+  def wait_for_connection do
+    Supervisor.which_children(Terminal.Supervisor)
+    |> Enum.each(fn {_id, child, _type, _modules} -> :sys.get_state(child) end)
+  end
+
   def terminate_all do
     Supervisor.which_children(Terminal.Supervisor)
     |> Enum.each(fn {_id, child, _type, _modules} ->

--- a/apps/sentinel/lib/sentinel/watchdog/watchdog.ex
+++ b/apps/sentinel/lib/sentinel/watchdog/watchdog.ex
@@ -26,17 +26,19 @@ defmodule Sentinel.Watchdog do
   @deployex_terminate_delay :timer.seconds(3)
   @watchdog_data :deployex_watchdog_data
 
+  @type level :: :ok | :warning | :critical
+
   @type t :: %__MODULE__{
           enabled: boolean(),
           enable_restart: boolean(),
-          warning_log_flag: boolean(),
+          level: level(),
           warning_threshold_percent: nil | non_neg_integer(),
           restart_threshold_percent: nil | non_neg_integer()
         }
 
   defstruct enabled: true,
             enable_restart: true,
-            warning_log_flag: false,
+            level: :ok,
             warning_threshold_percent: 75,
             restart_threshold_percent: 90
 
@@ -133,9 +135,16 @@ defmodule Sentinel.Watchdog do
       Enum.each(@monitored_app_limits, fn type ->
         config = get_app_config(node, type)
 
-        with_percentage(config, get_app_data(node, type), fn current_percentage ->
-          threshold_check_monitored_apps_limits(node, type, current_percentage, config)
-        end)
+        resource = %{
+          owner: node,
+          type: type,
+          label: "[#{node}] #{type}",
+          node: node,
+          repeat_restart: true,
+          restart: fn -> restart_application(node) end
+        }
+
+        with_percentage(config, get_app_data(node, type), &check_level(resource, config, &1))
       end)
     end
 
@@ -145,9 +154,16 @@ defmodule Sentinel.Watchdog do
 
       config = get_deployex_config(:memory)
 
-      with_percentage(config, get_deployex_data(:memory), fn current_percentage ->
-        threshold_check_deployex_memory(top_consumer_node, current_percentage, config)
-      end)
+      resource = %{
+        owner: :deployex,
+        type: :memory,
+        label: "Total Memory",
+        node: Node.self(),
+        repeat_restart: true,
+        restart: fn -> restart_top_memory_consumer(top_consumer_node) end
+      }
+
+      with_percentage(config, get_deployex_data(:memory), &check_level(resource, config, &1))
     end
 
     # A restart tears down the whole node, so the first resource asking for one ends the sweep
@@ -155,15 +171,17 @@ defmodule Sentinel.Watchdog do
       Enum.find(@deployex_limits, fn type ->
         config = get_deployex_config(type)
 
+        resource = %{
+          owner: :deployex,
+          type: type,
+          label: "[deployex] #{type}",
+          node: Node.self(),
+          repeat_restart: false,
+          restart: fn -> terminate_deployex(deployex_terminate_delay) end
+        }
+
         :restarting ==
-          with_percentage(config, get_deployex_data(type), fn current_percentage ->
-            threshold_check_deployex_limits(
-              type,
-              current_percentage,
-              config,
-              deployex_terminate_delay
-            )
-          end)
+          with_percentage(config, get_deployex_data(type), &check_level(resource, config, &1))
       end)
     end
 
@@ -405,266 +423,143 @@ defmodule Sentinel.Watchdog do
     :ok
   end
 
-  defp threshold_check_monitored_apps_limits(
-         node,
-         type,
-         current_percentage,
-         %{
-           enable_restart: true,
-           restart_threshold_percent: restart_threshold_percent
-         }
-       )
-       when current_percentage > restart_threshold_percent do
+  # Every resource is watched through the level its usage falls into. Reporting follows the
+  # changes of level, a resource sitting above a threshold repeats neither its log line nor its
+  # notification, and a resource that crosses both thresholds at once is reported for the level
+  # it actually reached. Restarting follows the level itself, see restart_on_level/4
+  defp check_level(resource, config, current_percentage) do
+    level = current_level(current_percentage, config)
+    level_changed? = level != config.level
+
+    if level_changed? do
+      :ets.insert(
+        @watchdog_data,
+        {{resource.owner, :config, resource.type}, %{config | level: level}}
+      )
+
+      report_level(level, resource, config, current_percentage)
+    end
+
+    restart_on_level(level, level_changed?, resource, config)
+  end
+
+  # A resource that stays critical is restarted on every check, the usage only comes down once the
+  # right application has gone away and the next check picks the next candidate. Terminating
+  # DeployEx is the exception, it happens once, the node is already on its way down and repeating
+  # it would only re-announce the same shutdown
+  defp restart_on_level(
+         :critical,
+         _level_changed?,
+         %{repeat_restart: true} = resource,
+         %{enable_restart: true}
+       ),
+       do: resource.restart.()
+
+  defp restart_on_level(:critical, true, resource, %{enable_restart: true}),
+    do: resource.restart.()
+
+  defp restart_on_level(_level, _level_changed?, _resource, _config), do: :ok
+
+  defp current_level(current_percentage, %{
+         warning_threshold_percent: warning_threshold_percent,
+         restart_threshold_percent: restart_threshold_percent
+       }) do
+    cond do
+      current_percentage >= restart_threshold_percent -> :critical
+      current_percentage >= warning_threshold_percent -> :warning
+      true -> :ok
+    end
+  end
+
+  # NOTE: enable_restart decides what DeployEx is allowed to do about a resource, not whether the
+  #       resource is worth reporting, so reaching the restart threshold is announced either way
+  defp report_level(:critical, resource, %{enable_restart: true} = config, current_percentage) do
     Logger.error(
-      "[#{node}] #{type} threshold exceeded: current #{current_percentage}% > restart #{restart_threshold_percent}%. Initiating restart..."
+      "#{resource.label} threshold exceeded: current #{current_percentage}% >= restart #{config.restart_threshold_percent}%. Initiating restart..."
     )
 
+    notify_threshold_exceeded(resource, config, current_percentage, :restart)
+
+    :ok
+  end
+
+  defp report_level(:critical, resource, config, current_percentage) do
+    Logger.error(
+      "#{resource.label} threshold exceeded: current #{current_percentage}% >= restart #{config.restart_threshold_percent}%. Restart is disabled, no action taken."
+    )
+
+    notify_threshold_exceeded(resource, config, current_percentage, :no_restart)
+
+    :ok
+  end
+
+  defp report_level(:warning, resource, config, current_percentage) do
+    Logger.warning(
+      "#{resource.label} threshold exceeded: current #{current_percentage}% >= warning #{config.warning_threshold_percent}%."
+    )
+
+    notify_threshold_warning(resource, config, current_percentage, :warning)
+
+    :ok
+  end
+
+  defp report_level(:ok, resource, config, current_percentage) do
+    Logger.warning(
+      "#{resource.label} threshold normalized: current #{current_percentage}% < warning #{config.warning_threshold_percent}%."
+    )
+
+    notify_threshold_warning(resource, config, current_percentage, :normalized)
+
+    :ok
+  end
+
+  defp notify_threshold_exceeded(resource, config, current_percentage, action) do
+    Foundation.Notifications.notify("watchdog_threshold_exceeded", %{
+      node: resource.node,
+      type: resource.type,
+      current_percentage: current_percentage,
+      restart_threshold_percent: config.restart_threshold_percent,
+      action: action
+    })
+  end
+
+  defp notify_threshold_warning(resource, config, current_percentage, action) do
+    Foundation.Notifications.notify("watchdog_threshold_warning", %{
+      node: resource.node,
+      type: resource.type,
+      current_percentage: current_percentage,
+      warning_threshold_percent: config.warning_threshold_percent,
+      action: action
+    })
+  end
+
+  defp restart_application(node) do
     %{sname: sname} = Catalog.node_info(node)
     Monitor.restart(sname)
 
-    Foundation.Notifications.notify("watchdog_threshold_exceeded", %{
-      node: node,
-      type: type,
-      current_percentage: current_percentage,
-      restart_threshold_percent: restart_threshold_percent
-    })
+    :ok
+  end
+
+  # The host memory is exhausted by the applications DeployEx monitors, so the heaviest one is
+  # restarted. There is nothing to restart when DeployEx is not monitoring any application yet
+  defp restart_top_memory_consumer(nil) do
+    Logger.error("There is no monitored application to restart")
 
     :ok
   end
 
-  defp threshold_check_monitored_apps_limits(
-         node,
-         type,
-         current_percentage,
-         %{
-           warning_log_flag: false,
-           warning_threshold_percent: warning_threshold_percent
-         } = config
-       )
-       when current_percentage > warning_threshold_percent do
-    Logger.warning(
-      "[#{node}] #{type} threshold exceeded: current #{current_percentage}% > warning #{warning_threshold_percent}%."
-    )
+  defp restart_top_memory_consumer(node) do
+    Logger.error("Restarting #{node}, the application consuming the most memory")
 
-    Foundation.Notifications.notify("watchdog_threshold_warning", %{
-      node: node,
-      type: type,
-      current_percentage: current_percentage,
-      warning_threshold_percent: warning_threshold_percent,
-      action: :warning
-    })
-
-    # Set flag indicating that warning log was emitted
-    :ets.insert(@watchdog_data, {{node, :config, type}, %{config | warning_log_flag: true}})
-
-    :ok
+    restart_application(node)
   end
-
-  defp threshold_check_monitored_apps_limits(
-         node,
-         type,
-         current_percentage,
-         %{
-           warning_log_flag: true,
-           warning_threshold_percent: warning_threshold_percent
-         } = config
-       )
-       when current_percentage <= warning_threshold_percent do
-    Logger.warning(
-      "[#{node}] #{type} threshold normalized: current #{current_percentage}% <= warning #{warning_threshold_percent}%."
-    )
-
-    Foundation.Notifications.notify("watchdog_threshold_warning", %{
-      node: node,
-      type: type,
-      current_percentage: current_percentage,
-      warning_threshold_percent: warning_threshold_percent,
-      action: :normalized
-    })
-
-    # Reset warning log flag, current value was normalized
-    :ets.insert(@watchdog_data, {{node, :config, type}, %{config | warning_log_flag: false}})
-
-    :ok
-  end
-
-  defp threshold_check_monitored_apps_limits(_node, _type, _current_percentage, _config), do: :ok
-
-  defp threshold_check_deployex_memory(nil, _current_percentage, _config), do: :ok
-
-  defp threshold_check_deployex_memory(
-         node,
-         current_percentage,
-         %{
-           enable_restart: true,
-           restart_threshold_percent: restart_threshold_percent
-         }
-       )
-       when current_percentage > restart_threshold_percent do
-    Logger.error(
-      "Total Memory threshold exceeded: current #{current_percentage}% > restart #{restart_threshold_percent}%. Initiating restart for #{node} ..."
-    )
-
-    %{sname: sname} = Catalog.node_info(node)
-    Monitor.restart(sname)
-
-    Foundation.Notifications.notify("watchdog_threshold_exceeded", %{
-      node: node,
-      type: :memory,
-      current_percentage: current_percentage,
-      restart_threshold_percent: restart_threshold_percent
-    })
-
-    :ok
-  end
-
-  defp threshold_check_deployex_memory(
-         _node,
-         current_percentage,
-         %{
-           warning_log_flag: false,
-           warning_threshold_percent: warning_threshold_percent
-         } = config
-       )
-       when current_percentage > warning_threshold_percent do
-    Logger.warning(
-      "Total Memory threshold exceeded: current #{current_percentage}% > warning #{warning_threshold_percent}%."
-    )
-
-    Foundation.Notifications.notify("watchdog_threshold_warning", %{
-      node: node(),
-      type: :memory,
-      current_percentage: current_percentage,
-      warning_threshold_percent: warning_threshold_percent,
-      action: :warning
-    })
-
-    # Set flag indicating that warning log was emitted
-    :ets.insert(
-      @watchdog_data,
-      {{:deployex, :config, :memory}, %{config | warning_log_flag: true}}
-    )
-
-    :ok
-  end
-
-  defp threshold_check_deployex_memory(
-         _node,
-         current_percentage,
-         %{
-           warning_log_flag: true,
-           warning_threshold_percent: warning_threshold_percent
-         } = config
-       )
-       when current_percentage <= warning_threshold_percent do
-    Logger.warning(
-      "Total Memory threshold normalized: current #{current_percentage}% <= warning #{warning_threshold_percent}%."
-    )
-
-    Foundation.Notifications.notify("watchdog_threshold_warning", %{
-      node: node(),
-      type: :memory,
-      current_percentage: current_percentage,
-      warning_threshold_percent: warning_threshold_percent,
-      action: :normalized
-    })
-
-    # Reset warning log flag, current value was normalized
-    :ets.insert(
-      @watchdog_data,
-      {{:deployex, :config, :memory}, %{config | warning_log_flag: false}}
-    )
-
-    :ok
-  end
-
-  defp threshold_check_deployex_memory(_node, _current, _config), do: :ok
 
   # DeployEx exhausting its own Beam VM limits can only be cleared by restarting DeployEx itself,
   # restarting a monitored application would not release the atoms, processes or ports leaked here.
   # When installed as a systemd service the termination is followed by an automatic restart
-  defp threshold_check_deployex_limits(
-         type,
-         current_percentage,
-         %{
-           enable_restart: true,
-           restart_threshold_percent: restart_threshold_percent
-         },
-         terminate_delay
-       )
-       when current_percentage > restart_threshold_percent do
-    Logger.error(
-      "[deployex] #{type} threshold exceeded: current #{current_percentage}% > restart #{restart_threshold_percent}%. Initiating restart..."
-    )
-
-    Foundation.Notifications.notify("watchdog_threshold_exceeded", %{
-      node: Node.self(),
-      type: type,
-      current_percentage: current_percentage,
-      restart_threshold_percent: restart_threshold_percent
-    })
-
+  defp terminate_deployex(terminate_delay) do
     Deployex.force_terminate(terminate_delay)
 
     :restarting
   end
-
-  defp threshold_check_deployex_limits(
-         type,
-         current_percentage,
-         %{
-           warning_log_flag: false,
-           warning_threshold_percent: warning_threshold_percent
-         } = config,
-         _terminate_delay
-       )
-       when current_percentage > warning_threshold_percent do
-    Logger.warning(
-      "[deployex] #{type} threshold exceeded: current #{current_percentage}% > warning #{warning_threshold_percent}%."
-    )
-
-    Foundation.Notifications.notify("watchdog_threshold_warning", %{
-      node: Node.self(),
-      type: type,
-      current_percentage: current_percentage,
-      warning_threshold_percent: warning_threshold_percent,
-      action: :warning
-    })
-
-    # Set flag indicating that warning log was emitted
-    :ets.insert(@watchdog_data, {{:deployex, :config, type}, %{config | warning_log_flag: true}})
-
-    :ok
-  end
-
-  defp threshold_check_deployex_limits(
-         type,
-         current_percentage,
-         %{
-           warning_log_flag: true,
-           warning_threshold_percent: warning_threshold_percent
-         } = config,
-         _terminate_delay
-       )
-       when current_percentage <= warning_threshold_percent do
-    Logger.warning(
-      "[deployex] #{type} threshold normalized: current #{current_percentage}% <= warning #{warning_threshold_percent}%."
-    )
-
-    Foundation.Notifications.notify("watchdog_threshold_warning", %{
-      node: Node.self(),
-      type: type,
-      current_percentage: current_percentage,
-      warning_threshold_percent: warning_threshold_percent,
-      action: :normalized
-    })
-
-    # Reset warning log flag, current value was normalized
-    :ets.insert(@watchdog_data, {{:deployex, :config, type}, %{config | warning_log_flag: false}})
-
-    :ok
-  end
-
-  defp threshold_check_deployex_limits(_type, _current_percentage, _config, _terminate_delay),
-    do: :ok
 end

--- a/apps/sentinel/test/watchdog/watchdog_test.exs
+++ b/apps/sentinel/test/watchdog/watchdog_test.exs
@@ -5,6 +5,7 @@ defmodule Sentinel.Watchdog.WatchdogTest do
   import ExUnit.CaptureLog
 
   alias Foundation.Catalog
+  alias Foundation.Notifications
   alias Sentinel.Fixture.Host, as: FixtureHost
   alias Sentinel.Fixture.Telemetry, as: FixtureTelemetry
   alias Sentinel.Watchdog
@@ -254,9 +255,9 @@ defmodule Sentinel.Watchdog.WatchdogTest do
     assert message == ""
 
     # Check Alarm is clear
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :port)
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :atom)
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :process)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :port)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :atom)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :process)
   end
 
   @tag :capture_log
@@ -291,23 +292,23 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "[#{node}] port threshold exceeded: current 11% > warning 10%."
-    assert message =~ "[#{node}] atom threshold exceeded: current 11% > warning 10%."
-    assert message =~ "[#{node}] process threshold exceeded: current 11% > warning 10%."
+    assert message =~ "[#{node}] port threshold exceeded: current 11% >= warning 10%."
+    assert message =~ "[#{node}] atom threshold exceeded: current 11% >= warning 10%."
+    assert message =~ "[#{node}] process threshold exceeded: current 11% >= warning 10%."
 
     # Check Alarm raised
-    assert %{warning_log_flag: true} = Watchdog.get_app_config(node, :port)
-    assert %{warning_log_flag: true} = Watchdog.get_app_config(node, :atom)
-    assert %{warning_log_flag: true} = Watchdog.get_app_config(node, :process)
+    assert %{level: :warning} = Watchdog.get_app_config(node, :port)
+    assert %{level: :warning} = Watchdog.get_app_config(node, :atom)
+    assert %{level: :warning} = Watchdog.get_app_config(node, :process)
 
     node_statistic = %{
       total_memory: 1_000_000,
       port_limit: 1_000,
-      port_count: 100,
+      port_count: 90,
       atom_limit: 2_000,
-      atom_count: 200,
+      atom_count: 180,
       process_limit: 3_000,
-      process_count: 300
+      process_count: 270
     }
 
     FixtureTelemetry.send_update_app_message(pid, node, node_statistic)
@@ -321,13 +322,13 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "[#{node}] port threshold normalized: current 10% <= warning 10%."
-    assert message =~ "[#{node}] atom threshold normalized: current 10% <= warning 10%."
-    assert message =~ "[#{node}] process threshold normalized: current 10% <= warning 10%."
+    assert message =~ "[#{node}] port threshold normalized: current 9% < warning 10%."
+    assert message =~ "[#{node}] atom threshold normalized: current 9% < warning 10%."
+    assert message =~ "[#{node}] process threshold normalized: current 9% < warning 10%."
     # Check Alarm cleared
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :port)
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :atom)
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :process)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :port)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :atom)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :process)
   end
 
   @tag :capture_log
@@ -360,9 +361,9 @@ defmodule Sentinel.Watchdog.WatchdogTest do
     wait_message_processing(pid)
 
     # Check Alarm raised
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :port)
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :atom)
-    assert %{warning_log_flag: false} = Watchdog.get_app_config(node, :process)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :port)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :atom)
+    assert %{level: :ok} = Watchdog.get_app_config(node, :process)
   end
 
   @tag :capture_log
@@ -405,13 +406,13 @@ defmodule Sentinel.Watchdog.WatchdogTest do
       end)
 
     assert message =~
-             "[#{node}] port threshold exceeded: current 21% > restart 20%. Initiating restart..."
+             "[#{node}] port threshold exceeded: current 21% >= restart 20%. Initiating restart..."
 
     assert message =~
-             "[#{node}] atom threshold exceeded: current 21% > restart 20%. Initiating restart..."
+             "[#{node}] atom threshold exceeded: current 21% >= restart 20%. Initiating restart..."
 
     assert message =~
-             "[#{node}] process threshold exceeded: current 21% > restart 20%. Initiating restart..."
+             "[#{node}] process threshold exceeded: current 21% >= restart 20%. Initiating restart..."
 
     # Check reset after restart
     Enum.each(monitored_nodes, fn node ->
@@ -460,7 +461,7 @@ defmodule Sentinel.Watchdog.WatchdogTest do
 
   @tag :capture_log
   test "Deployex memory - No warning if the consumed memory is inside the threshold" do
-    memory_free = 900_000
+    memory_free = 910_000
     memory_total = 1_000_000
     self_node = Node.self()
 
@@ -493,7 +494,7 @@ defmodule Sentinel.Watchdog.WatchdogTest do
     assert message == ""
 
     # Check Alarm is clear
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:memory)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:memory)
   end
 
   @tag :capture_log
@@ -528,12 +529,12 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "Total Memory threshold exceeded: current 11% > warning 10%."
+    assert message =~ "Total Memory threshold exceeded: current 11% >= warning 10%."
 
     # Check Alarm is set
-    assert %{warning_log_flag: true} = Watchdog.get_deployex_config(:memory)
+    assert %{level: :warning} = Watchdog.get_deployex_config(:memory)
 
-    memory_free = 900_000
+    memory_free = 910_000
 
     FixtureHost.send_update_sys_info_message(pid, self_node, memory_free, memory_total)
 
@@ -546,10 +547,10 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "Total Memory threshold normalized: current 10% <= warning 10%."
+    assert message =~ "Total Memory threshold normalized: current 9% < warning 10%."
 
     # Check Alarm is clear
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:memory)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:memory)
   end
 
   @tag :capture_log
@@ -596,10 +597,12 @@ defmodule Sentinel.Watchdog.WatchdogTest do
       end)
 
     assert message =~
-             "Total Memory threshold exceeded: current 21% > restart 20%. Initiating restart for #{node_2} ..."
+             "Total Memory threshold exceeded: current 21% >= restart 20%. Initiating restart..."
 
-    # Check Alarm is clear after Node Down
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:memory)
+    assert message =~ "Restarting #{node_2}, the application consuming the most memory"
+
+    # The memory did not come down, the resource stays critical
+    assert %{level: :critical} = Watchdog.get_deployex_config(:memory)
 
     # Check next app available for restarting is the other node
     wait_message_processing(pid)
@@ -611,11 +614,12 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~
-             "Total Memory threshold exceeded: current 21% > restart 20%. Initiating restart for #{node_1} ..."
+    # The level has not changed, so the restart repeats without repeating the report
+    assert message =~ "Restarting #{node_1}, the application consuming the most memory"
 
-    # Check Alarm is clear after Node Down
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:memory)
+    refute message =~ "Total Memory threshold exceeded"
+
+    assert %{level: :critical} = Watchdog.get_deployex_config(:memory)
 
     # Add node_1 again
     send(pid, {:new_deploy, Node.self(), sname_1})
@@ -636,8 +640,7 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~
-             "Total Memory threshold exceeded: current 21% > restart 20%. Initiating restart for #{node_1} ..."
+    assert message =~ "Restarting #{node_1}, the application consuming the most memory"
   end
 
   @tag :capture_log
@@ -663,7 +666,13 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message == ""
+    # The host memory is reported even though DeployEx has no application to restart for it
+    assert message =~
+             "Total Memory threshold exceeded: current 21% >= restart 20%. Initiating restart..."
+
+    assert message =~ "There is no monitored application to restart"
+
+    assert %{level: :critical} = Watchdog.get_deployex_config(:memory)
   end
 
   @tag :capture_log
@@ -737,9 +746,9 @@ defmodule Sentinel.Watchdog.WatchdogTest do
     assert message == ""
 
     # Check Alarm is clear
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:port)
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:atom)
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:process)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:port)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:atom)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:process)
   end
 
   @tag :capture_log
@@ -770,22 +779,22 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "[deployex] port threshold exceeded: current 11% > warning 10%."
-    assert message =~ "[deployex] atom threshold exceeded: current 11% > warning 10%."
-    assert message =~ "[deployex] process threshold exceeded: current 11% > warning 10%."
+    assert message =~ "[deployex] port threshold exceeded: current 11% >= warning 10%."
+    assert message =~ "[deployex] atom threshold exceeded: current 11% >= warning 10%."
+    assert message =~ "[deployex] process threshold exceeded: current 11% >= warning 10%."
 
     # Check Alarm raised
-    assert %{warning_log_flag: true} = Watchdog.get_deployex_config(:port)
-    assert %{warning_log_flag: true} = Watchdog.get_deployex_config(:atom)
-    assert %{warning_log_flag: true} = Watchdog.get_deployex_config(:process)
+    assert %{level: :warning} = Watchdog.get_deployex_config(:port)
+    assert %{level: :warning} = Watchdog.get_deployex_config(:atom)
+    assert %{level: :warning} = Watchdog.get_deployex_config(:process)
 
     node_statistic = %{
       port_limit: 1_000,
-      port_count: 100,
+      port_count: 90,
       atom_limit: 2_000,
-      atom_count: 200,
+      atom_count: 180,
       process_limit: 3_000,
-      process_count: 300
+      process_count: 270
     }
 
     FixtureTelemetry.send_update_app_message(pid, Node.self(), node_statistic)
@@ -799,14 +808,14 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "[deployex] port threshold normalized: current 10% <= warning 10%."
-    assert message =~ "[deployex] atom threshold normalized: current 10% <= warning 10%."
-    assert message =~ "[deployex] process threshold normalized: current 10% <= warning 10%."
+    assert message =~ "[deployex] port threshold normalized: current 9% < warning 10%."
+    assert message =~ "[deployex] atom threshold normalized: current 9% < warning 10%."
+    assert message =~ "[deployex] process threshold normalized: current 9% < warning 10%."
 
     # Check Alarm cleared
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:port)
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:atom)
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:process)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:port)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:atom)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:process)
   end
 
   @tag :capture_log
@@ -835,9 +844,9 @@ defmodule Sentinel.Watchdog.WatchdogTest do
     wait_message_processing(pid)
 
     # Check Alarm is clear
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:port)
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:atom)
-    assert %{warning_log_flag: false} = Watchdog.get_deployex_config(:process)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:port)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:atom)
+    assert %{level: :ok} = Watchdog.get_deployex_config(:process)
   end
 
   @tag :capture_log
@@ -874,10 +883,12 @@ defmodule Sentinel.Watchdog.WatchdogTest do
         wait_message_processing(pid)
       end)
 
-    assert message =~ "[deployex] port threshold exceeded: current 21% > warning 10%."
+    # port has enable_restart: false in the test config, it is reported and left alone
+    assert message =~
+             "[deployex] port threshold exceeded: current 21% >= restart 20%. Restart is disabled, no action taken."
 
     assert message =~
-             "[deployex] atom threshold exceeded: current 21% > restart 20%. Initiating restart..."
+             "[deployex] atom threshold exceeded: current 21% >= restart 20%. Initiating restart..."
 
     assert message =~ "Deployex was requested to terminate, see you soon!!!"
 
@@ -935,6 +946,70 @@ defmodule Sentinel.Watchdog.WatchdogTest do
     assert %{enabled: false} = Watchdog.get_deployex_config(:atom)
     assert %{enabled: false} = Watchdog.get_deployex_config(:process)
     assert %{enabled: true} = Watchdog.get_deployex_config(:port)
+  end
+
+  @tag :capture_log
+  test "Deployex limits - the critical level is notified even when the restart is disabled" do
+    self_node = Node.self()
+
+    Phoenix.PubSub.subscribe(
+      Foundation.PubSub,
+      Notifications.topic("watchdog_threshold_exceeded")
+    )
+
+    Deployer.MonitorMock
+    |> expect(:list, fn -> [] end)
+    |> expect(:subscribe_new_deploy, fn -> :ok end)
+
+    assert {:ok, pid} = Watchdog.start_link(watchdog_check_interval: 10_000)
+
+    # Only port is above its restart threshold, and port has enable_restart: false in the test
+    # config, so nothing is restarted and DeployEx keeps running
+    node_statistic = %{
+      port_limit: 1_000,
+      port_count: 210,
+      atom_limit: 1_000,
+      atom_count: 10,
+      process_limit: 1_000,
+      process_count: 10
+    }
+
+    FixtureTelemetry.send_update_app_message(pid, self_node, node_statistic)
+
+    wait_message_processing(pid)
+
+    message =
+      capture_log(fn ->
+        send(pid, :watchdog_check)
+
+        wait_message_processing(pid)
+      end)
+
+    assert message =~
+             "[deployex] port threshold exceeded: current 21% >= restart 20%. Restart is disabled, no action taken."
+
+    assert_receive {"watchdog_threshold_exceeded",
+                    %{
+                      node: ^self_node,
+                      type: :port,
+                      current_percentage: 21,
+                      restart_threshold_percent: 20,
+                      action: :no_restart
+                    }}
+
+    assert %{level: :critical} = Watchdog.get_deployex_config(:port)
+
+    # A resource that stays at the same level is not reported again
+    message =
+      capture_log(fn ->
+        send(pid, :watchdog_check)
+
+        wait_message_processing(pid)
+      end)
+
+    assert message == ""
+
+    refute_receive {"watchdog_threshold_exceeded", _payload}
   end
 
   # Note: Fetching the state guarantees that handle_info will be executed and the ETS table will be updated.

--- a/guides/docs/yaml/README.md
+++ b/guides/docs/yaml/README.md
@@ -89,7 +89,7 @@ notifications:
       - "deployment_complete"                            # Deployment finished (success or failure)
       - "application_ready"                              # App reported itself running, whatever put it there
       - "deployment_shutdown"                            # App was force-terminated (will restart)
-      - "watchdog_threshold_exceeded"                    # Resource threshold crossed; app restarted
+      - "watchdog_threshold_exceeded"                    # Resource reached the restart threshold, restarted or not
       - "watchdog_threshold_warning"                     # Resource crossed warning threshold (or normalized)
       - "certificate_renewed"                            # TLS certificate successfully renewed
       - "certificate_valid"                              # Periodic check found a still-valid certificate


### PR DESCRIPTION
## What changed and why

Follows [#292](https://github.com/thiagoesteves/deployex/pull/292), now merged, and targets `main`.

A resource that crossed the restart threshold with `enable_restart: false` said nothing at all. The restart clause did not match, the warning clause had already fired on the way past the warning threshold, and the check fell through to its catch-all. The only signal an operator ever got was the warning at 75%, and that is exactly the shape the installer templates hand out for the DeployEx `atom`, `process` and `port` limits, where `enable_restart` is off by default. `enable_restart` decides what DeployEx may do about a resource, not whether the resource is worth reporting.

`Sentinel.Watchdog` now tracks each resource through the level its usage falls into, `:ok`, `:warning` or `:critical`, which is the model `Components.Monitoring` already uses to colour the card. That replaces the `warning_log_flag` boolean and collapses three near-identical clause families into one, a net 105 lines lighter.

- Reaching the restart threshold is logged and notified whether or not a restart follows.
- Reporting follows the changes of level, so a resource parked above a threshold no longer repeats its log line and its notification on every check, once per second.
- A usage that jumps past both thresholds between two checks is reported as critical instead of being announced as a warning.
- Restarting still follows the level itself: while the host memory stays critical each check restarts the current heaviest application, the cascade the existing test pins. Terminating DeployEx is the exception, the node is already on its way down and a repeat would only re-announce the same shutdown.

## Behaviour changes to be aware of

`watchdog_threshold_exceeded` carries an `action` of `:restart` or `:no_restart`. Anything treating the event as proof that something was restarted needs to read it. Slack and PagerDuty say which one happened, and the PagerDuty severity stays `critical` either way, the resource is at its limit regardless of what DeployEx is allowed to do about it.

The memory event now carries the DeployEx node, the node the measurement is about, instead of the application that happened to be restarted. Previously the payload read `type: :memory` next to a monitored application's node, which looks like that application's memory rather than the host's. The restarted application is named in the log line.

The comparisons are now inclusive, `>=` for both thresholds. The UI card already read Critical at exactly the restart threshold while the watchdog stayed quiet. The log lines print `>=` and `<` accordingly, so log greps built on the old `>` and `<=` wording need updating.

The DeployEx host memory is reported at critical even when there is no monitored application to restart for it. The `nil` clause used to come first and suppressed the whole check, warnings included.

## Two unrelated fixes, each in its own commit

Both came out of chasing intermittent suite failures and are kept separate so they can be dropped on their own.

`Foundation.CatalogTest` ran `async: true` while its `setup` wipes `var_path`, the tree `Foundation.CatalogExDocTest` walks in the `setup_all_apps/0` doctest. When the two overlapped, `mkdir_p` failed with `:enotdir`, about one full-suite run in seven. A module that destroys state the whole suite shares cannot be async.

`Host.Terminal.Server` opens its connection in a continue, after `Terminal.new/1` has returned, so the terminal page renders while the LiveView still has no process to write to. A key pressed inside that window reached `Commander.send/2` with a `nil` process and took the terminal down. Those keys are dropped now, and the test waits for the connection through a fixture helper instead of racing the server. That one failed about one run in twelve.

## Risk assessment

**Impact:** operators get a log line and a notification when a resource reaches its restart threshold with the restart disabled, which is the default the templates ship for the three DeployEx Beam VM limits. Repeated notifications for a resource that stays above a threshold stop. The payload of `watchdog_threshold_exceeded` gains `action`, and its `node` changes for the memory resource. A keystroke typed before the terminal connection is open no longer crashes the page.

**Blast radius:** the threshold evaluation in `Sentinel.Watchdog`, the formatting of `watchdog_threshold_exceeded` in the Slack and PagerDuty adapters, and the key handler of the terminal LiveView. Metric collection, the ETS layout, the restart mechanics, the YAML parsing and every other event are untouched.

**Regression risk:** low for the actions, which keep their existing behaviour including the memory cascade, and moderate for anything parsing the log lines, since the comparisons they show changed. The tests cover every level transition, the critical level with the restart disabled, and the absence of a repeat while a level lasts.

**Rollback:** plain commit revert, per commit. No data or config migration, the level lives only in the runtime ETS table.

## Verification

Compile `--warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` and `mix dialyzer` pass. Around 90 suite runs went into the two flake fixes: foundation and web went from one failure in twelve to zero in fifteen, the terminal tests zero in twenty-five, sentinel zero in twenty, deployer zero in ten, and the CI invocation `mix test --cover --warnings-as-errors` zero in eight.

## Follow-up

The CHANGELOG is not touched here. The `action` field, the `node` change on the memory event and the new log wording belong under Backwards incompatible changes for `0.9.13`.

`ObserverWeb.Telemetry.Storage` was seen crashing once with `System.os_time/1 is undefined`, meck reloading `System` for a `with_mocks` block while the observer_web poller calls into it. It crashes a GenServer without failing a test and is left alone here, the fix is to give `Foundation.Yaml` an injectable config path so the tests stop mocking `System` globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
