### PR TITLE
feat(deployer): display monitored application logo

### DIFF
--- a/apps/deployer/lib/deployer/status.ex
+++ b/apps/deployer/lib/deployer/status.ex
@@ -37,7 +37,7 @@ defmodule Deployer.Status do
           otp_version: String.t() | nil,
           elixir_version: String.t() | nil,
           phoenix_version: String.t() | nil,
-          favicon: String.t() | nil
+          logo: String.t() | nil
         }
 
   defstruct name: nil,
@@ -65,7 +65,7 @@ defmodule Deployer.Status do
             otp_version: nil,
             elixir_version: nil,
             phoenix_version: nil,
-            favicon: nil
+            logo: nil
 
   @behaviour Deployer.Status.Adapter
 

--- a/apps/deployer/lib/deployer/status.ex
+++ b/apps/deployer/lib/deployer/status.ex
@@ -36,7 +36,8 @@ defmodule Deployer.Status do
           certificates: [],
           otp_version: String.t() | nil,
           elixir_version: String.t() | nil,
-          phoenix_version: String.t() | nil
+          phoenix_version: String.t() | nil,
+          favicon: String.t() | nil
         }
 
   defstruct name: nil,
@@ -63,7 +64,8 @@ defmodule Deployer.Status do
             certificates: [],
             otp_version: nil,
             elixir_version: nil,
-            phoenix_version: nil
+            phoenix_version: nil,
+            favicon: nil
 
   @behaviour Deployer.Status.Adapter
 

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -386,7 +386,7 @@ defmodule Deployer.Status.Application do
       otp_version: node_otp_version(node),
       elixir_version: node_elixir_version(node),
       phoenix_version: node_phoenix_version(node),
-      favicon: node_favicon(node, otp == :connected)
+      favicon: node_favicon(node, otp == :connected, name)
     }
   end
 
@@ -455,10 +455,10 @@ defmodule Deployer.Status.Application do
     end
   end
 
-  defp node_favicon(node, connected?) do
+  defp node_favicon(node, connected?, name) do
     if connected? do
       cache_in_process({node, :favicon}) do
-        Favicon.image(node)
+        Favicon.image(node, name)
       end
     else
       Process.delete({node, :favicon})

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -12,7 +12,7 @@ defmodule Deployer.Status.Application do
   alias Deployer.Monitor
   alias Deployer.Status
   alias Deployer.Status.Endpoints
-  alias Deployer.Status.Favicon
+  alias Deployer.Status.Logo
   alias Deployer.Status.Versions
   alias Foundation.Catalog
   alias Foundation.Certificates.PublicKey
@@ -386,7 +386,7 @@ defmodule Deployer.Status.Application do
       otp_version: node_otp_version(node),
       elixir_version: node_elixir_version(node),
       phoenix_version: node_phoenix_version(node),
-      favicon: node_favicon(node, otp == :connected, name)
+      logo: node_logo(node, otp == :connected, name)
     }
   end
 
@@ -455,13 +455,13 @@ defmodule Deployer.Status.Application do
     end
   end
 
-  defp node_favicon(node, connected?, name) do
+  defp node_logo(node, connected?, name) do
     if connected? do
-      cache_in_process({node, :favicon}) do
-        Favicon.image(node, name)
+      cache_in_process({node, :logo}) do
+        Logo.image(node, name)
       end
     else
-      Process.delete({node, :favicon})
+      Process.delete({node, :logo})
       nil
     end
   end

--- a/apps/deployer/lib/deployer/status/application.ex
+++ b/apps/deployer/lib/deployer/status/application.ex
@@ -12,6 +12,7 @@ defmodule Deployer.Status.Application do
   alias Deployer.Monitor
   alias Deployer.Status
   alias Deployer.Status.Endpoints
+  alias Deployer.Status.Favicon
   alias Deployer.Status.Versions
   alias Foundation.Catalog
   alias Foundation.Certificates.PublicKey
@@ -384,7 +385,8 @@ defmodule Deployer.Status.Application do
       monitoring: monitoring,
       otp_version: node_otp_version(node),
       elixir_version: node_elixir_version(node),
-      phoenix_version: node_phoenix_version(node)
+      phoenix_version: node_phoenix_version(node),
+      favicon: node_favicon(node, otp == :connected)
     }
   end
 
@@ -450,6 +452,17 @@ defmodule Deployer.Status.Application do
   defp node_phoenix_version(node) do
     cache_in_process({node, :phoenix}) do
       Versions.phoenix_version(node)
