### PR TITLE
fix(ui): show normalized CPU percentage in the system bar

### DIFF
--- a/apps/deployex_web/lib/deployex_web/live/components/system_bar.ex
+++ b/apps/deployex_web/lib/deployex_web/live/components/system_bar.ex
@@ -18,9 +18,8 @@ defmodule DeployexWeb.Components.SystemBar do
         |> assign(description: "--")
         |> assign(memory_used: 0)
         |> assign(memory_max: "--")
-        |> assign(cpu: 0.00)
         |> assign(cpus_used: 0)
-        |> assign(cpus_max: "--")
+        |> assign(cores: "--")
         |> assign(uptime: "--")
       else
         memory_used = trunc((info.memory_total - info.memory_free) / info.memory_total * 100)
@@ -36,9 +35,8 @@ defmodule DeployexWeb.Components.SystemBar do
         |> assign(description: info.description)
         |> assign(memory_used: memory_used)
         |> assign(memory_max: memory_max)
-        |> assign(cpu: info.cpu)
         |> assign(cpus_used: cpus_used)
-        |> assign(cpus_max: cpus_max)
+        |> assign(cores: div(cpus_max, 100))
         |> assign(uptime: uptime)
       end
 
@@ -113,11 +111,11 @@ defmodule DeployexWeb.Components.SystemBar do
             <div class="flex items-center gap-3">
               <div class="flex flex-col items-end">
                 <span class="text-sm font-semibold text-base-content">CPU</span>
-                <span class="text-xs text-base-content/60">{@cpus_max}% Max</span>
+                <span class="text-xs text-base-content/60">{@cores} cores</span>
               </div>
               <div class="flex items-center gap-2">
                 <progress class="progress progress-warning w-20 h-2" value={@cpus_used} max="100"></progress>
-                <span class="text-sm font-bold text-warning min-w-[3rem] text-right">{@cpu}%</span>
+                <span class="text-sm font-bold text-warning min-w-[3rem] text-right">{@cpus_used}%</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

The system bar CPU number and its progress bar used different scales. The number showed raw multi-core CPU (for example `115%`), while the bar was normalized to 0-100%. On a multi-core host at low load the two disagree: the
bar shows about 15%, the number shows 115%, which reads as over the limit.

## Changes

- Show the normalized utilization as the number, so it matches the bar.
- Replace the `1000% Max` label with the core count (for example `10 cores`).
- Remove the now-unused `cpu` assign.

No metric is recomputed. The normalized value was already calculated for the bar; the number now uses it too.

## Before / after

`Before`: `1000% Max`, number `115%`, bar ~15% full.
<img width="264" height="63" alt="image" src="https://github.com/user-attachments/assets/fc742ded-3b08-47fc-a7a6-f3e380d1c305" />

After: `10 cores`, number `16%`, bar ~16% full.
<img width="250" height="61" alt="image" src="https://github.com/user-attachments/assets/29de7ae0-8af7-4434-b32c-cffb3812d384" />


## Verification
`mise exec -- mix test apps/deployex_web/test` - 198 passed (6 doctests, 192 tests).
