### PR TITLE
feat(web): compact logs and history logs UI to maximize log view space

### DIFF
--- a/apps/deployex_web/lib/deployex_web/components/core_components.ex
+++ b/apps/deployex_web/lib/deployex_web/components/core_components.ex
@@ -704,8 +704,8 @@ defmodule DeployexWeb.CoreComponents do
 
   def modern_history_logs_table(assigns) do
     ~H"""
-    <div class="max-h-[600px] overflow-y-auto" id={"#{@id}-container"}>
-      <table class="table table-zebra table-pin-rows">
+    <div class="max-h-[calc(100vh-240px)] overflow-y-auto" id={"#{@id}-container"}>
+      <table class="table table-sm table-zebra table-pin-rows">
         <thead>
           <tr class="bg-base-200">
             <th class="w-40">
@@ -790,11 +790,11 @@ defmodule DeployexWeb.CoreComponents do
               <div class="flex items-center gap-2">
                 <div class="w-2 h-2 rounded-full" style={"background-color: #{log_message.color};"}>
                 </div>
-                <span class="badge badge-neutral truncate">{log_message.service}</span>
+                <span class="badge badge-sm badge-neutral truncate">{log_message.service}</span>
               </div>
             </td>
             <td>
-              <div class={["font-mono text-xs badge", log_type_badge(log_message.type)]}>
+              <div class={["font-mono text-xs badge badge-sm", log_type_badge(log_message.type)]}>
                 {log_message.type}
               </div>
             </td>
@@ -835,8 +835,8 @@ defmodule DeployexWeb.CoreComponents do
       end
 
     ~H"""
-    <div class="h-[600px] overflow-y-auto" id={"#{@id}-container"} phx-hook="ScrollBottom">
-      <table class="table table-zebra table-pin-rows">
+    <div class="h-[calc(100vh-200px)] overflow-y-auto" id={"#{@id}-container"} phx-hook="ScrollBottom">
+      <table class="table table-sm table-zebra table-pin-rows">
         <thead>
           <tr class="bg-base-200">
             <th class="w-32">
@@ -906,11 +906,11 @@ defmodule DeployexWeb.CoreComponents do
               <div class="flex items-center gap-2">
                 <div class="w-2 h-2 rounded-full" style={"background-color: #{log_message.color};"}>
                 </div>
-                <span class="badge badge-neutral truncate">{log_message.service}</span>
+                <span class="badge badge-sm badge-neutral truncate">{log_message.service}</span>
               </div>
             </td>
             <td>
-              <div class={["font-mono text-xs badge", log_type_badge(log_message.type)]}>
+              <div class={["font-mono text-xs badge badge-sm", log_type_badge(log_message.type)]}>
                 {log_message.type}
               </div>
             </td>