+    end
+  end
+
+  defp node_favicon(node, connected?) do
+    if connected? do
+      cache_in_process({node, :favicon}) do
+        Favicon.image(node)
+      end
+    else
+      Process.delete({node, :favicon})
+      nil
     end
   end
 end

--- a/apps/deployer/lib/deployer/status/favicon.ex
+++ b/apps/deployer/lib/deployer/status/favicon.ex
@@ -1,40 +1,38 @@
 defmodule Deployer.Status.Favicon do
   @moduledoc """
-  Reads the logo of a monitored application from the first Phoenix endpoint
-  it can find on the node. Returns a base64 data URI when the node has a
-  `priv/static/logo.svg` or `priv/static/favicon.ico` file, otherwise `nil`.
+  Reads the icon of a monitored application from its `priv` directory.
+  It looks for `logo.*` or `favicon.*` directly under `priv` or one level
+  below (e.g. `priv/static/`) and returns the first match as a base64
+  `data:` URI, otherwise `nil`.
   """
 
   alias Foundation.Rpc
 
   @rpc_timeout 1_000
-  @endpoint_suffix "Endpoint"
-
-  # Prefer the SVG logo because a favicon is usually too small for the dashboard
-  # card; fall back to the ICO if that is all the app ships.
-  @candidates [
-    {"logo.svg", "image/svg+xml"},
-    {"favicon.ico", "image/x-icon"}
-  ]
 
   ### ==========================================================================
   ### Public APIs
   ### ==========================================================================
 
   @doc """
-  Return the logo as a `data:` URI for the node, or `nil` when no logo
+  Return the icon as a `data:` URI for the node, or `nil` when no icon
   is found. Returns `:error` when the node is unreachable.
   """
-  @spec image(node :: node()) :: {:ok, String.t() | nil} | :error
-  def image(node) do
-    case Rpc.call(node, :erlang, :registered, [], @rpc_timeout) do
-      names when is_list(names) ->
-        favicon =
-          names
-          |> Enum.filter(&endpoint_module?/1)
-          |> Enum.find_value(&read_favicon(node, &1))
+  @spec image(node :: node(), app :: String.t()) :: {:ok, String.t() | nil} | :error
+  def image(node, app) do
+    case Rpc.call(node, :code, :priv_dir, [String.to_atom(app)], @rpc_timeout) do
+      priv_dir when is_binary(priv_dir) or is_list(priv_dir) ->
+        priv_dir = to_string(priv_dir)
 
-        {:ok, favicon}
+        with patterns = icon_patterns(priv_dir),
+             matches when is_list(matches) and matches != [] <-
+               Rpc.call(node, :filelib, :wildcard, [patterns], @rpc_timeout),
+             path <- choose_match(matches),
+             {:ok, binary} <- Rpc.call(node, :file, :read_file, [path], @rpc_timeout) do
+          {:ok, "data:#{mime(path)};base64," <> Base.encode64(binary)}
+        else
+          _ -> {:ok, nil}
+        end
 
       _ ->
         :error
@@ -45,27 +43,40 @@ defmodule Deployer.Status.Favicon do
   ### Private functions
   ### ==========================================================================
 
-  defp endpoint_module?(name) do
-    case Atom.to_string(name) do
-      "Elixir." <> module -> String.ends_with?(module, @endpoint_suffix)
-      _ -> false
+  defp icon_patterns(priv_dir) do
+    Enum.flat_map([priv_dir, Path.join(priv_dir, "*")], fn dir ->
+      Enum.map(["logo.*", "favicon.*"], fn file ->
+        Path.join([dir, file]) |> String.to_charlist()
+      end)
+    end)
+  end
+
+  defp choose_match(matches) do
+    matches
+    |> Enum.map(&to_string/1)
+    |> Enum.min_by(&match_score/1)
+    |> String.to_charlist()
+  end
+
+  # Lower score is better; prefer logo.svg, then favicon.ico, then other svg/ico
+  defp match_score(path) do
+    case {Path.basename(path), Path.extname(path)} do
+      {"logo.svg", _} -> 0
+      {"favicon.ico", _} -> 1
+      {_, ".svg"} -> 2
+      {_, ".ico"} -> 3
+      _ -> 100
     end
   end
 
