### PR TITLE
docs: clarify AI agent attribution in PR guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,9 @@ Also include the risk assessment in the commit message body so it survives outsi
 For bug fixes, state how the bug was reproduced (ideally a test that fails without the fix).
 
 When a PR is authored by an AI agent, credit it at the end of the description with:
-`🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+`🤖 Generated with [Devin](https://devin.ai) (<model name>)` when running through Devin,
+or `🤖 Generated with [Claude Code](https://claude.com/claude-code) (<model name>)` when running through Claude Code directly.
+`<model name>` is the model the agent is running on (e.g. `GLM-5.2 High`, `Claude Sonnet 4.5`).
 Never add the agent as commit co-author.
 
 ---


### PR DESCRIPTION
## Summary

- Generalize the AI agent attribution line in `AGENTS.md` to cover both Devin and Claude Code directly, each with the model name as a parameter
- Examples: `🤖 Generated with [Devin](https://devin.ai) (GLM-5.2 High)` or `🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Sonnet 4.5)`
- This applies to any AI agent regardless of which tool or model it runs on

## Risk assessment

**Impact:** agents reading `AGENTS.md` now know to credit the tool they are running through (Devin or Claude Code) and their own model, rather than copying a single hardcoded line that may not apply.

**Blast radius:** only `AGENTS.md`. No code or config changes.

**Regression risk:** none. Documentation-only change.

**Rollback:** revert this commit.

#### Test plan

- [ ] Read the updated `AGENTS.md` PR section and confirm the attribution line covers both Devin and Claude Code

🤖 Generated with [Devin](https://devin.ai) (GLM-5.2 High)