--- a/apps/deployex_web/lib/deployex_web/live/components/multi_select.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/multi_select.ex
@@ -20,13 +20,13 @@ defmodule DeployexWeb.Components.MultiSelect do
   def content(assigns) do
     ~H"""
     <div class="w-full">
-      <!-- Selected Items Display -->
-      <div class="flex flex-wrap gap-2 mb-4">
-        <div class="badge badge-neutral badge-lg">{@selected_text}</div>
+      <!-- Selected Items Display + Toggle -->
+      <div class="flex flex-wrap items-center gap-2 mb-2">
+        <div class="badge badge-neutral badge-sm">{@selected_text}</div>
 
         <%= for item <- @selected do %>
           <%= for key <- item.keys do %>
-            <div class={["badge badge-lg gap-2", badge_color(item.name)]}>
+            <div class={["badge badge-sm gap-1", badge_color(item.name)]}>
               <span class="text-xs font-medium">{"#{item.name}:#{key}"}</span>
               <button
                 id={Helper.normalize_id("#{@id}-#{item.name}-#{key}-remove-item")}
@@ -48,16 +48,13 @@ defmodule DeployexWeb.Components.MultiSelect do
             </div>
           <% end %>
         <% end %>
-      </div>
-      
-    <!-- Toggle Button -->
-      <div class="flex justify-center mb-4">
+
         <button
           id={Helper.normalize_id("#{@id}-toggle-options")}
-          class="btn btn-outline btn-sm"
+          class="btn btn-outline btn-xs ml-auto"
           phx-click="toggle-options"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               :if={!@show_options}
               stroke-linecap="round"
@@ -75,14 +72,14 @@ defmodule DeployexWeb.Components.MultiSelect do
             >
             </path>
           </svg>
-          {if @show_options, do: "Hide Options", else: "Show Options"}
+          {if @show_options, do: "Hide", else: "Options"}
         </button>
       </div>
       
     <!-- Available Options -->
       <div :if={@show_options} class="collapse collapse-open bg-base-200 rounded-lg">
         <div
-          class="collapse-content p-4"
+          class="collapse-content p-3"
           phx-mounted={
             JS.transition(
               {"first:ease-in duration-300", "first:opacity-0 first:scale-95",
@@ -92,18 +89,18 @@ defmodule DeployexWeb.Components.MultiSelect do
           }
         >
           <%= for item <- @unselected do %>
-            <div class="mb-6 last:mb-0">
-              <h3 class="text-sm font-semibold text-base-content mb-3 flex items-center gap-2">
-                <div class={["w-3 h-3 rounded-full", category_color(item.name)]}></div>
+            <div class="mb-3 last:mb-0">
+              <h3 class="text-xs font-semibold text-base-content mb-2 flex items-center gap-2">
+                <div class={["w-2 h-2 rounded-full", category_color(item.name)]}></div>
                 {String.capitalize(item.name)}
               </h3>
 
-              <div class="flex flex-wrap gap-2">
+              <div class="flex flex-wrap gap-1">
                 <%= for key <- item.keys do %>
                   <button
                     id={Helper.normalize_id("#{@id}-#{item.name}-#{key}-add-item")}
                     class={[
-                      "btn btn-sm gap-2",
+                      "btn btn-xs gap-1",
                       if(key in item.unselected_highlight, do: "btn-success", else: "btn-neutral")
                     ]}
                     phx-click="multi-select-add-item"

--- a/apps/deployex_web/lib/deployex_web/live/logs/history/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/logs/history/index.ex
@@ -25,11 +25,11 @@ defmodule DeployexWeb.HistoryLive do
       <div class="min-h-screen bg-base-300">
         <!-- Header -->
         <div class="bg-base-100 border-b border-base-200 shadow-sm">
-          <div class="max-w-7xl mx-auto px-4 py-4">
+          <div class="max-w-8xl mx-auto px-4 py-2">
             <div class="flex items-center justify-between">
-              <div>
-                <h1 class="text-3xl font-bold text-base-content">History Logs</h1>
-                <p class="text-base-content/60 mt-1">Browse historical application logs</p>
+              <div class="flex items-baseline gap-2">
+                <h1 class="text-xl font-bold text-base-content">History Logs</h1>
+                <p class="text-sm text-base-content/50">Browse historical application logs</p>
               </div>
               <div class="flex items-center gap-4">
                 <!-- Time Range Selector -->
@@ -87,11 +87,10 @@ defmodule DeployexWeb.HistoryLive do
           </div>
         </div>
         <!-- Main Content -->
-        <div class="max-w-8xl mx-auto px-3 py-3">
+        <div class="max-w-8xl mx-auto px-3 py-2">
           <!-- Filters Card -->
-          <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-6">
-              <h2 class="card-title text-lg mb-4">Log Filters</h2>
+          <div class="card bg-base-100 shadow-sm mb-3">
+            <div class="card-body p-3">
               <MultiSelect.content
                 id="logs-history-multi-select"
                 selected_text="Selected logs"
@@ -112,56 +111,44 @@ defmodule DeployexWeb.HistoryLive do
             </div>
           </div>
           <!-- Statistics Card -->
-          <div :if={length(@log_messages) > 0} class="stats shadow mb-6">
-            <div class="stat">
-              <div class="stat-figure text-primary">
-                <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                  >
-                  </path>
-                </svg>
-              </div>
-              <div class="stat-title">Total Logs</div>
-              <div class="stat-value text-primary">{length(@log_messages)}</div>
-              <div class="stat-desc">Historical log entries</div>
+          <div :if={length(@log_messages) > 0} class="flex flex-wrap items-center gap-2 mb-3">
+            <div class="badge badge-sm gap-1 text-primary">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                >
+                </path>
+              </svg>
+              Total: {length(@log_messages)}
             </div>
 
-            <div class="stat">
-              <div class="stat-figure text-secondary">
-                <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                  >
-                  </path>
-                </svg>
-              </div>
-              <div class="stat-title">Services</div>
-              <div class="stat-value text-secondary">{length(@node_info.selected_services)}</div>
-              <div class="stat-desc">Active services</div>
+            <div class="badge badge-sm gap-1 text-secondary">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                >
+                </path>
+              </svg>
+              Services: {length(@node_info.selected_services)}
             </div>
 
-            <div class="stat">
-              <div class="stat-figure text-accent">
-                <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                  >
-                  </path>
-                </svg>
-              </div>
-              <div class="stat-title">Time Range</div>
-              <div class="stat-value text-accent">{@form.params["start_time"] || "5m"}</div>
-              <div class="stat-desc">Looking back</div>
+            <div class="badge badge-sm gap-1 text-accent">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                >
+                </path>
+              </svg>
+              Range: {@form.params["start_time"] || "5m"}
             </div>
           </div>
           <!-- Logs Display Card -->

--- a/apps/deployex_web/lib/deployex_web/live/logs/live/index.ex
+++ b/apps/deployex_web/lib/deployex_web/live/logs/live/index.ex
@@ -25,11 +25,11 @@ defmodule DeployexWeb.LogsLive do
       <div class="min-h-screen bg-base-300">
         <!-- Header -->
         <div class="bg-base-100 border-b border-base-200 shadow-sm">
-          <div class="max-w-7xl mx-auto px-4 py-4">
+          <div class="max-w-8xl mx-auto px-4 py-2">
             <div class="flex items-center justify-between">
-              <div>
-                <h1 class="text-3xl font-bold text-base-content">Live Logs</h1>
-                <p class="text-base-content/60 mt-1">Real-time application logs monitoring</p>
+              <div class="flex items-baseline gap-2">
+                <h1 class="text-xl font-bold text-base-content">Live Logs</h1>
+                <p class="text-sm text-base-content/50">Real-time application logs monitoring</p>
               </div>
               <div class="flex items-center gap-4">
                 <button
@@ -54,11 +54,10 @@ defmodule DeployexWeb.LogsLive do
           </div>
         </div>
         <!-- Main Content -->
-        <div class="max-w-8xl mx-auto px-3 py-3">
+        <div class="max-w-8xl mx-auto px-3 py-2">
           <!-- Filters Card -->
-          <div class="card bg-base-100 shadow-sm mb-6">
-            <div class="card-body p-6">
-              <h2 class="card-title text-lg mb-4">Log Filters</h2>
+          <div class="card bg-base-100 shadow-sm mb-3">
+            <div class="card-body p-3">
               <MultiSelect.content
                 id="logs-live-multi-select"
                 selected_text="Selected logs"


### PR DESCRIPTION
## Summary
- Shrink the filter/selection chrome and stats around the log tables so more log rows fit in the viewport without scrolling
- MultiSelect: merge the toggle button into the selected-items row, shrink badges to `badge-sm`, tighten margins and panel padding
- Live/History headers: title and subtitle on one line, `text-xl`, `py-2`
- Filter cards: drop redundant "Log Filters" title, `p-6` to `p-3`, `mb-6` to `mb-3`
- History stats: replace stacked `stat` blocks with a single compact `badge-sm` row (Total / Services / Range)
- Log tables: `table-sm` modifier and `badge-sm` for service/type badges
- Table heights: fixed `600px` to viewport-relative `calc(100vh - Xpx)`

## Risk assessment
- **Impact:** operators see more log rows per screen; same info, denser layout
- **Blast radius:** deployex_web only (4 files); no backend/sentinel/deployer changes
- **Regression risk:** low - pure presentation/class changes, no logic touched
- **Rollback:** plain commit revert

#### Test plan
- [x] `mix format --check-formatted` on changed files
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` (deployex_web)
- [x] `mix test apps/deployex_web/test/deployex_web/live/logs/` (28 tests, 0 failures)
- [ ] Manual visual review of `/logs/live` and `/logs/history` in browser

🤖 Generated with [Devin](https://devin.ai) (GLM-5.2 High)