-  defp read_favicon(node, module) do
-    with beam_path when is_binary(beam_path) <-
-           Rpc.call(node, :code, :which, [module], @rpc_timeout),
-         priv_dir = Path.join([Path.dirname(Path.dirname(beam_path)), "priv"]) do
-      Enum.find_value(@candidates, fn {file, mime} ->
-        favicon_path = Path.join([priv_dir, "static", file])
-
-        case Rpc.call(node, :file, :read_file, [favicon_path], @rpc_timeout) do
-          {:ok, binary} -> "data:#{mime};base64," <> Base.encode64(binary)
-          _ -> nil
-        end
-      end)
-    else
-      _ -> nil
+  defp mime(path) do
+    case Path.extname(to_string(path)) do
+      ".svg" -> "image/svg+xml"
+      ".ico" -> "image/x-icon"
+      ".png" -> "image/png"
+      ".jpg" -> "image/jpeg"
+      ".jpeg" -> "image/jpeg"
+      _ -> "application/octet-stream"
     end
   end
 end

--- a/apps/deployer/lib/deployer/status/favicon.ex
+++ b/apps/deployer/lib/deployer/status/favicon.ex
@@ -1,9 +1,8 @@
 defmodule Deployer.Status.Favicon do
   @moduledoc """
-  Reads the icon of a monitored application from its `priv` directory.
-  It looks for `logo.*` or `favicon.*` directly under `priv` or one level
-  below (e.g. `priv/static/`) and returns the first match as a base64
-  `data:` URI, otherwise `nil`.
+  Reads the icon of a monitored application from `priv/static/images/`.
+  It looks for `logo.*` or `favicon.*` and returns the first match as a
+  base64 `data:` URI, otherwise `nil`.
   """
 
   alias Foundation.Rpc
@@ -20,7 +19,8 @@ defmodule Deployer.Status.Favicon do
   """
   @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil} | :error
   def image(node, name) do
-    with {:ok, priv_dir} <- app_priv_dir(node, name),
+    with app when is_atom(app) <- to_existing_atom(name),
+         {:ok, priv_dir} <- app_priv_dir(node, app),
          patterns = icon_patterns(priv_dir),
          matches when is_list(matches) and matches != [] <-
            Rpc.call(node, :filelib, :wildcard, [patterns], @rpc_timeout),
@@ -37,30 +37,27 @@ defmodule Deployer.Status.Favicon do
   ### Private functions
   ### ==========================================================================
 
-  defp app_priv_dir(node, name) do
-    [to_existing_or_new_atom(name), String.to_atom("#{name}_web")]
-    |> Enum.find_value(fn app ->
-      case Rpc.call(node, :code, :priv_dir, [app], @rpc_timeout) do
-        priv_dir when is_binary(priv_dir) or is_list(priv_dir) -> to_string(priv_dir)
-        _ -> nil
-      end
-    end)
-    |> case do
-      nil -> :error
-      priv_dir -> {:ok, priv_dir}
+  defp to_existing_atom(name) do
+    String.to_existing_atom(name)
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp app_priv_dir(node, app) do
+    case Rpc.call(node, :code, :priv_dir, [app], @rpc_timeout) do
+      priv_dir when is_binary(priv_dir) or is_list(priv_dir) ->
+        {:ok, to_string(priv_dir)}
+
+      _ ->
+        :error
     end
   end
 
-  defp to_existing_or_new_atom(name) do
-    String.to_existing_atom(name)
-  rescue
-    ArgumentError -> String.to_atom(name)
-  end
-
   defp icon_patterns(priv_dir) do
-    for dir <- [priv_dir, Path.join(priv_dir, "*")],
-        file <- [~c"logo.*", ~c"favicon.*"] do
-      ~c"#{Path.join([dir, to_string(file)])}"
+    images_dir = Path.join([priv_dir, "static", "images"])
+
+    for file <- [~c"logo.*", ~c"favicon.*"] do
+      ~c"#{Path.join([images_dir, to_string(file)])}"
     end
   end
 

--- a/apps/deployer/lib/deployer/status/favicon.ex
+++ b/apps/deployer/lib/deployer/status/favicon.ex
@@ -1,8 +1,15 @@
 defmodule Deployer.Status.Favicon do
   @moduledoc """
