### PR TITLE
feat(deployer): fetch logo from the <name>_web child for Phoenix umbrella apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
  * [`PULL-292`](https://github.com/thiagoesteves/deployex/pull/292) Monitor the DeployEx atom, process and port limits alongside the host memory
  * [`PULL-293`](https://github.com/thiagoesteves/deployex/pull/293) Show the URLs each connected application is serving on, read from its own endpoints
  * [`PULL-296`](https://github.com/thiagoesteves/deployex/pull/296) Replace the Elixir and Erlang logos with the official ones and swap to a brighter variant on dark themes
- * [`PULL-297`](https://github.com/thiagoesteves/deployex/pull/297) Fetch the logo from the `<name>_web` child when the monitored application is a Phoenix umbrella
+ * [`PULL-305`](https://github.com/thiagoesteves/deployex/pull/305) Fetch the logo from the `<name>_web` child when the monitored application is a Phoenix umbrella
 
 ## 0.9.12 🚀 (2026-08-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  * [`PULL-292`](https://github.com/thiagoesteves/deployex/pull/292) Monitor the DeployEx atom, process and port limits alongside the host memory
  * [`PULL-293`](https://github.com/thiagoesteves/deployex/pull/293) Show the URLs each connected application is serving on, read from its own endpoints
  * [`PULL-296`](https://github.com/thiagoesteves/deployex/pull/296) Replace the Elixir and Erlang logos with the official ones and swap to a brighter variant on dark themes
+ * [`PULL-297`](https://github.com/thiagoesteves/deployex/pull/297) Fetch the logo from the `<name>_web` child when the monitored application is a Phoenix umbrella
 
 ## 0.9.12 🚀 (2026-08-12)
 

--- a/apps/deployer/lib/deployer/status/logo.ex
+++ b/apps/deployer/lib/deployer/status/logo.ex
@@ -7,6 +7,12 @@ defmodule Deployer.Status.Logo do
   directory, and returned as a base64 `data:` URI ready to be used as an
   `<img>` source.
 
+  For a single-app release the logo is read from the application named after
+  the catalog entry. For a Phoenix umbrella the logo usually lives in the
+  `<name>_web` child, whose atom is not known on this node, so the loaded
+  applications on the monitored node are inspected over RPC and the `<name>_web`
+  child is probed for the logo.
+
   Lookup is best effort and never fails: an unknown application, an
   unreachable node or a missing file all yield `nil`, so a missing logo
   never prevents an application from being rendered. The caller is free to
@@ -33,7 +39,44 @@ defmodule Deployer.Status.Logo do
   @spec image(node :: node(), name :: String.t()) :: {:ok, String.t() | nil}
   def image(node, name) do
     with {:ok, app} <- existing_atom(name),
-         {:ok, priv_dir} <- app_priv_dir(node, app),
+         {:ok, value} when value != nil <- logo_from_app(node, app) do
+      {:ok, value}
+    else
+      # The name is not a known application on this node, so it is not a
+      # catalog entry: do not reach the remote node for an umbrella probe.
+      {:error, :unknown} ->
+        {:ok, nil}
+
+      # The main application has no logo: try the `<name>_web` umbrella child,
+      # whose atom is not known on this node and is discovered from the loaded
+      # applications on the monitored node.
+      _ ->
+        logo_from_elixir_umbrella(node, name)
+    end
+  end
+
+  ### ==========================================================================
+  ### Private functions
+  ### ==========================================================================
+
+  # An umbrella's logo usually lives in the `<name>_web` child, whose atom is
+  # not known on this node. The loaded applications on the monitored node are
+  # the source of truth for the real child atom, so no local atom conversion is
+  # needed: the atoms come back in the RPC response.
+  defp logo_from_elixir_umbrella(node, name) do
+    with apps when is_list(apps) <-
+           Rpc.call(node, :application, :loaded_applications, [], @rpc_timeout),
+         [{app, _descr, _version}] <-
+           Enum.filter(apps, fn {app, _descr, _version} -> "#{app}" == "#{name}_web" end) do
+      logo_from_app(node, app)
+    else
+      _err ->
+        {:ok, nil}
+    end
+  end
+
+  defp logo_from_app(node, app) do
+    with {:ok, priv_dir} <- app_priv_dir(node, app),
          path <- logo_path(priv_dir),
          {:ok, binary} <- Rpc.call(node, :file, :read_file, [path], @rpc_timeout) do
       {:ok, "data:image/svg+xml;base64," <> Base.encode64(binary)}
@@ -42,16 +85,12 @@ defmodule Deployer.Status.Logo do
     end
   end
 
-  ### ==========================================================================
-  ### Private functions
-  ### ==========================================================================
-
   # The application name only maps to an atom when the application is known
   # to this node, so an unknown name is a normal miss rather than a failure.
   defp existing_atom(name) do
     {:ok, String.to_existing_atom(name)}
   rescue
-    ArgumentError -> :error
+    ArgumentError -> {:error, :unknown}
   end
 
   defp app_priv_dir(node, app) do
@@ -60,7 +99,7 @@ defmodule Deployer.Status.Logo do
         {:ok, to_string(priv_dir)}
 
       _err ->
-        :error
+        {:error, :no_priv}
     end
   end
 

--- a/apps/deployer/test/status/logo_test.exs
+++ b/apps/deployer/test/status/logo_test.exs
@@ -13,7 +13,9 @@ defmodule Deployer.Status.LogoTest do
   @node :"myelixir-abc123@nohost"
   @name "myelixir"
   @app :myelixir
+  @web_app :myelixir_web
   @priv_dir ~c"/opt/myelixir/lib/myelixir-1.0.0/priv"
+  @web_priv_dir ~c"/opt/myelixir/lib/myelixir_web-1.0.0/priv"
   @svg ~s(<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"></svg>)
 
   test "image/2 returns the logo as a base64 svg data uri" do
@@ -40,6 +42,9 @@ defmodule Deployer.Status.LogoTest do
     Foundation.RpcMock
     |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
     |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      [{@app, "myelixir", "1.0.0"}]
+    end)
 
     assert {:ok, nil} = Logo.image(@node, @name)
   end
@@ -47,6 +52,7 @@ defmodule Deployer.Status.LogoTest do
   test "image/2 returns nil when the application is not loaded on the node" do
     Foundation.RpcMock
     |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:error, :bad_name} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout -> [] end)
 
     assert {:ok, nil} = Logo.image(@node, @name)
   end
@@ -54,6 +60,9 @@ defmodule Deployer.Status.LogoTest do
   test "image/2 returns nil when the node is unreachable" do
     Foundation.RpcMock
     |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:badrpc, :nodedown} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      {:badrpc, :nodedown}
+    end)
 
     assert {:ok, nil} = Logo.image(@node, @name)
   end
@@ -68,9 +77,71 @@ defmodule Deployer.Status.LogoTest do
     Foundation.RpcMock
     |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
     |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
-    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> {:badrpc, :nodedown} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      [{@app, "myelixir", "1.0.0"}]
+    end)
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      [{@app, "myelixir", "1.0.0"}]
+    end)
 
     assert {:ok, nil} = Logo.image(@node, @name)
+    assert {:ok, nil} = Logo.image(@node, @name)
+  end
+
+  test "image/2 falls back to the umbrella child for the logo" do
+    # the main app has no logo, so the umbrella path is taken
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      [{@app, "myelixir", "1.0.0"}, {@web_app, "myelixir_web", "1.0.0"}]
+    end)
+    # the web app is probed and has the logo
+    |> expect(:call, fn @node, :code, :priv_dir, [@web_app], _timeout -> @web_priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [path], _timeout ->
+      assert path == "/opt/myelixir/lib/myelixir_web-1.0.0/priv/static/images/logo.svg"
+      {:ok, @svg}
+    end)
+
+    assert {:ok, "data:image/svg+xml;base64," <> encoded} = Logo.image(@node, @name)
+    assert {:ok, @svg} = Base.decode64(encoded)
+  end
+
+  test "image/2 ignores an unrelated app from another project" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      [{@app, "myelixir", "1.0.0"}, {:observer_web, "observer_web", "0.1.0"}]
+    end)
+
+    # observer_web is not myelixir_web, so no probe and a nil logo
+    assert {:ok, nil} = Logo.image(@node, @name)
+  end
+
+  test "image/2 returns nil when the umbrella child has no logo.svg" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      [{@app, "myelixir", "1.0.0"}, {@web_app, "myelixir_web", "1.0.0"}]
+    end)
+    |> expect(:call, fn @node, :code, :priv_dir, [@web_app], _timeout -> @web_priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+
+    assert {:ok, nil} = Logo.image(@node, @name)
+  end
+
+  test "image/2 returns nil when loaded_applications is unreachable" do
+    Foundation.RpcMock
+    |> expect(:call, fn @node, :code, :priv_dir, [@app], _timeout -> @priv_dir end)
+    |> expect(:call, fn @node, :file, :read_file, [_path], _timeout -> {:error, :enoent} end)
+    |> expect(:call, fn @node, :application, :loaded_applications, [], _timeout ->
+      {:badrpc, :nodedown}
+    end)
+
     assert {:ok, nil} = Logo.image(@node, @name)
   end
 end


### PR DESCRIPTION
## Summary
- The logo lookup only checked the catalog app's own `priv` directory, which fails for Phoenix umbrella apps where `logo.svg` lives in the `<name>_web` child
- The `<name>_web` atom is not known on the DeployEx node, so it is discovered from `:application.loaded_applications/0` on the monitored node and probed for the logo
- The single-app path is unchanged; the umbrella fallback only fires when the main app has no logo, and the result is cached by the caller so the extra RPC happens once per node

## Risk assessment
- **Impact:** umbrella apps now show their logo in the dashboard instead of a blank image
- **Blast radius:** `Deployer.Status.Logo` only; no other module is touched
- **Regression risk:** low - the single-app path is unchanged and the umbrella path is purely additive, gated behind the main app returning no logo
- **Rollback:** plain commit revert

#### Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes (logo.ex)
- [x] `mix dialyzer` passes (0 errors)
- [x] `mix test apps/deployer/test/status/logo_test.exs` passes (11 tests)
- [x] Manual: verify logo renders for an umbrella app with `logo.svg` in `<name>_web/priv/static/images/`
- [x] Manual: verify logo still renders for a single-app release

🤖 Generated with [Devin](https://devin.ai) (GLM-5.2 High)