-  Reads the icon of a monitored application from `priv/static/images/`.
-  It looks for `logo.*` or `favicon.*` and returns the first match as a
-  base64 `data:` URI, otherwise `nil`.
+  Reads the logo of a monitored application so it can be shown in the UI.
+
+  The logo is fetched over RPC from the monitored node, at
+  `priv/static/images/logo.svg` inside the application's own `priv`
+  directory, and returned as a base64 `data:` URI ready to be used as an
+  `<img>` source.
+
+  Lookup is best effort: an unknown application, an unreachable node or a
+  missing file all yield `nil` rather than an error, so a missing logo
+  never prevents the application from being rendered.
   """
 
   alias Foundation.Rpc
@@ -14,21 +21,20 @@ defmodule Deployer.Status.Favicon do
   ### ==========================================================================
 
   @doc """
-  Return the icon as a `data:` URI for the node, or `nil` when no icon
-  is found. Returns `:error` when the node is unreachable.
+  Return the logo of the application `name` running on `node` as a base64
+  `data:` URI.
+
+  Returns `{:ok, nil}` when the application is unknown, the node is
+  unreachable or the node has no `logo.svg`.
   """
-  @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil} | :error
+  @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil}
   def image(node, name) do
-    with app when is_atom(app) <- to_existing_atom(name),
+    with {:ok, app} <- existing_atom(name),
          {:ok, priv_dir} <- app_priv_dir(node, app),
-         patterns = icon_patterns(priv_dir),
-         matches when is_list(matches) and matches != [] <-
-           Rpc.call(node, :filelib, :wildcard, [patterns], @rpc_timeout),
-         path <- choose_match(matches),
+         path <- logo_path(priv_dir),
          {:ok, binary} <- Rpc.call(node, :file, :read_file, [path], @rpc_timeout) do
-      {:ok, "data:#{mime(path)};base64," <> Base.encode64(binary)}
+      {:ok, "data:image/svg+xml;base64," <> Base.encode64(binary)}
     else
-      :error -> :error
       _ -> {:ok, nil}
     end
   end
@@ -37,56 +43,25 @@ defmodule Deployer.Status.Favicon do
   ### Private functions
   ### ==========================================================================
 
-  defp to_existing_atom(name) do
-    String.to_existing_atom(name)
+  # The application name only maps to an atom when the application is known
+  # to this node, so an unknown name is a normal miss rather than a failure.
+  defp existing_atom(name) do
+    {:ok, String.to_existing_atom(name)}
   rescue
     ArgumentError -> :error
   end
 
   defp app_priv_dir(node, app) do
     case Rpc.call(node, :code, :priv_dir, [app], @rpc_timeout) do
-      priv_dir when is_binary(priv_dir) or is_list(priv_dir) ->
+      priv_dir when is_list(priv_dir) ->
         {:ok, to_string(priv_dir)}
 
-      _ ->
+      _err ->
         :error
     end
   end
 
-  defp icon_patterns(priv_dir) do
-    images_dir = Path.join([priv_dir, "static", "images"])
-
-    for file <- [~c"logo.*", ~c"favicon.*"] do
-      ~c"#{Path.join([images_dir, to_string(file)])}"
-    end
-  end
-
-  defp choose_match(matches) do
-    matches
-    |> Enum.map(&to_string/1)
-    |> Enum.min_by(&match_score/1)
-    |> String.to_charlist()
-  end
-
-  # Lower score is better; prefer logo.svg, then favicon.ico, then other svg/ico
-  defp match_score(path) do
-    case {Path.basename(path), Path.extname(path)} do
-      {"logo.svg", _} -> 0
-      {"favicon.ico", _} -> 1
-      {_, ".svg"} -> 2
-      {_, ".ico"} -> 3
-      _ -> 100
-    end
-  end
-
-  defp mime(path) do
-    case Path.extname(to_string(path)) do
-      ".svg" -> "image/svg+xml"
-      ".ico" -> "image/x-icon"
-      ".png" -> "image/png"
-      ".jpg" -> "image/jpeg"
-      ".jpeg" -> "image/jpeg"
-      _ -> "application/octet-stream"
-    end
+  defp logo_path(priv_dir) do
+    Path.join([priv_dir, "static", "images", "logo.svg"])
   end
 end

--- a/apps/deployer/lib/deployer/status/favicon.ex
+++ b/apps/deployer/lib/deployer/status/favicon.ex
@@ -1,0 +1,60 @@
+defmodule Deployer.Status.Favicon do
+  @moduledoc """
+  Reads the favicon of a monitored application from the first Phoenix endpoint
+  it can find on the node. Returns a base64 data URI when the node has a
+  `priv/static/favicon.ico` file, otherwise `nil`.
+  """
+
+  alias Foundation.Rpc
+
+  @rpc_timeout 1_000
+  @favicon "favicon.ico"
+  @endpoint_suffix "Endpoint"
+
+  ### ==========================================================================
+  ### Public APIs
+  ### ==========================================================================
+
+  @doc """
+  Return the favicon as a `data:` URI for the node, or `nil` when no favicon
+  is found. Returns `:error` when the node is unreachable.
+  """
+  @spec image(node :: node()) :: {:ok, String.t() | nil} | :error
+  def image(node) do
+    case Rpc.call(node, :erlang, :registered, [], @rpc_timeout) do
+      names when is_list(names) ->
+        favicon =
+          names
+          |> Enum.filter(&endpoint_module?/1)
+          |> Enum.find_value(&read_favicon(node, &1))
+
+        {:ok, favicon}
+
+      _ ->
+        :error
+    end
+  end
+
+  ### ==========================================================================
+  ### Private functions
+  ### ==========================================================================
+
+  defp endpoint_module?(name) do
+    case Atom.to_string(name) do
+      "Elixir." <> module -> String.ends_with?(module, @endpoint_suffix)
+      _ -> false
+    end
+  end
+
+  defp read_favicon(node, module) do
+    with beam_path when is_binary(beam_path) <-
+           Rpc.call(node, :code, :which, [module], @rpc_timeout),
+         priv_dir = Path.join([Path.dirname(Path.dirname(beam_path)), "priv"]),
+         favicon_path = Path.join([priv_dir, "static", @favicon]),
+         {:ok, binary} <- Rpc.call(node, :file, :read_file, [favicon_path], @rpc_timeout) do
+      "data:image/x-icon;base64," <> Base.encode64(binary)
+    else
+      _ -> nil
+    end
+  end
+end

--- a/apps/deployer/lib/deployer/status/favicon.ex
+++ b/apps/deployer/lib/deployer/status/favicon.ex
@@ -1,22 +1,28 @@
 defmodule Deployer.Status.Favicon do
   @moduledoc """
-  Reads the favicon of a monitored application from the first Phoenix endpoint
+  Reads the logo of a monitored application from the first Phoenix endpoint
   it can find on the node. Returns a base64 data URI when the node has a
-  `priv/static/favicon.ico` file, otherwise `nil`.
+  `priv/static/logo.svg` or `priv/static/favicon.ico` file, otherwise `nil`.
   """
 
   alias Foundation.Rpc
 
   @rpc_timeout 1_000
-  @favicon "favicon.ico"
   @endpoint_suffix "Endpoint"
+
+  # Prefer the SVG logo because a favicon is usually too small for the dashboard
+  # card; fall back to the ICO if that is all the app ships.
+  @candidates [
+    {"logo.svg", "image/svg+xml"},
+    {"favicon.ico", "image/x-icon"}
+  ]
 
   ### ==========================================================================
   ### Public APIs
   ### ==========================================================================
 
   @doc """
-  Return the favicon as a `data:` URI for the node, or `nil` when no favicon
+  Return the logo as a `data:` URI for the node, or `nil` when no logo
   is found. Returns `:error` when the node is unreachable.
   """
   @spec image(node :: node()) :: {:ok, String.t() | nil} | :error
@@ -49,10 +55,15 @@ defmodule Deployer.Status.Favicon do
   defp read_favicon(node, module) do
     with beam_path when is_binary(beam_path) <-
            Rpc.call(node, :code, :which, [module], @rpc_timeout),
-         priv_dir = Path.join([Path.dirname(Path.dirname(beam_path)), "priv"]),
-         favicon_path = Path.join([priv_dir, "static", @favicon]),
-         {:ok, binary} <- Rpc.call(node, :file, :read_file, [favicon_path], @rpc_timeout) do
-      "data:image/x-icon;base64," <> Base.encode64(binary)
+         priv_dir = Path.join([Path.dirname(Path.dirname(beam_path)), "priv"]) do
+      Enum.find_value(@candidates, fn {file, mime} ->
+        favicon_path = Path.join([priv_dir, "static", file])
+
+        case Rpc.call(node, :file, :read_file, [favicon_path], @rpc_timeout) do
+          {:ok, binary} -> "data:#{mime};base64," <> Base.encode64(binary)
+          _ -> nil
+        end
+      end)
     else
       _ -> nil
     end

--- a/apps/deployer/lib/deployer/status/favicon.ex
+++ b/apps/deployer/lib/deployer/status/favicon.ex
@@ -18,24 +18,18 @@ defmodule Deployer.Status.Favicon do
   Return the icon as a `data:` URI for the node, or `nil` when no icon
   is found. Returns `:error` when the node is unreachable.
   """
-  @spec image(node :: node(), app :: String.t()) :: {:ok, String.t() | nil} | :error
-  def image(node, app) do
-    case Rpc.call(node, :code, :priv_dir, [String.to_atom(app)], @rpc_timeout) do
-      priv_dir when is_binary(priv_dir) or is_list(priv_dir) ->
-        priv_dir = to_string(priv_dir)
-
-        with patterns = icon_patterns(priv_dir),
-             matches when is_list(matches) and matches != [] <-
-               Rpc.call(node, :filelib, :wildcard, [patterns], @rpc_timeout),
-             path <- choose_match(matches),
-             {:ok, binary} <- Rpc.call(node, :file, :read_file, [path], @rpc_timeout) do
-          {:ok, "data:#{mime(path)};base64," <> Base.encode64(binary)}
-        else
-          _ -> {:ok, nil}
-        end
-
-      _ ->
-        :error
+  @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil} | :error
+  def image(node, name) do
+    with {:ok, priv_dir} <- app_priv_dir(node, name),
+         patterns = icon_patterns(priv_dir),
+         matches when is_list(matches) and matches != [] <-
+           Rpc.call(node, :filelib, :wildcard, [patterns], @rpc_timeout),
+         path <- choose_match(matches),
+         {:ok, binary} <- Rpc.call(node, :file, :read_file, [path], @rpc_timeout) do
+      {:ok, "data:#{mime(path)};base64," <> Base.encode64(binary)}
+    else
+      :error -> :error
+      _ -> {:ok, nil}
     end
   end
 
@@ -43,12 +37,31 @@ defmodule Deployer.Status.Favicon do
   ### Private functions
   ### ==========================================================================
 
-  defp icon_patterns(priv_dir) do
-    Enum.flat_map([priv_dir, Path.join(priv_dir, "*")], fn dir ->
-      Enum.map(["logo.*", "favicon.*"], fn file ->
-        Path.join([dir, file]) |> String.to_charlist()
-      end)
+  defp app_priv_dir(node, name) do
+    [to_existing_or_new_atom(name), String.to_atom("#{name}_web")]
+    |> Enum.find_value(fn app ->
+      case Rpc.call(node, :code, :priv_dir, [app], @rpc_timeout) do
+        priv_dir when is_binary(priv_dir) or is_list(priv_dir) -> to_string(priv_dir)
+        _ -> nil
+      end
     end)
+    |> case do
+      nil -> :error
+      priv_dir -> {:ok, priv_dir}
+    end
+  end
+
+  defp to_existing_or_new_atom(name) do
+    String.to_existing_atom(name)
+  rescue
+    ArgumentError -> String.to_atom(name)
+  end
+
+  defp icon_patterns(priv_dir) do
+    for dir <- [priv_dir, Path.join(priv_dir, "*")],
+        file <- [~c"logo.*", ~c"favicon.*"] do
+      ~c"#{Path.join([dir, to_string(file)])}"
+    end
   end
 
   defp choose_match(matches) do

--- a/apps/deployer/lib/deployer/status/logo.ex
+++ b/apps/deployer/lib/deployer/status/logo.ex
@@ -7,9 +7,11 @@ defmodule Deployer.Status.Logo do
   directory, and returned as a base64 `data:` URI ready to be used as an
   `<img>` source.
 
-  Lookup is best effort: an unknown application, an unreachable node or a
-  missing file all yield `nil` rather than an error, so a missing logo
-  never prevents the application from being rendered.
+  Lookup is best effort and never prevents an application from being
+  rendered. It distinguishes an application that answered and has no logo,
+  which is a definitive answer, from a lookup that could not be performed
+  because the node did not reply, so that a transient failure is not
+  remembered as a missing logo.
   """
 
   alias Foundation.Rpc
@@ -24,10 +26,15 @@ defmodule Deployer.Status.Logo do
   Return the logo of the application `name` running on `node` as a base64
   `data:` URI.
 
-  Returns `{:ok, nil}` when the application is unknown, the node is
-  unreachable or the node has no `logo.svg`.
+  Returns `{:ok, nil}` when the node answered but has no `logo.svg`, which
+  is a definitive answer and safe for the caller to cache.
+
+  Returns `:error` when the question could not be answered at all, because
+  the name is not a known application or the node did not reply. The caller
+  is expected to treat this as "unknown for now" and ask again later rather
+  than remembering the absence of a logo.
   """
-  @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil}
+  @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil} | :error
   def image(node, name) do
     with {:ok, app} <- existing_atom(name),
          {:ok, priv_dir} <- app_priv_dir(node, app),
@@ -35,6 +42,7 @@ defmodule Deployer.Status.Logo do
          {:ok, binary} <- Rpc.call(node, :file, :read_file, [path], @rpc_timeout) do
       {:ok, "data:image/svg+xml;base64," <> Base.encode64(binary)}
     else
+      :error -> :error
       _ -> {:ok, nil}
     end
   end

--- a/apps/deployer/lib/deployer/status/logo.ex
+++ b/apps/deployer/lib/deployer/status/logo.ex
@@ -1,4 +1,4 @@
-defmodule Deployer.Status.Favicon do
+defmodule Deployer.Status.Logo do
   @moduledoc """
   Reads the logo of a monitored application so it can be shown in the UI.
 

--- a/apps/deployer/test/status/logo_test.exs
+++ b/apps/deployer/test/status/logo_test.exs
@@ -1,0 +1,65 @@
+defmodule Deployer.Status.LogoTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Deployer.Status.Logo
+
+  setup [
+    :set_mox_global,
+    :verify_on_exit!
+  ]
+
+  @node :"myelixir-abc123@nohost"
+  @name "myelixir"
+  @app :myelixir
+  @priv_dir ~c"/opt/myelixir/lib/myelixir-1.0.0/priv"
+  @svg ~s(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"></svg>)
+
+  test "image/2 returns the logo as a base64 svg data uri" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:ok, @svg} end)
+
+    assert {:ok, "data:image/svg+xml;base64," <> encoded} = Logo.image(@node, @name)
+    assert {:ok, @svg} = Base.decode64(encoded)
+  end
+
+  test "image/2 reads logo.svg from the application's own priv directory" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [path], _timeout ->
+      assert path == "/opt/myelixir/lib/myelixir-1.0.0/priv/static/images/logo.svg"
+      {:ok, @svg}
+    end)
+
+    assert {:ok, _data_uri} = Logo.image(@node, @name)
+  end
+
+  test "image/2 returns nil when the application has no logo.svg" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+
+    assert {:ok, nil} = Logo.image(@node, @name)
+  end
+
+  test "image/2 returns nil when the application is not loaded on the node" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:error, :bad_name} end)
+
+    assert {:ok, nil} = Logo.image(@node, @name)
+  end
+
+  test "image/2 returns nil when the node is unreachable" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:badrpc, :nodedown} end)
+
+    assert {:ok, nil} = Logo.image(@node, @name)
+  end
+
+  test "image/2 returns nil for an unknown application name without calling the node" do
+    # verify_on_exit! fails the test if the unknown name reaches the node
+    assert {:ok, nil} = Logo.image(@node, "unknown_#{System.unique_integer([:positive])}")
+  end
+end

--- a/apps/deployer/test/status/logo_test.exs
+++ b/apps/deployer/test/status/logo_test.exs
@@ -44,22 +44,33 @@ defmodule Deployer.Status.LogoTest do
     assert {:ok, nil} = Logo.image(@node, @name)
   end
 
-  test "image/2 returns nil when the application is not loaded on the node" do
+  test "image/2 errors when the application is not loaded on the node" do
     Foundation.RpcMock
     |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:error, :bad_name} end)
 
-    assert {:ok, nil} = Logo.image(@node, @name)
+    assert :error = Logo.image(@node, @name)
   end
 
-  test "image/2 returns nil when the node is unreachable" do
+  test "image/2 errors when the node is unreachable" do
     Foundation.RpcMock
     |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:badrpc, :nodedown} end)
 
-    assert {:ok, nil} = Logo.image(@node, @name)
+    assert :error = Logo.image(@node, @name)
   end
 
-  test "image/2 returns nil for an unknown application name without calling the node" do
+  test "image/2 errors for an unknown application name without calling the node" do
     # verify_on_exit! fails the test if the unknown name reaches the node
-    assert {:ok, nil} = Logo.image(@node, "unknown_#{System.unique_integer([:positive])}")
+    assert :error = Logo.image(@node, "unknown_#{System.unique_integer([:positive])}")
+  end
+
+  test "image/2 separates a node with no logo from a node that did not answer" do
+    # only the first is a definitive answer, so only it is safe for the caller to cache
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:badrpc, :nodedown} end)
+
+    assert {:ok, nil} = Logo.image(@node, @name)
+    assert :error = Logo.image(@node, @name)
   end
 end

--- a/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
@@ -37,7 +37,11 @@ defmodule DeployexWeb.Components.ApplicationCard do
             <div class="flex items-center gap-6 mb-8">
               <div class="avatar">
                 <div class="w-20 h-20 rounded-xl bg-base-200/30 flex items-center justify-center">
-                  <img src={"/images/#{@application.language}.ico"} alt="" class="w-12 h-12" />
+                  <img
+                    src={@application.favicon || "/images/#{@application.language}.ico"}
+                    alt=""
+                    class="w-12 h-12"
+                  />
                 </div>
               </div>
               <div class="flex-1">

--- a/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
@@ -35,14 +35,12 @@ defmodule DeployexWeb.Components.ApplicationCard do
           <!-- App Header -->
           <div class="gap-6">
             <div class="flex items-center gap-6 mb-8">
-              <div class="avatar">
-                <div class="w-20 h-20 rounded-xl bg-base-200/30 flex items-center justify-center">
-                  <img
-                    src={@application.favicon || "/images/#{@application.language}.ico"}
-                    alt=""
-                    class="w-12 h-12"
-                  />
-                </div>
+              <div class="w-20 h-20 shrink-0 rounded-xl bg-base-200/30 flex items-center justify-center">
+                <img
+                  src={@application.favicon || "/images/#{@application.language}.ico"}
+                  alt=""
+                  class="w-full h-full object-contain"
+                />
               </div>
               <div class="flex-1">
                 <h1 class="text-3xl font-bold text-base-content mb-2">{@application.name}</h1>

--- a/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/application_card.ex
@@ -37,7 +37,7 @@ defmodule DeployexWeb.Components.ApplicationCard do
             <div class="flex items-center gap-6 mb-8">
               <div class="w-20 h-20 shrink-0 rounded-xl bg-base-200/30 flex items-center justify-center">
                 <img
-                  src={@application.favicon || "/images/#{@application.language}.ico"}
+                  src={@application.logo || "/images/#{@application.language}.ico"}
                   alt=""
                   class="w-full h-full object-contain"
                 />


### PR DESCRIPTION
## Summary
- Add `Deployer.Status.Logo`, which reads `priv/static/images/logo.svg` from a monitored application's own `priv` directory over RPC and returns it as a base64 `data:` URI.
- Add a `logo` field to `Deployer.Status` and `Deployer.Status.Application`, cached per node and cleared when the node disconnects.
- Update `ApplicationCard` to display the application logo, falling back to the generic language icon.

## Notes
Lookup is best effort and never prevents an application from rendering. It separates two cases that matter to the caller: a node that answered and has no `logo.svg` returns `{:ok, nil}` and is cached, while an unknown application name or a node that did not reply returns `:error` and is retried. The per node cache only stores a value on `{:ok, value}`, so a transient RPC failure is not remembered as a missing logo.

The card icon does not use the avatar component. Its `img` rule sets `object-fit: cover` at a higher specificity than the utility classes, and both land in the same cascade layer, so a non-square logo was cropped rather than fitted. A plain flex box with `object-contain` scales any logo to fit without distortion.

The feature is named `logo` rather than `favicon` throughout, since it reads the application's `logo.svg` and never a favicon. The browser's own `favicon.ico` static path is unchanged.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix credo --strict`
- [x] `mix dialyzer`
- [x] `mix test` (full umbrella suite green)
- [x] New `Deployer.Status.LogoTest` covers the success path, the exact priv path requested from the node, a missing file, an application that is not loaded, an unreachable node, an unknown application name that must not reach the node, and the split between a definitive miss and a node that did not answer
- [x] Logo rendering verified visually in the running dashboard

## Risk assessment
- **Impact:** Monitored applications shipping `priv/static/images/logo.svg` show their own logo in the dashboard; everything else keeps the existing language icon.
- **Blast radius:** `Deployer.Status`, `Deployer.Status.Application`, `Deployer.Status.Logo`, `DeployexWeb.Components.ApplicationCard`.
- **Regression risk:** Low. The lookup is read only, bounded by an RPC timeout, and every failure path falls back to the language icon. Applications shipping only `favicon.ico` are not picked up, matching the previous behaviour for apps without an icon.
- **Rollback:** Revert the commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)